### PR TITLE
manually append facies columns

### DIFF
--- a/app/src/state/actions/generate-chart-actions.ts
+++ b/app/src/state/actions/generate-chart-actions.ts
@@ -74,19 +74,19 @@ export const fetchChartFromServer = action("fetchChartFromServer", async (naviga
  * and change before the conversion to xml. The downside is we must check
  * every ColumnInfo object which may cause problems with time consistency.
  * However, this is asyncronous, which makes it less likely to cause problems.
- * @param column 
+ * @param column
  */
 function changeFaciesColumn(column: ColumnInfo) {
   if (column.name === `${column.parent} Facies Label`) {
-    column.name = "Facies Label"
+    column.name = "Facies Label";
   } else if (column.name === `${column.parent} Series Label`) {
-    column.name = "Series Label"
+    column.name = "Series Label";
   } else if (column.name === `${column.parent} Members`) {
-    column.name = "Members"
+    column.name = "Members";
   } else if (column.name === `${column.parent} Facies`) {
-    column.name = "Facies"
+    column.name = "Facies";
   }
   for (const child of column.children) {
-    changeFaciesColumn(child)
+    changeFaciesColumn(child);
   }
 }

--- a/app/src/state/actions/generate-chart-actions.ts
+++ b/app/src/state/actions/generate-chart-actions.ts
@@ -3,7 +3,7 @@ import { displayServerError } from "./util-actions";
 import { state } from "../state";
 import { action } from "mobx";
 import { fetcher, devSafeUrl } from "../../util";
-import { assertChartInfo } from "@tsconline/shared";
+import { ColumnInfo, assertChartInfo } from "@tsconline/shared";
 import { jsonToXml } from "../parse-settings";
 import { NavigateFunction } from "react-router";
 import { ErrorCodes, ErrorMessages } from "../../util/error-codes";
@@ -36,7 +36,9 @@ export const fetchChartFromServer = action("fetchChartFromServer", async (naviga
   generalActions.setChartPath("");
   //let xmlSettings = jsonToXml(state.settingsJSON); // Convert JSON to XML using jsonToXml function
   // console.log("XML Settings:", xmlSettings); // Log the XML settings to the console
-  const xmlSettings = jsonToXml(state.settingsJSON, state.settingsTabs.columns, state.settings);
+  const columnCopy: ColumnInfo = JSON.parse(JSON.stringify(state.settingsTabs.columns));
+  changeFaciesColumn(columnCopy);
+  const xmlSettings = jsonToXml(state.settingsJSON, columnCopy, state.settings);
   const body = JSON.stringify({
     settings: xmlSettings,
     datapacks: state.config.datapacks
@@ -64,3 +66,27 @@ export const fetchChartFromServer = action("fetchChartFromServer", async (naviga
     displayServerError(null, ErrorCodes.SERVER_RESPONSE_ERROR, ErrorMessages[ErrorCodes.SERVER_RESPONSE_ERROR]);
   }
 });
+
+/**
+ * Since we hash by name only to allow consistency between facies maps and
+ * the column page, a generic like Facies Label will cause errors.
+ * The solution @Paolo came up with is to prepend the name of the parent
+ * and change before the conversion to xml. The downside is we must check
+ * every ColumnInfo object which may cause problems with time consistency.
+ * However, this is asyncronous, which makes it less likely to cause problems.
+ * @param column 
+ */
+function changeFaciesColumn(column: ColumnInfo) {
+  if (column.name === `${column.parent} Facies Label`) {
+    column.name = "Facies Label"
+  } else if (column.name === `${column.parent} Series Label`) {
+    column.name = "Series Label"
+  } else if (column.name === `${column.parent} Members`) {
+    column.name = "Members"
+  } else if (column.name === `${column.parent} Facies`) {
+    column.name = "Facies"
+  }
+  for (const child of column.children) {
+    changeFaciesColumn(child)
+  }
+}

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -32,7 +32,88 @@
                         "font": "Arial"
                     },
                     "popup": "",
-                    "children": [],
+                    "children": [
+                        {
+                            "name": "Nigeria Coast Facies",
+                            "editName": "Nigeria Coast",
+                            "on": true,
+                            "enableTitle": false,
+                            "fontsInfo": {
+                              "font": "Arial"
+                            },
+                            "popup": "",
+                            "children": [],
+                            "parent": "Nigeria Coast",
+                            "minAge": 0,
+                            "maxAge": 10,
+                            "width": 84,
+                            "rgb": {
+                                "r": 255,
+                                "g": 255,
+                                "b": 255
+                            }
+                        },
+                        {
+                            "name": "Nigeria Coast Members",
+                            "editName": "Members",
+                            "on": false,
+                            "enableTitle": false,
+                            "fontsInfo": {
+                              "font": "Arial"
+                            },
+                            "popup": "",
+                            "children": [],
+                            "parent": "Nigeria Coast",
+                            "minAge": 0,
+                            "maxAge": 10,
+                            "width": 210,
+                            "rgb": {
+                                "r": 255,
+                                "g": 255,
+                                "b": 255
+                            }
+                          },
+                          {
+                            "name": "Nigeria Coast Facies Label",
+                            "editName": "Facies Label",
+                            "on": true,
+                            "enableTitle": false,
+                            "fontsInfo": {
+                              "font": "Arial"
+                            },
+                            "popup": "",
+                            "children": [],
+                            "parent": "Nigeria Coast",
+                            "minAge": 0,
+                            "maxAge": 10,
+                            "width": 84,
+                            "rgb": {
+                                "r": 255,
+                                "g": 255,
+                                "b": 255
+                            }
+                        },
+                        {
+                            "name": "Nigeria Coast Series Label",
+                            "editName": "Series Label",
+                            "on": true,
+                            "enableTitle": false,
+                            "fontsInfo": {
+                              "font": "Arial"
+                            },
+                            "popup": "",
+                            "children": [],
+                            "parent": "Nigeria Coast",
+                            "minAge": 0,
+                            "maxAge": 10,
+                            "rgb": {
+                                "r": 255,
+                                "g": 255,
+                                "b": 255
+                            },
+                            "width": 42
+                        }
+                    ],
                     "parent": "Central Africa Cenozoic",
                     "minAge": 0,
                     "maxAge": 10,
@@ -71,7 +152,88 @@
                         "font": "Arial"
                     },
                     "popup": "",
-                    "children": [],
+                    "children": [
+                        {
+                            "name": "South Atlantic Facies",
+                            "editName": "South Atlantic",
+                            "on": true,
+                            "enableTitle": false,
+                            "fontsInfo": {
+                              "font": "Arial"
+                            },
+                            "popup": "",
+                            "children": [],
+                            "parent": "South Atlantic",
+                            "minAge": 0,
+                            "maxAge": 10,
+                            "width": 84,
+                            "rgb": {
+                                "r": 255,
+                                "g": 255,
+                                "b": 255
+                            }
+                        },
+                        {
+                            "name": "South Atlantic Members",
+                            "editName": "Members",
+                            "on": false,
+                            "enableTitle": false,
+                            "fontsInfo": {
+                              "font": "Arial"
+                            },
+                            "popup": "",
+                            "children": [],
+                            "parent": "South Atlantic",
+                            "minAge": 0,
+                            "maxAge": 10,
+                            "width": 210,
+                            "rgb": {
+                                "r": 255,
+                                "g": 255,
+                                "b": 255
+                            }
+                        },
+                        {
+                            "name": "South Atlantic Facies Label",
+                            "editName": "Facies Label",
+                            "on": true,
+                            "enableTitle": false,
+                            "fontsInfo": {
+                              "font": "Arial"
+                            },
+                            "popup": "",
+                            "children": [],
+                            "parent": "South Atlantic",
+                            "minAge": 0,
+                            "maxAge": 10,
+                            "width": 84,
+                            "rgb": {
+                                "r": 255,
+                                "g": 255,
+                                "b": 255
+                            }
+                        },
+                        {
+                            "name": "South Atlantic Series Label",
+                            "editName": "Series Label",
+                            "on": true,
+                            "enableTitle": false,
+                            "fontsInfo": {
+                              "font": "Arial"
+                            },
+                            "popup": "",
+                            "children": [],
+                            "parent": "South Atlantic",
+                            "minAge": 0,
+                            "maxAge": 10,
+                            "rgb": {
+                                "r": 255,
+                                "g": 255,
+                                "b": 255
+                            },
+                            "width": 42
+                        }
+                    ],
                     "parent": "Central Africa Cenozoic",
                     "minAge": 0,
                     "maxAge": 10,
@@ -194,7 +356,88 @@
                     "font": "Arial"
                 },
                 "popup": "Facies Popup",
-                "children": [],
+                "children": [
+                    {
+                        "name": "Facies Facies",
+                        "editName": "Facies",
+                        "on": true,
+                        "enableTitle": false,
+                        "fontsInfo": {
+                          "font": "Arial"
+                        },
+                        "popup": "",
+                        "children": [],
+                        "parent": "Facies",
+                        "minAge": 0,
+                        "maxAge": 10,
+                        "width": 84,
+                        "rgb": {
+                            "r": 255,
+                            "g": 255,
+                            "b": 255
+                        }
+                    },
+                    {
+                        "name": "Facies Members",
+                        "editName": "Members",
+                        "on": false,
+                        "enableTitle": false,
+                        "fontsInfo": {
+                          "font": "Arial"
+                        },
+                        "popup": "",
+                        "children": [],
+                        "parent": "Facies",
+                        "minAge": 0,
+                        "maxAge": 10,
+                        "width": 210,
+                        "rgb": {
+                            "r": 255,
+                            "g": 255,
+                            "b": 255
+                        }
+                    },
+                    {
+                        "name": "Facies Facies Label",
+                        "editName": "Facies Label",
+                        "on": true,
+                        "enableTitle": false,
+                        "fontsInfo": {
+                          "font": "Arial"
+                        },
+                        "popup": "",
+                        "children": [],
+                        "parent": "Facies",
+                        "minAge": 0,
+                        "maxAge": 10,
+                        "width": 84,
+                        "rgb": {
+                            "r": 255,
+                            "g": 255,
+                            "b": 255
+                        }
+                    },
+                    {
+                        "name": "Facies Series Label",
+                        "editName": "Series Label",
+                        "on": true,
+                        "enableTitle": false,
+                        "fontsInfo": {
+                          "font": "Arial"
+                        },
+                        "popup": "",
+                        "children": [],
+                        "parent": "Facies",
+                        "minAge": 0,
+                        "maxAge": 10,
+                        "rgb": {
+                            "r": 255,
+                            "g": 255,
+                            "b": 255
+                        },
+                        "width": 42
+                    }
+                ],
                 "width": 210,
                 "enableTitle": false,
                 "rgb": {

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -1134,7 +1134,13 @@ function recursive(
       ...currentFacies,
       subFaciesInfo: JSON.parse(JSON.stringify(currentFacies.subFaciesInfo))
     });
-    addFaciesChildren(currentColumnInfo.children, currentColumnInfo.name, currentColumnInfo.width, currentColumnInfo.minAge, currentColumnInfo.maxAge);
+    addFaciesChildren(
+      currentColumnInfo.children,
+      currentColumnInfo.name,
+      currentColumnInfo.width,
+      currentColumnInfo.minAge,
+      currentColumnInfo.maxAge
+    );
     returnValue.subFaciesInfo = currentFacies.subFaciesInfo;
     returnValue.minAge = currentColumnInfo.minAge;
     returnValue.maxAge = currentColumnInfo.maxAge;
@@ -1241,6 +1247,15 @@ export function createDefaultColumnHeaderProps(overrides: Partial<ColumnHeaderPr
   return { ...defaultProps, ...overrides };
 }
 
+/**
+ * facies columns consist of 4 different "columns" and we need to add them to the children array
+ * since they are manually added in the java file
+ * @param children the children to add to
+ * @param name the parent
+ * @param width the width of the parent
+ * @param minAge the minage of the parent
+ * @param maxAge  the maxage of the parent
+ */
 function addFaciesChildren(children: ColumnInfo[], name: string, width: number, minAge: number, maxAge: number) {
   children.push({
     name: `${name} Facies`,
@@ -1259,7 +1274,7 @@ function addFaciesChildren(children: ColumnInfo[], name: string, width: number, 
       g: 255,
       b: 255
     }
-  })
+  });
   children.push({
     name: `${name} Members`,
     editName: "Members",
@@ -1277,7 +1292,7 @@ function addFaciesChildren(children: ColumnInfo[], name: string, width: number, 
       g: 255,
       b: 255
     }
-  })
+  });
   children.push({
     name: `${name} Facies Label`,
     editName: "Facies Label",
@@ -1295,7 +1310,7 @@ function addFaciesChildren(children: ColumnInfo[], name: string, width: number, 
       g: 255,
       b: 255
     }
-  })
+  });
   children.push({
     name: `${name} Series Label`,
     editName: "Series Label",
@@ -1313,5 +1328,5 @@ function addFaciesChildren(children: ColumnInfo[], name: string, width: number, 
       b: 255
     },
     width: width * 0.2
-  })
+  });
 }

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -1134,6 +1134,7 @@ function recursive(
       ...currentFacies,
       subFaciesInfo: JSON.parse(JSON.stringify(currentFacies.subFaciesInfo))
     });
+    addFaciesChildren(currentColumnInfo.children, currentColumnInfo.name, currentColumnInfo.width, currentColumnInfo.minAge, currentColumnInfo.maxAge);
     returnValue.subFaciesInfo = currentFacies.subFaciesInfo;
     returnValue.minAge = currentColumnInfo.minAge;
     returnValue.maxAge = currentColumnInfo.maxAge;
@@ -1238,4 +1239,79 @@ export function createDefaultColumnHeaderProps(overrides: Partial<ColumnHeaderPr
   };
 
   return { ...defaultProps, ...overrides };
+}
+
+function addFaciesChildren(children: ColumnInfo[], name: string, width: number, minAge: number, maxAge: number) {
+  children.push({
+    name: `${name} Facies`,
+    editName: name,
+    on: true,
+    enableTitle: false,
+    fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
+    popup: "",
+    children: [],
+    parent: name,
+    minAge,
+    maxAge,
+    width: width * 0.4,
+    rgb: {
+      r: 255,
+      g: 255,
+      b: 255
+    }
+  })
+  children.push({
+    name: `${name} Members`,
+    editName: "Members",
+    on: false,
+    enableTitle: false,
+    fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
+    popup: "",
+    children: [],
+    parent: name,
+    minAge,
+    maxAge,
+    width,
+    rgb: {
+      r: 255,
+      g: 255,
+      b: 255
+    }
+  })
+  children.push({
+    name: `${name} Facies Label`,
+    editName: "Facies Label",
+    on: true,
+    enableTitle: false,
+    fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
+    popup: "",
+    children: [],
+    parent: name,
+    minAge,
+    maxAge,
+    width: width * 0.4,
+    rgb: {
+      r: 255,
+      g: 255,
+      b: 255
+    }
+  })
+  children.push({
+    name: `${name} Series Label`,
+    editName: "Series Label",
+    on: true,
+    enableTitle: false,
+    fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
+    popup: "",
+    children: [],
+    parent: name,
+    minAge,
+    maxAge,
+    rgb: {
+      r: 255,
+      g: 255,
+      b: 255
+    },
+    width: width * 0.2
+  })
 }


### PR DESCRIPTION
this is the comment about the "hack"
```
/**
 * Since we hash by name only to allow consistency between facies maps and
 * the column page, a generic like Facies Label will cause errors.
 * The solution @Paolo came up with is to prepend the name of the parent
 * and change before the conversion to xml. The downside is we must check
 * every ColumnInfo object which may cause problems with time consistency.
 * However, this is asyncronous, which makes it less likely to cause problems.
 * @param column
 */
```
<img width="207" alt="Screenshot 2024-03-27 at 9 09 48 PM" src="https://github.com/earthhistoryviz/tsconline/assets/89664317/15ec1194-c097-4f1c-b693-ef5c38758861">

java file ^

https://github.com/earthhistoryviz/tsconline/assets/89664317/5ca55d3e-1c7b-4835-a9b1-bd649467f08b

