### PR TITLE
default filter changes, sort on load, patterns on load

### DIFF
--- a/app/src/SettingsTabs/Legend.tsx
+++ b/app/src/SettingsTabs/Legend.tsx
@@ -25,7 +25,6 @@ import SimpleBarCore from "simplebar-core";
 import ArrowUpIcon from "../assets/icons/arrow-up.json";
 import { LEGEND_HEADER_HEIGHT } from "./MapPointConstants";
 import { Color, Patterns } from "@tsconline/shared";
-import { compareStrings } from "../util/util";
 
 /**
  * This is the legend that describes the icons present on the
@@ -35,8 +34,8 @@ import { compareStrings } from "../util/util";
 export const Legend = observer(() => {
   // the filters for the facies patterns
   const [searchValue, setSearchValue] = useState("");
-  const [filterByPresent, setFilterByPresent] = useState(false);
-  const [alphabeticalSort, setAlphabeticalSort] = useState(false);
+  const [filterByPresent, setFilterByPresent] = useState(true);
+  const [alphabeticalSort, setAlphabeticalSort] = useState(true);
   const [colorFilter, setColorFilter] = useState<Set<string>>(new Set<string>());
 
   //scroll state
@@ -75,7 +74,8 @@ export const Legend = observer(() => {
   });
   const colors = new Set<string>();
   const colorHash = new Map<string, Color>();
-  const filteredPatterns = Object.values(state.mapPatterns).filter((value) => {
+  const patterns = alphabeticalSort ? state.mapPatterns.sortedPatterns : state.mapPatterns.patterns;
+  const filteredPatterns = Object.values(patterns).filter((value) => {
     const isPresent = !filterByPresent || state.mapState.currentFaciesOptions.presentRockTypes.has(value.formattedName);
     const matchesSearch = value.formattedName.toLowerCase().includes(searchValue.toLowerCase());
     const hasColor = colorFilter.size == 0 || colorFilter.has(value.color.name);
@@ -86,11 +86,6 @@ export const Legend = observer(() => {
     }
     return isPresent && matchesSearch && hasColor;
   });
-  if (alphabeticalSort) {
-    filteredPatterns.sort((a, b) => {
-      return compareStrings(a.formattedName, b.formattedName);
-    });
-  }
   // legend icon array
   const legendItems: LegendItem[] = [
     { color: theme.palette.on.main, label: "On", icon: AvailableIcon },

--- a/app/src/state/actions/GeneralActions.ts
+++ b/app/src/state/actions/GeneralActions.ts
@@ -25,6 +25,7 @@ import { initializeColumnHashMap } from "./ColumnActions";
 import { jsonToXml, xmlToJson } from "../parseSettings";
 import { displayError } from "./UtilActions";
 import { Settings } from "../../types";
+import { compareStrings } from "../../util/util";
 
 export const fetchFaciesPatterns = action("fetchFaciesPatterns", async () => {
   try {
@@ -33,7 +34,10 @@ export const fetchFaciesPatterns = action("fetchFaciesPatterns", async () => {
     if (response.ok) {
       const { patterns } = patternJson;
       assertPatterns(patterns);
-      state.mapPatterns = patterns;
+      state.mapPatterns = {
+        patterns,
+        sortedPatterns: Object.values(patterns).sort((a, b) => compareStrings(a.name, b.name))
+      };
       console.log("Successfully fetched Map Patterns");
     } else {
       displayError(null, patternJson, `Server responded with ${response.status}`);

--- a/app/src/state/actions/GeneralActions.ts
+++ b/app/src/state/actions/GeneralActions.ts
@@ -29,13 +29,14 @@ import { Settings } from "../../types";
 export const fetchFaciesPatterns = action("fetchFaciesPatterns", async () => {
   try {
     const response = await fetcher("/facies-patterns");
+    const patternJson = await response.json();
     if (response.ok) {
-      const { patterns } = await response.json();
+      const { patterns } = patternJson;
       assertPatterns(patterns);
       state.mapPatterns = patterns;
       console.log("Successfully fetched Map Patterns");
     } else {
-      displayError(null, response, `Server responded with ${response.status}`);
+      displayError(null, patternJson, `Server responded with ${response.status}`);
     }
   } catch (e) {
     displayError(e, null, "Error fetching the facies patterns");

--- a/app/src/state/state.ts
+++ b/app/src/state/state.ts
@@ -49,7 +49,10 @@ export type State = {
   presets: Presets;
   datapackIndex: DatapackIndex;
   mapPackIndex: MapPackIndex;
-  mapPatterns: Patterns;
+  mapPatterns: {
+    patterns: Patterns;
+    sortedPatterns: Patterns[string][];
+  };
   selectedPreset: ChartConfig | null;
   chartPath: string;
   chartHash: string;
@@ -105,7 +108,10 @@ export const state = observable<State>({
   presets: {},
   datapackIndex: {},
   mapPackIndex: {},
-  mapPatterns: {},
+  mapPatterns: {
+    patterns: {},
+    sortedPatterns: []
+  },
   selectedPreset: null,
   chartPath: "",
   chartHash: "",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -114,7 +114,8 @@ server.get<{ Params: { settingFile: string } }>("/settingsXml/:settingFile", rou
 
 // handles chart columns and age ranges requests
 server.post<{ Params: { files: string } }>("/mapimages/:files", routes.refreshMapImages);
-server.get("/datapackinfoindex", (request, reply) => {
+
+server.get("/datapackinfoindex", (_request, reply) => {
   if (!datapackIndex || !mapPackIndex) {
     reply.send({ error: "datapackIndex/mapPackIndex is null" });
   } else {
@@ -133,9 +134,10 @@ server.get<{ Params: { hash: string } }>("/svgstatus/:hash", routes.fetchSVGStat
 
 server.get("/facies-patterns", (_request, reply) => {
   if (!patterns || Object.keys(patterns).length === 0) {
-    reply.status(500).send({ error: "Server isn't able to load patterns" });
+    reply.status(500).send({ error: "Server isn't able to load facies patterns" });
+  } else {
+    reply.status(200).send({ patterns });
   }
-  reply.status(200).send({ patterns });
 });
 
 // generates chart and sends to proper directory

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,16 +8,9 @@ import { loadPresets } from "./preset.js";
 import { AssetConfig, assertAssetConfig } from "./types.js";
 import { deleteDirectory } from "./util.js";
 import * as routes from "./routes.js";
-import {
-  DatapackIndex,
-  MapPackIndex,
-  assertDatapackParsingPack,
-  assertIndexResponse,
-  assertMapPack
-} from "@tsconline/shared";
-import { parseDatapacks } from "./parse-datapacks.js";
-import { parseMapPacks } from "./parse-map-packs.js";
+import { DatapackIndex, MapPackIndex, assertIndexResponse } from "@tsconline/shared";
 import fastifyCompress from "@fastify/compress";
+import { loadFaciesPatterns, loadIndexes } from "./load-packs.js";
 
 const server = fastify({
   logger: false,
@@ -64,33 +57,10 @@ try {
   process.exit(1);
 }
 
-export const datapackIndex: DatapackIndex = {};
-export const mapPackIndex: MapPackIndex = {};
-try {
-  console.log(`\nParsing datapacks: ${assetconfigs.activeDatapacks}\n`);
-  for (const datapack of assetconfigs.activeDatapacks) {
-    parseDatapacks(assetconfigs.decryptionDirectory, [datapack])
-      .then((datapackParsingPack) => {
-        assertDatapackParsingPack(datapackParsingPack);
-        datapackIndex[datapack] = datapackParsingPack;
-        console.log(`Successfully parsed ${datapack}`);
-      })
-      .catch((e) => {
-        console.log(`Cannot create a datapackParsingPack with datapack ${datapack} and error: ${e}`);
-      });
-    parseMapPacks([datapack])
-      .then((mapPack) => {
-        assertMapPack(mapPack);
-        mapPackIndex[datapack] = mapPack;
-      })
-      .catch((e) => {
-        console.log(`Cannot create a mapPack with datapack ${datapack} and error: ${e}`);
-      });
-  }
-} catch (e) {
-  console.log("ERROR: Failed to parse datapacks of activeDatapacks in AssetConfig with error: ", e);
-  process.exit(1);
-}
+const datapackIndex: DatapackIndex = {};
+const mapPackIndex: MapPackIndex = {};
+const patterns = await loadFaciesPatterns();
+await loadIndexes(datapackIndex, mapPackIndex);
 // Serve the main app from /
 // @ts-expect-error: server.register doesn't accept the proper types. open bug-report asap to fastify
 server.register(fastifyStatic, {
@@ -161,7 +131,12 @@ server.get("/datapackinfoindex", (request, reply) => {
 // checks chart.pdf-status
 server.get<{ Params: { hash: string } }>("/svgstatus/:hash", routes.fetchSVGStatus);
 
-server.get("/facies-patterns", routes.fetchFaciesPatterns);
+server.get("/facies-patterns", (_request, reply) => {
+  if (!patterns || Object.keys(patterns).length === 0) {
+    reply.status(500).send({ error: "Server isn't able to load patterns" });
+  }
+  reply.status(200).send({ patterns });
+});
 
 // generates chart and sends to proper directory
 // will return url chart path and hash that was generated for it

--- a/server/src/load-packs.ts
+++ b/server/src/load-packs.ts
@@ -1,0 +1,86 @@
+import {
+  DatapackIndex,
+  MapPackIndex,
+  Patterns,
+  assertDatapackParsingPack,
+  assertMapPack,
+  assertPatterns
+} from "@tsconline/shared";
+import { assetconfigs } from "./index.js";
+import { parseDatapacks } from "./parse-datapacks.js";
+import { parseMapPacks } from "./parse-map-packs.js";
+import { getColorFromURL } from "color-thief-node";
+import { glob } from "glob";
+import { readFile } from "fs/promises";
+import nearestColor from "nearest-color";
+import path from "path";
+import { assertColors } from "./types.js";
+import { rgbToHex } from "./util.js";
+
+export async function loadIndexes(datapackIndex: DatapackIndex, mapPackIndex: MapPackIndex) {
+  console.log(`\nParsing datapacks: ${assetconfigs.activeDatapacks}\n`);
+  for (const datapack of assetconfigs.activeDatapacks) {
+    parseDatapacks(assetconfigs.decryptionDirectory, [datapack])
+      .then((datapackParsingPack) => {
+        assertDatapackParsingPack(datapackParsingPack);
+        datapackIndex[datapack] = datapackParsingPack;
+        console.log(`Successfully parsed ${datapack}`);
+      })
+      .catch((e) => {
+        console.log(`Cannot create a datapackParsingPack with datapack ${datapack} and error: ${e}`);
+      });
+    parseMapPacks([datapack])
+      .then((mapPack) => {
+        assertMapPack(mapPack);
+        mapPackIndex[datapack] = mapPack;
+      })
+      .catch((e) => {
+        console.log(`Cannot create a mapPack with datapack ${datapack} and error: ${e}`);
+      });
+  }
+}
+export async function loadFaciesPatterns() {
+  try {
+    const patterns: Patterns = {};
+    const patternsGlobed = await glob(`${assetconfigs.patternsDirectory}/*.PNG`);
+    const colors = JSON.parse((await readFile(assetconfigs.colors)).toString());
+    assertColors(colors);
+    const nearest = nearestColor.from(colors);
+    if (patternsGlobed.length == 0) throw new Error("No patterns found");
+    for (const pattern of patternsGlobed) {
+      const name = path.basename(pattern).split(".")[0];
+      const dominant = await getColorFromURL(pattern);
+      const color = nearest(rgbToHex(dominant[0], dominant[1], dominant[2]));
+      if (!name) {
+        console.error(`Unrecognized pattern file in ${assetconfigs.patternsDirectory} with path ${pattern}`);
+        continue;
+      }
+      if (!color) {
+        console.error(
+          `Unrecognized color in ${assetconfigs.patternsDirectory} with path ${pattern} with color ${color}`
+        );
+        continue;
+      }
+      // format so it splits all underscores and capitalizes the first letter
+      const formattedName = name
+        .split("_")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ");
+      patterns[name] = {
+        name,
+        formattedName,
+        filePath: `/${pattern}`,
+        color: {
+          name: color.name,
+          hex: color.value,
+          rgb: color.rgb
+        }
+      };
+    }
+    assertPatterns(patterns);
+    return patterns;
+  } catch (e) {
+    console.error(e);
+    return {};
+  }
+}

--- a/server/src/load-packs.ts
+++ b/server/src/load-packs.ts
@@ -17,6 +17,13 @@ import path from "path";
 import { assertColors } from "./types.js";
 import { rgbToHex } from "./util.js";
 
+/**
+ * Loads all the indexes for the active datapacks and mapPacks (if they exist)
+ * will stop parsing if an error is thrown
+ * will keep parsed datapacks that don't have errors
+ * @param datapackIndex the datapackIndex to load
+ * @param mapPackIndex the mapPackIndex to load
+ */
 export async function loadIndexes(datapackIndex: DatapackIndex, mapPackIndex: MapPackIndex) {
   console.log(`\nParsing datapacks: ${assetconfigs.activeDatapacks}\n`);
   for (const datapack of assetconfigs.activeDatapacks) {
@@ -39,6 +46,10 @@ export async function loadIndexes(datapackIndex: DatapackIndex, mapPackIndex: Ma
       });
   }
 }
+/**
+ * Loads all the facies patterns from the patterns directory
+ * @returns Patterns
+ */
 export async function loadFaciesPatterns() {
   try {
     const patterns: Patterns = {};

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,6 +6,5 @@
     "allowJs": true
   },
   "include": [ 
-    "./src/**/*" 
-, "src/parse-map-packs.ts"  ]
+    "./src/**/*"]
 }


### PR DESCRIPTION
changes reflected in 3/1 meeting

patterns now load on `yarn start`
patterns sorted when loaded into `app`
filter default to `presentInMap` and `alphabetical`

more refactoring on the server side to make `index.ts` cleaner