### PR TITLE
font options should be recursively set in the parsing of datapacks, chron multi column capability, subTransect fix

### DIFF
--- a/app/src/SettingsTabs/ColumnMenu.tsx
+++ b/app/src/SettingsTabs/ColumnMenu.tsx
@@ -82,7 +82,7 @@ export const ColumnMenu = observer(() => {
       </div>
       <div id="ColumnMenuContent" className="column-menu-content">
         {state.settingsTabs.columnSelected && <EditNameField />}
-        {state.settingsTabs.columnSelected && <FontMenu />}
+        <FontMenu />
       </div>
     </div>
   );

--- a/app/src/SettingsTabs/ColumnMenu.tsx
+++ b/app/src/SettingsTabs/ColumnMenu.tsx
@@ -84,7 +84,7 @@ export const ColumnMenu = observer(() => {
       </div>
       <div id="ColumnMenuContent" className="column-menu-content">
         {column && <EditNameField />}
-        {column && <FontMenu column={column}/>}
+        {column && <FontMenu column={column} />}
       </div>
     </div>
   );

--- a/app/src/SettingsTabs/ColumnMenu.tsx
+++ b/app/src/SettingsTabs/ColumnMenu.tsx
@@ -46,6 +46,8 @@ const EditNameField = observer(() => {
 export const ColumnMenu = observer(() => {
   const { state } = useContext(context);
   const [openMenu, setOpenMenu] = useState(false);
+  const selectedColumn = state.settingsTabs.columnSelected;
+  const column = selectedColumn ? state.settingsTabs.columnHashMap.get(selectedColumn!) : undefined;
 
   function showMenu() {
     const menu = document.getElementById("ColumnMenuContent");
@@ -81,8 +83,8 @@ export const ColumnMenu = observer(() => {
         </div>
       </div>
       <div id="ColumnMenuContent" className="column-menu-content">
-        {state.settingsTabs.columnSelected && <EditNameField />}
-        <FontMenu />
+        {column && <EditNameField />}
+        {column && <FontMenu column={column}/>}
       </div>
     </div>
   );

--- a/app/src/SettingsTabs/FontMenu.tsx
+++ b/app/src/SettingsTabs/FontMenu.tsx
@@ -143,6 +143,7 @@ const FontMenuRow: React.FC<{
 export const FontMenu: React.FC<object> = observer(() => {
   const { state } = useContext(context);
   const theme = useTheme();
+  if (state.settingsTabs.columnSelected === null) return null;
   const name =
     state.settingsTabs.columnSelected === null
       ? ""

--- a/app/src/SettingsTabs/FontMenu.tsx
+++ b/app/src/SettingsTabs/FontMenu.tsx
@@ -24,7 +24,7 @@ import FormatItalicIcon from "@mui/icons-material/FormatItalic";
 import { MuiColorInput } from "mui-color-input";
 import CloseIcon from "@mui/icons-material/Close";
 import "./FontMenu.css";
-import { ValidFontOptions } from "@tsconline/shared";
+import { ColumnInfo, ValidFontOptions } from "@tsconline/shared";
 
 const FontMenuRow: React.FC<{
   target: ValidFontOptions;
@@ -143,24 +143,11 @@ const FontMenuRow: React.FC<{
 export const FontMenu: React.FC<object> = observer(() => {
   const { state } = useContext(context);
   const theme = useTheme();
-  if (state.settingsTabs.columnSelected === null) return null;
-  const name =
-    state.settingsTabs.columnSelected === null
-      ? ""
-      : state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected)!.editName;
-  let fontOptionsSet: Set<ValidFontOptions> = new Set();
-  const defaultFontSet: Set<ValidFontOptions> = new Set([
-    "Age Label",
-    "Zone Column Label",
-    "Uncertainty Label",
-    "Event Column Label",
-    "Range Label"
-  ]);
-  if (state.settingsTabs.columnSelected) {
-    fontOptionsSet =
-      state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected)?.fontOptions ?? defaultFontSet;
-  }
   const [open, setOpen] = useState(false);
+  if (!state.settingsTabs.columnSelected || !state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected))
+    return null;
+  const column = state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected)!;
+  const metaColumn = column.children.length > 0;
   const handleOpen = () => {
     setOpen(true);
   };
@@ -177,30 +164,57 @@ export const FontMenu: React.FC<object> = observer(() => {
       <Modal open={open} onClose={handleClose}>
         <Box id="FontMenuContainer">
           <div id="HeadingContainer">
-            <Typography id="FontOptionsTitle">Font Options for {`"${name}"`}</Typography>
+            <Typography id="FontOptionsTitle">Font Options for {`"${column.name}"`}</Typography>
             <div onClick={handleClose}>
               <CloseIcon sx={{ color: theme.palette.primary.main }} />
             </div>
           </div>
-          <Grid container rowSpacing={2} columnSpacing={0}>
-            <Grid item xs={12}>
-              <Typography id="Bold">Change Font</Typography>
-              <FontMenuRow target="Column Header" />
-            </Grid>
-            <Grid item xs={12}>
-              <Divider />
-            </Grid>
-            <Grid item xs={12} style={{ marginBottom: "-16px" }}>
-              <Typography id="AdditionalFontsText">Additional fonts for child columns</Typography>
-            </Grid>
-            {Array.from(fontOptionsSet).map((target) => (
-              <Grid item xs={12} key={target}>
-                <FontMenuRow target={target} />
-              </Grid>
-            ))}
-          </Grid>
+          {metaColumn ? <MetaColumnFontMenu column={column} /> : <LeafColumnFontMenu column={column} />}
         </Box>
       </Modal>
     </div>
+  );
+});
+
+type FontMenuProps = {
+  column: ColumnInfo;
+};
+const MetaColumnFontMenu: React.FC<FontMenuProps> = observer(({ column }) => {
+  return (
+    <Grid container rowSpacing={2} columnSpacing={0}>
+      <Grid item xs={12}>
+        <Typography id="Bold">Change Font</Typography>
+        <FontMenuRow target="Column Header" />
+      </Grid>
+      <Grid item xs={12}>
+        <Divider />
+      </Grid>
+      <Grid item xs={12} style={{ marginBottom: "-16px" }}>
+        <Typography id="AdditionalFontsText">Additional fonts for child columns</Typography>
+      </Grid>
+      {Array.from(column.fontOptions).map((target) => {
+        if (target === "Column Header") return null;
+        return (
+          <Grid item xs={12} key={target}>
+            <FontMenuRow target={target} />
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+});
+
+const LeafColumnFontMenu: React.FC<FontMenuProps> = observer(({ column }) => {
+  return (
+    <Grid container rowSpacing={2} columnSpacing={0}>
+      <Grid item xs={12}>
+        <Typography id="Bold">Change Font</Typography>
+        {Array.from(column.fontOptions).map((target) => (
+          <Grid item xs={12} key={target}>
+            <FontMenuRow target={target} />
+          </Grid>
+        ))}
+      </Grid>
+    </Grid>
   );
 });

--- a/app/src/SettingsTabs/FontMenu.tsx
+++ b/app/src/SettingsTabs/FontMenu.tsx
@@ -140,13 +140,13 @@ const FontMenuRow: React.FC<{
   );
 });
 
-export const FontMenu: React.FC<object> = observer(() => {
-  const { state } = useContext(context);
+type FontMenuProps = {
+  column: ColumnInfo;
+};
+
+export const FontMenu: React.FC<FontMenuProps> = observer(({ column }) => {
   const theme = useTheme();
   const [open, setOpen] = useState(false);
-  if (!state.settingsTabs.columnSelected || !state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected))
-    return null;
-  const column = state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected)!;
   const metaColumn = column.children.length > 0;
   const handleOpen = () => {
     setOpen(true);
@@ -176,9 +176,6 @@ export const FontMenu: React.FC<object> = observer(() => {
   );
 });
 
-type FontMenuProps = {
-  column: ColumnInfo;
-};
 const MetaColumnFontMenu: React.FC<FontMenuProps> = observer(({ column }) => {
   return (
     <Grid container rowSpacing={2} columnSpacing={0}>

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -347,7 +347,7 @@ export const setDatapackConfig = action(
       assertColumnInfo(columnInfo);
       assertMapInfo(mapInfo);
     } catch (e) {
-      console.error(e)
+      console.error(e);
       pushError(ErrorCodes.INVALID_DATAPACK_CONFIG);
       return false;
     }

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -266,6 +266,7 @@ export const setDatapackConfig = action(
         name: "Chart Root", // if you change this, change parse-datapacks.ts :69
         editName: "Chart Root",
         fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
+        fontOptions: ["Column Header"],
         popup: "",
         on: true,
         width: 100,
@@ -284,6 +285,7 @@ export const setDatapackConfig = action(
             fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
             on: true,
             width: 100,
+            fontOptions: ["Column Header"],
             enableTitle: true,
             rgb: {
               r: 255,
@@ -296,6 +298,7 @@ export const setDatapackConfig = action(
                 name: "Ma",
                 editName: "Ma",
                 fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
+                fontOptions: ["Column Header", "Ruler Label"],
                 on: true,
                 width: 100,
                 enableTitle: true,

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -347,6 +347,7 @@ export const setDatapackConfig = action(
       assertColumnInfo(columnInfo);
       assertMapInfo(mapInfo);
     } catch (e) {
+      console.error(e)
       pushError(ErrorCodes.INVALID_DATAPACK_CONFIG);
       return false;
     }

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -807,6 +807,40 @@
                 "children": [],
                 "editName": "Blank",
                 "parent": "Parent 1"
+            },
+            {
+                "name": "Transect",
+                "editName": "Transect",
+                "on": true,
+                "enableTitle": true,
+                "fontsInfo": {
+                  "font": "Arial"
+                },
+                "popup": "Transect Popup",
+                "children": [],
+                "parent": "Parent 1",
+                "minAge": 0,
+                "maxAge": 9.22,
+                "width": 500,
+                "rgb": {
+                  "r": 240,
+                  "g": 255,
+                  "b": 255
+                },
+                "fontOptions": [
+                    "Column Header"
+                ],
+                "subTransectInfo": [
+                  {
+                    "age": 0
+                  },
+                  {
+                    "age": 2.58
+                  },
+                  {
+                    "age": 9.22
+                  }
+                ]
             }
             ],
             "parent": "Chart Title",

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -440,8 +440,8 @@
                         "maxAge": 10,
                         "width": 84,
                         "rgb": {
-                            "r": 255,
-                            "g": 255,
+                            "r": 100,
+                            "g": 200,
                             "b": 255
                         }
                     },
@@ -465,8 +465,8 @@
                         "maxAge": 10,
                         "width": 210,
                         "rgb": {
-                            "r": 255,
-                            "g": 255,
+                            "r": 100,
+                            "g": 200,
                             "b": 255
                         }
                     },
@@ -490,8 +490,8 @@
                         "maxAge": 10,
                         "width": 84,
                         "rgb": {
-                            "r": 255,
-                            "g": 255,
+                            "r": 100,
+                            "g": 200,
                             "b": 255
                         }
                     },
@@ -514,8 +514,8 @@
                         "minAge": 0,
                         "maxAge": 10,
                         "rgb": {
-                            "r": 255,
-                            "g": 255,
+                            "r": 100,
+                            "g": 200,
                             "b": 255
                         },
                         "width": 42
@@ -643,10 +643,86 @@
                 },
                 "fontOptions": [
                     "Column Header",
-                    "Age Label"
+                    "Age Label",
+                    "Zone Column Label"
                 ],
                 "popup": "Chron Popup",
-                "children": [],
+                "children": [
+                    {
+                        "name": "Chron Chron",
+                        "editName": "Chron",
+                        "on": true,
+                        "enableTitle": false,
+                        "fontOptions": [
+                          "Column Header",
+                          "Age Label"
+                        ],
+                        "fontsInfo": {
+                          "font": "Arial"
+                        },
+                        "popup": "",
+                        "children": [],
+                        "parent": "Chron",
+                        "minAge": 0,
+                        "maxAge": 0.234,
+                        "width": 60,
+                        "rgb": {
+                          "r": 255,
+                          "g": 255,
+                          "b": 255
+                        }
+                    },
+                    {
+                        "name": "Chron Chron Label",
+                        "editName": "Chron Label",
+                        "on": false,
+                        "enableTitle": false,
+                        "fontOptions": [
+                          "Column Header",
+                          "Age Label",
+                          "Zone Column Label"
+                        ],
+                        "fontsInfo": {
+                          "font": "Arial"
+                        },
+                        "popup": "",
+                        "children": [],
+                        "parent": "Chron",
+                        "minAge": 0,
+                        "maxAge": 0.234,
+                        "width": 40,
+                        "rgb": {
+                          "r": 255,
+                          "g": 255,
+                          "b": 255
+                        }
+                    },
+                    {
+                        "name": "Chron Series Label",
+                        "editName": "Series Label",
+                        "on": true,
+                        "enableTitle": false,
+                        "fontOptions": [
+                          "Column Header",
+                          "Age Label",
+                          "Zone Column Label"
+                        ],
+                        "fontsInfo": {
+                          "font": "Arial"
+                        },
+                        "popup": "",
+                        "children": [],
+                        "parent": "Chron",
+                        "minAge": 0,
+                        "maxAge": 0.234,
+                        "width": 40,
+                        "rgb": {
+                          "r": 255,
+                          "g": 255,
+                          "b": 255
+                        }
+                    }    
+                ],
                 "parent": "Parent 1",
                 "minAge": 0,
                 "maxAge": 0.234,

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -15,6 +15,12 @@
                 "fontsInfo": {
                     "font": "Arial"
                 },
+                "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Uncertainty Label",
+                    "Zone Column Label"
+                ],
                 "popup": "",
                 "children": [
                 {
@@ -31,6 +37,12 @@
                     "fontsInfo": {
                         "font": "Arial"
                     },
+                    "fontOptions": [
+                        "Column Header",
+                        "Age Label",
+                        "Uncertainty Label",
+                        "Zone Column Label"
+                    ],
                     "popup": "",
                     "children": [
                         {
@@ -41,6 +53,11 @@
                             "fontsInfo": {
                               "font": "Arial"
                             },
+                            "fontOptions": [
+                                "Column Header",
+                                "Age Label",
+                                "Uncertainty Label"
+                            ],
                             "popup": "",
                             "children": [],
                             "parent": "Nigeria Coast",
@@ -61,6 +78,11 @@
                             "fontsInfo": {
                               "font": "Arial"
                             },
+                            "fontOptions": [
+                                "Column Header",
+                                "Age Label",
+                                "Zone Column Label"
+                            ],
                             "popup": "",
                             "children": [],
                             "parent": "Nigeria Coast",
@@ -81,6 +103,11 @@
                             "fontsInfo": {
                               "font": "Arial"
                             },
+                            "fontOptions": [
+                                "Column Header",
+                                "Age Label",
+                                "Zone Column Label"
+                            ],
                             "popup": "",
                             "children": [],
                             "parent": "Nigeria Coast",
@@ -101,6 +128,11 @@
                             "fontsInfo": {
                               "font": "Arial"
                             },
+                            "fontOptions": [
+                                "Column Header",
+                                "Age Label",
+                                "Zone Column Label"
+                            ],
                             "popup": "",
                             "children": [],
                             "parent": "Nigeria Coast",
@@ -151,6 +183,12 @@
                     "fontsInfo": {
                         "font": "Arial"
                     },
+                    "fontOptions": [
+                        "Column Header",
+                        "Age Label",
+                        "Uncertainty Label",
+                        "Zone Column Label"
+                    ],
                     "popup": "",
                     "children": [
                         {
@@ -161,6 +199,11 @@
                             "fontsInfo": {
                               "font": "Arial"
                             },
+                            "fontOptions": [
+                                "Column Header",
+                                "Age Label",
+                                "Uncertainty Label"
+                            ],
                             "popup": "",
                             "children": [],
                             "parent": "South Atlantic",
@@ -181,6 +224,11 @@
                             "fontsInfo": {
                               "font": "Arial"
                             },
+                            "fontOptions": [
+                                "Column Header",
+                                "Age Label",
+                                "Zone Column Label"
+                            ],
                             "popup": "",
                             "children": [],
                             "parent": "South Atlantic",
@@ -201,6 +249,11 @@
                             "fontsInfo": {
                               "font": "Arial"
                             },
+                            "fontOptions": [
+                                "Column Header",
+                                "Age Label",
+                                "Zone Column Label"
+                            ],
                             "popup": "",
                             "children": [],
                             "parent": "South Atlantic",
@@ -221,6 +274,11 @@
                             "fontsInfo": {
                               "font": "Arial"
                             },
+                            "fontOptions": [
+                                "Column Header",
+                                "Age Label",
+                                "Zone Column Label"
+                            ],
                             "popup": "",
                             "children": [],
                             "parent": "South Atlantic",
@@ -323,6 +381,11 @@
                     "g": 217,
                     "b": 234
                 },
+                "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
                 "subBlockInfo": [
                 {
                     "label": "TOP",
@@ -367,6 +430,11 @@
                         },
                         "popup": "",
                         "children": [],
+                        "fontOptions": [
+                            "Column Header",
+                            "Age Label",
+                            "Uncertainty Label"
+                          ],
                         "parent": "Facies",
                         "minAge": 0,
                         "maxAge": 10,
@@ -385,6 +453,11 @@
                         "fontsInfo": {
                           "font": "Arial"
                         },
+                        "fontOptions": [
+                            "Column Header",
+                            "Age Label",
+                            "Zone Column Label"
+                          ],
                         "popup": "",
                         "children": [],
                         "parent": "Facies",
@@ -405,6 +478,11 @@
                         "fontsInfo": {
                           "font": "Arial"
                         },
+                        "fontOptions": [
+                            "Column Header",
+                            "Age Label",
+                            "Zone Column Label"
+                          ],
                         "popup": "",
                         "children": [],
                         "parent": "Facies",
@@ -425,6 +503,11 @@
                         "fontsInfo": {
                           "font": "Arial"
                         },
+                        "fontOptions": [
+                            "Column Header",
+                            "Age Label",
+                            "Zone Column Label"
+                          ],
                         "popup": "",
                         "children": [],
                         "parent": "Facies",
@@ -446,6 +529,12 @@
                     "b": 255
                 },
                 "parent": "Parent 1",
+                "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Uncertainty Label",
+                    "Zone Column Label"
+                ],
                 "minAge": 0,
                 "maxAge": 10,
                 "subFaciesInfo": [
@@ -475,6 +564,13 @@
                 "fontsInfo": {
                     "font": "Arial"
                 },
+                "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Event Column Label",
+                    "Uncertainty Label",
+                    "Range Label"
+                  ],
                 "popup": "Event Popup",
                 "children": [],
                 "parent": "Parent 1",
@@ -534,6 +630,7 @@
                 "fontsInfo": {
                     "font": "Arial"
                 },
+                "fontOptions": ["Column Header", "Popup Body"],
                 "editName": "Range"
             },
             {
@@ -544,6 +641,10 @@
                 "fontsInfo": {
                     "font": "Arial"
                 },
+                "fontOptions": [
+                    "Column Header",
+                    "Age Label"
+                ],
                 "popup": "Chron Popup",
                 "children": [],
                 "parent": "Parent 1",
@@ -582,6 +683,10 @@
                 "fontsInfo": {
                     "font": "Arial"
                 },
+                "fontOptions": [
+                    "Column Header",
+                    "Point Column Scale Label"
+                ],
                 "parent": "Parent 1",
                 "minAge": 4,
                 "maxAge": 5,
@@ -617,6 +722,11 @@
                 "fontsInfo": {
                     "font": "Arial"
                 },
+                "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Sequence Column Label"
+                ],
                 "parent": "Parent 1",
                 "on": true,
                 "width": 900,
@@ -661,6 +771,9 @@
                   "g": 123,
                   "b": 104
                 },
+                "fontOptions": [
+                    "Column Header"
+                ],
                 "subFreehandInfo": [
                   {
                     "topAge": 0,
@@ -688,6 +801,9 @@
                 "fontsInfo": {
                     "font": "Arial"
                 },
+                "fontOptions": [
+                    "Column Header"
+                ],
                 "children": [],
                 "editName": "Blank",
                 "parent": "Parent 1"
@@ -714,7 +830,18 @@
                 "age": 10,
                 "info": ""
             }
-            ]
+            ],
+            "fontOptions": [
+                "Column Header",
+                "Age Label",
+                "Zone Column Label",
+                "Uncertainty Label",
+                "Event Column Label",
+                "Range Label",
+                "Popup Body",
+                "Point Column Scale Label",
+                "Sequence Column Label"
+              ]
         }
         ],
         "datapackAgeInfo": {

--- a/server/__tests__/__data__/parse-datapacks-test-2.txt
+++ b/server/__tests__/__data__/parse-datapacks-test-2.txt
@@ -3,7 +3,7 @@ SetTop:	0
 SetBase:	5
 SetScale:	6
 
-Parent 1	:	Block	Facies	Event	Range	Chron	Point	Sequence	Freehand	Blank
+Parent 1	:	Block	Facies	Event	Range	Chron	Point	Sequence	Freehand	Blank	Transect
 
 Block	block	120	197/217/234	notitle	off	Block Popup
 	TOP	419.2

--- a/server/__tests__/parse-datapacks.test.ts
+++ b/server/__tests__/parse-datapacks.test.ts
@@ -61,23 +61,12 @@ import {
 } from "@tsconline/shared";
 const key = JSON.parse(readFileSync("server/__tests__/__data__/column-keys.json").toString());
 
-/**
- * converts the sets to arrays for comparison with json files
- * @param files
- * @param decrypt_filepath
- * @returns
- */
-async function parseDatapacksAndNormalize(files: string[], decrypt_filepath: string) {
-  const datapacks = await parseDatapacks(files, decrypt_filepath);
-  return JSON.parse(JSON.stringify(datapacks, (_key, value) => (value instanceof Set ? [...value] : value)));
-}
-
 describe("general parse-datapacks tests", () => {
   /**
    * Parses the general Africa Bight map pack
    */
   it("should parse africa general datapack", async () => {
-    const datapacks = await parseDatapacksAndNormalize([], "parse-datapacks-test-1.txt");
+    const datapacks = await parseDatapacks([], "parse-datapacks-test-1.txt");
     expect(datapacks).toEqual(key["general-parse-datapacks-test-1-key"]);
   });
 
@@ -86,7 +75,7 @@ describe("general parse-datapacks tests", () => {
    * Checks both datapack ages and columnInfo values
    */
   it("should parse general datapack with all column types", async () => {
-    const datapacks = await parseDatapacksAndNormalize([], "parse-datapacks-test-2.txt");
+    const datapacks = await parseDatapacks([], "parse-datapacks-test-2.txt");
     expect(datapacks).toEqual(key["general-parse-datapacks-test-2-key"]);
   });
 

--- a/server/__tests__/parse-datapacks.test.ts
+++ b/server/__tests__/parse-datapacks.test.ts
@@ -61,28 +61,33 @@ import {
 } from "@tsconline/shared";
 const key = JSON.parse(readFileSync("server/__tests__/__data__/column-keys.json").toString());
 
+/**
+ * converts the sets to arrays for comparison with json files
+ * @param files
+ * @param decrypt_filepath
+ * @returns
+ */
+async function parseDatapacksAndNormalize(files: string[], decrypt_filepath: string) {
+  const datapacks = await parseDatapacks(files, decrypt_filepath);
+  return JSON.parse(JSON.stringify(datapacks, (_key, value) => (value instanceof Set ? [...value] : value)));
+}
+
 describe("general parse-datapacks tests", () => {
   /**
    * Parses the general Africa Bight map pack
    */
   it("should parse africa general datapack", async () => {
-    const datapacks = await parseDatapacks([], "parse-datapacks-test-1.txt");
-    const normalizedDatapacks = JSON.parse(JSON.stringify(datapacks, (_key, value) =>
-      value instanceof Set ? [...value] : value
-    ));
-    expect(normalizedDatapacks).toEqual(key["general-parse-datapacks-test-1-key"]);
+    const datapacks = await parseDatapacksAndNormalize([], "parse-datapacks-test-1.txt");
+    expect(datapacks).toEqual(key["general-parse-datapacks-test-1-key"]);
   });
 
   /**
-   * Parses a custom simple pack of both facies and block
+   * Parses a custom simple pack of all column types
    * Checks both datapack ages and columnInfo values
    */
   it("should parse general datapack with all column types", async () => {
-    const datapacks = await parseDatapacks([], "parse-datapacks-test-2.txt");
-    const normalizedDatapacks = JSON.parse(JSON.stringify(datapacks, (_key, value) =>
-      value instanceof Set ? [...value] : value
-    ));
-    expect(normalizedDatapacks).toEqual(key["general-parse-datapacks-test-2-key"]);
+    const datapacks = await parseDatapacksAndNormalize([], "parse-datapacks-test-2.txt");
+    expect(datapacks).toEqual(key["general-parse-datapacks-test-2-key"]);
   });
 
   /**

--- a/server/__tests__/parse-datapacks.test.ts
+++ b/server/__tests__/parse-datapacks.test.ts
@@ -25,6 +25,7 @@ jest.mock("@tsconline/shared", () => ({
     if (typeof o.b !== "number") throw new Error("Invalid rgb");
     if (o.b < 0 || o.b > 255) throw new Error("Invalid rgb");
   }),
+  allFontOptions: ["Column Header", "Popup Body"],
   defaultFontsInfo: { font: "Arial" },
   assertFontsInfo: jest.fn().mockImplementation((fonts) => {
     if (fonts.font !== "Arial") throw new Error("Invalid font");
@@ -66,7 +67,10 @@ describe("general parse-datapacks tests", () => {
    */
   it("should parse africa general datapack", async () => {
     const datapacks = await parseDatapacks([], "parse-datapacks-test-1.txt");
-    expect(datapacks).toEqual(key["general-parse-datapacks-test-1-key"]);
+    const normalizedDatapacks = JSON.parse(JSON.stringify(datapacks, (_key, value) =>
+      value instanceof Set ? [...value] : value
+    ));
+    expect(normalizedDatapacks).toEqual(key["general-parse-datapacks-test-1-key"]);
   });
 
   /**
@@ -75,7 +79,10 @@ describe("general parse-datapacks tests", () => {
    */
   it("should parse general datapack with all column types", async () => {
     const datapacks = await parseDatapacks([], "parse-datapacks-test-2.txt");
-    expect(datapacks).toEqual(key["general-parse-datapacks-test-2-key"]);
+    const normalizedDatapacks = JSON.parse(JSON.stringify(datapacks, (_key, value) =>
+      value instanceof Set ? [...value] : value
+    ));
+    expect(normalizedDatapacks).toEqual(key["general-parse-datapacks-test-2-key"]);
   });
 
   /**

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -1146,8 +1146,9 @@ function recursive(
       currentColumnInfo.width,
       currentColumnInfo.minAge,
       currentColumnInfo.maxAge,
-      returnValue.fontOptions
+      currentColumnInfo.fontOptions
     );
+    returnValue.fontOptions = currentColumnInfo.fontOptions;
     returnValue.subFaciesInfo = currentFacies.subFaciesInfo;
     returnValue.minAge = currentColumnInfo.minAge;
     returnValue.maxAge = currentColumnInfo.maxAge;
@@ -1275,8 +1276,8 @@ export function createDefaultColumnHeaderProps(overrides: Partial<ColumnHeaderPr
 function addFaciesChildren(children: ColumnInfo[], name: string, width: number, minAge: number, maxAge: number, fontOptions: Set<ValidFontOptions>) {
   fontOptions.add("Column Header");
   fontOptions.add("Age Label");
-  fontOptions.add("Zone Column Label");
   fontOptions.add("Uncertainty Label")
+  fontOptions.add("Zone Column Label");
   children.push({
     name: `${name} Facies`,
     editName: name,

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -56,7 +56,7 @@ type FaciesFoundAndAgeRange = {
   subFaciesInfo?: SubFaciesInfo[];
   minAge: number;
   maxAge: number;
-  fontOptions: Set<ValidFontOptions>;
+  fontOptions: ValidFontOptions[];
 };
 /**
  * parses the METACOLUMN and info of the children string
@@ -1077,13 +1077,13 @@ function recursive(
       g: 255,
       b: 255
     },
-    fontOptions: new Set<ValidFontOptions>(["Column Header"])
+    fontOptions: ["Column Header"]
   };
   const returnValue: FaciesFoundAndAgeRange = {
     faciesFound: false,
     minAge: 99999,
     maxAge: -99999,
-    fontOptions: new Set<ValidFontOptions>(["Column Header"])
+    fontOptions: ["Column Header"]
   };
 
   if (parsedColumnEntry) {
@@ -1105,7 +1105,7 @@ function recursive(
     const currentSequence = sequenceMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentSequence,
-      fontOptions: new Set<ValidFontOptions>(["Column Header", "Age Label", "Sequence Column Label"]),
+      fontOptions: ["Column Header", "Age Label", "Sequence Column Label"],
       subSequenceInfo: JSON.parse(JSON.stringify(currentSequence.subSequenceInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1116,7 +1116,7 @@ function recursive(
     const currentBlock = blocksMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentBlock,
-      fontOptions: new Set<ValidFontOptions>(["Column Header", "Age Label", "Zone Column Label"]),
+      fontOptions: ["Column Header", "Age Label", "Zone Column Label"],
       subBlockInfo: JSON.parse(JSON.stringify(currentBlock.subBlockInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1127,7 +1127,7 @@ function recursive(
     const currentRange = rangeMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentRange,
-      fontOptions: new Set<ValidFontOptions>(allFontOptions),
+      fontOptions: [...allFontOptions],
       subRangeInfo: JSON.parse(JSON.stringify(currentRange.subRangeInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1157,13 +1157,7 @@ function recursive(
     const currentEvent = eventMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentEvent,
-      fontOptions: new Set<ValidFontOptions>([
-        "Column Header",
-        "Age Label",
-        "Event Column Label",
-        "Uncertainty Label",
-        "Range Label"
-      ]),
+      fontOptions: ["Column Header", "Age Label", "Event Column Label", "Uncertainty Label", "Range Label"],
       subEventInfo: JSON.parse(JSON.stringify(currentEvent.subEventInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1174,7 +1168,7 @@ function recursive(
     const currentChron = chronMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentChron,
-      fontOptions: new Set<ValidFontOptions>(["Column Header", "Age Label"]),
+      fontOptions: ["Column Header", "Age Label"],
       subChronInfo: JSON.parse(JSON.stringify(currentChron.subChronInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1185,7 +1179,7 @@ function recursive(
     const currentPoint = pointMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentPoint,
-      fontOptions: new Set<ValidFontOptions>(["Column Header", "Point Column Scale Label"]),
+      fontOptions: ["Column Header", "Point Column Scale Label"],
       subPointInfo: JSON.parse(JSON.stringify(currentPoint.subPointInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1234,7 +1228,9 @@ function recursive(
       );
       returnValue.minAge = Math.min(compareValue.minAge, returnValue.minAge);
       returnValue.maxAge = Math.max(compareValue.maxAge, returnValue.maxAge);
-      currentColumnInfo.fontOptions = new Set([...currentColumnInfo.fontOptions, ...compareValue.fontOptions]);
+      currentColumnInfo.fontOptions = Array.from(
+        new Set([...currentColumnInfo.fontOptions, ...compareValue.fontOptions])
+      );
       currentColumnInfo.minAge = returnValue.minAge;
       currentColumnInfo.maxAge = returnValue.maxAge;
       returnValue.faciesFound = compareValue.faciesFound || returnValue.faciesFound;
@@ -1285,19 +1281,18 @@ function addFaciesChildren(
   width: number,
   minAge: number,
   maxAge: number,
-  fontOptions: Set<ValidFontOptions>
+  fontOptions: ValidFontOptions[]
 ) {
-  fontOptions.add("Column Header");
-  fontOptions.add("Age Label");
-  fontOptions.add("Uncertainty Label");
-  fontOptions.add("Zone Column Label");
+  fontOptions.push("Age Label");
+  fontOptions.push("Uncertainty Label");
+  fontOptions.push("Zone Column Label");
   children.push({
     name: `${name} Facies`,
     editName: name,
     on: true,
     enableTitle: false,
     fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
-    fontOptions: new Set<ValidFontOptions>(["Column Header", "Age Label", "Uncertainty Label"]),
+    fontOptions: ["Column Header", "Age Label", "Uncertainty Label"],
     popup: "",
     children: [],
     parent: name,
@@ -1315,7 +1310,7 @@ function addFaciesChildren(
     editName: "Members",
     on: false,
     enableTitle: false,
-    fontOptions: new Set<ValidFontOptions>(["Column Header", "Age Label", "Zone Column Label"]),
+    fontOptions: ["Column Header", "Age Label", "Zone Column Label"],
     fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
     popup: "",
     children: [],
@@ -1335,7 +1330,7 @@ function addFaciesChildren(
     on: true,
     enableTitle: false,
     fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
-    fontOptions: new Set<ValidFontOptions>(["Column Header", "Age Label", "Zone Column Label"]),
+    fontOptions: ["Column Header", "Age Label", "Zone Column Label"],
     popup: "",
     children: [],
     parent: name,
@@ -1354,7 +1349,7 @@ function addFaciesChildren(
     on: true,
     enableTitle: false,
     fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
-    fontOptions: new Set<ValidFontOptions>(["Column Header", "Age Label", "Zone Column Label"]),
+    fontOptions: ["Column Header", "Age Label", "Zone Column Label"],
     popup: "",
     children: [],
     parent: name,

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -1231,6 +1231,7 @@ function recursive(
       currentColumnInfo.fontOptions = Array.from(
         new Set([...currentColumnInfo.fontOptions, ...compareValue.fontOptions])
       );
+      returnValue.fontOptions = currentColumnInfo.fontOptions;
       currentColumnInfo.minAge = returnValue.minAge;
       currentColumnInfo.maxAge = returnValue.maxAge;
       returnValue.faciesFound = compareValue.faciesFound || returnValue.faciesFound;

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -1146,6 +1146,7 @@ function recursive(
       currentColumnInfo.width,
       currentColumnInfo.minAge,
       currentColumnInfo.maxAge,
+      currentColumnInfo.rgb,
       currentColumnInfo.fontOptions
     );
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1165,12 +1166,20 @@ function recursive(
     returnValue.minAge = currentColumnInfo.minAge;
   }
   if (chronMap.has(currentColumn)) {
-    const currentChron = chronMap.get(currentColumn)!;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { width, ...currentChron } = chronMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentChron,
-      fontOptions: ["Column Header", "Age Label"],
       subChronInfo: JSON.parse(JSON.stringify(currentChron.subChronInfo))
     });
+    addChronChildren(
+      currentColumnInfo.children,
+      currentColumnInfo.name,
+      currentColumnInfo.minAge,
+      currentColumnInfo.maxAge,
+      currentColumnInfo.rgb,
+      currentColumnInfo.fontOptions
+    );
     returnValue.fontOptions = currentColumnInfo.fontOptions;
     returnValue.maxAge = currentColumnInfo.maxAge;
     returnValue.minAge = currentColumnInfo.minAge;
@@ -1282,6 +1291,7 @@ function addFaciesChildren(
   width: number,
   minAge: number,
   maxAge: number,
+  rgb: RGB,
   fontOptions: ValidFontOptions[]
 ) {
   fontOptions.push("Age Label");
@@ -1300,11 +1310,7 @@ function addFaciesChildren(
     minAge,
     maxAge,
     width: width * 0.4,
-    rgb: {
-      r: 255,
-      g: 255,
-      b: 255
-    }
+    rgb
   });
   children.push({
     name: `${name} Members`,
@@ -1319,11 +1325,7 @@ function addFaciesChildren(
     minAge,
     maxAge,
     width,
-    rgb: {
-      r: 255,
-      g: 255,
-      b: 255
-    }
+    rgb
   });
   children.push({
     name: `${name} Facies Label`,
@@ -1338,11 +1340,7 @@ function addFaciesChildren(
     minAge,
     maxAge,
     width: width * 0.4,
-    rgb: {
-      r: 255,
-      g: 255,
-      b: 255
-    }
+    rgb
   });
   children.push({
     name: `${name} Series Label`,
@@ -1356,11 +1354,77 @@ function addFaciesChildren(
     parent: name,
     minAge,
     maxAge,
-    rgb: {
-      r: 255,
-      g: 255,
-      b: 255
-    },
+    rgb,
     width: width * 0.2
+  });
+}
+
+/**
+ * Chrons columns consist of three sub columns
+ * Currently from trial and error, even if there is a width on the parent chrons
+ * the children will have a width of 60, 40, 40
+ * TODO check to make sure this is okay in the future
+ * @param children
+ * @param name
+ * @param width
+ * @param minAge
+ * @param maxAge
+ * @param rgb
+ * @param fontOptions
+ */
+function addChronChildren(
+  children: ColumnInfo[],
+  name: string,
+  minAge: number,
+  maxAge: number,
+  rgb: RGB,
+  fontOptions: ValidFontOptions[]
+) {
+  fontOptions.push("Age Label");
+  fontOptions.push("Zone Column Label");
+  children.push({
+    name: `${name} Chron`,
+    editName: name,
+    on: true,
+    enableTitle: false,
+    fontOptions: ["Column Header", "Age Label"],
+    fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
+    popup: "",
+    children: [],
+    parent: name,
+    minAge,
+    maxAge,
+    width: 60,
+    rgb
+  });
+  children.push({
+    name: `${name} Chron Label`,
+    editName: "Chron Label",
+    on: false,
+    enableTitle: false,
+    fontOptions: ["Column Header", "Age Label", "Zone Column Label"],
+    fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
+    popup: "",
+    children: [],
+    parent: name,
+    minAge,
+    maxAge,
+    width: 40,
+    rgb
+  });
+  children.push({
+    name: `${name} Series Label`,
+    editName: "Series Label",
+    on: true,
+    enableTitle: false,
+    fontOptions: ["Column Header", "Age Label", "Zone Column Label"],
+    fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
+    popup: "",
+    children: [],
+    parent: name,
+    minAge,
+    maxAge,
+    width: 40,
+    rgb
   });
 }

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -1157,7 +1157,13 @@ function recursive(
     const currentEvent = eventMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentEvent,
-      fontOptions: new Set<ValidFontOptions>(["Column Header", "Age Label", "Event Column Label", "Uncertainty Label", "Range Label"]),
+      fontOptions: new Set<ValidFontOptions>([
+        "Column Header",
+        "Age Label",
+        "Event Column Label",
+        "Uncertainty Label",
+        "Range Label"
+      ]),
       subEventInfo: JSON.parse(JSON.stringify(currentEvent.subEventInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1273,10 +1279,17 @@ export function createDefaultColumnHeaderProps(overrides: Partial<ColumnHeaderPr
  * @param minAge the minage of the parent
  * @param maxAge  the maxage of the parent
  */
-function addFaciesChildren(children: ColumnInfo[], name: string, width: number, minAge: number, maxAge: number, fontOptions: Set<ValidFontOptions>) {
+function addFaciesChildren(
+  children: ColumnInfo[],
+  name: string,
+  width: number,
+  minAge: number,
+  maxAge: number,
+  fontOptions: Set<ValidFontOptions>
+) {
   fontOptions.add("Column Header");
   fontOptions.add("Age Label");
-  fontOptions.add("Uncertainty Label")
+  fontOptions.add("Uncertainty Label");
   fontOptions.add("Zone Column Label");
   children.push({
     name: `${name} Facies`,

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -12,9 +12,21 @@ import {
 } from "./index";
 
 export const allFontOptions: ValidFontOptions[] = [
-  "Column Header", "Age Label", "Uncertainty Label", "Zone Column Label", "Sequence Column Label",
-  "Event Column Label", "Popup Body", "Ruler Label", "Point Column Scale Label", "Range Label",
-  "Ruler Tick Mark Label", "Legend Title", "Legend Column Name", "Legend Column Source", "Range Box Label"
+  "Column Header",
+  "Age Label",
+  "Uncertainty Label",
+  "Zone Column Label",
+  "Sequence Column Label",
+  "Event Column Label",
+  "Popup Body",
+  "Ruler Label",
+  "Point Column Scale Label",
+  "Range Label",
+  "Ruler Tick Mark Label",
+  "Legend Title",
+  "Legend Column Name",
+  "Legend Column Source",
+  "Range Box Label"
 ];
 
 export const defaultFontsInfoConstant: FontsInfo = {

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -7,8 +7,15 @@ import {
   RangeColumnInfoTSC,
   RulerColumnInfoTSC,
   SequenceColumnInfoTSC,
+  ValidFontOptions,
   ZoneColumnInfoTSC
 } from "./index";
+
+export const allFontOptions: ValidFontOptions[] = [
+  "Column Header", "Age Label", "Uncertainty Label", "Zone Column Label", "Sequence Column Label",
+  "Event Column Label", "Popup Body", "Ruler Label", "Point Column Scale Label", "Range Label",
+  "Ruler Tick Mark Label", "Legend Title", "Legend Column Name", "Legend Column Source", "Range Box Label"
+];
 
 export const defaultFontsInfoConstant: FontsInfo = {
   "Age Label": {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -155,7 +155,7 @@ export type ColumnInfo = {
   name: string;
   editName: string;
   fontsInfo: FontsInfo;
-  fontOptions?: Set<ValidFontOptions>;
+  fontOptions: Set<ValidFontOptions>;
   on: boolean;
   popup: string;
   children: ColumnInfo[];
@@ -168,6 +168,7 @@ export type ColumnInfo = {
   subPointInfo?: SubPointInfo[];
   subFreehandInfo?: SubFreehandInfo[];
   subSequenceInfo?: SubSequenceInfo[];
+  subTransectInfo?: SubTransectInfo[];
   minAge: number;
   maxAge: number;
   enableTitle: boolean;
@@ -716,6 +717,13 @@ export function assertColumnInfo(o: any): asserts o is ColumnInfo {
       throwError("ColumnInfo", "subSequenceInfo", "array", o.subSequenceInfo);
     for (const sequence of o.subSequenceInfo) {
       assertSubSequenceInfo(sequence);
+    }
+  }
+  if ("subTransectInfo" in o) {
+    if (!o.subTransectInfo || !Array.isArray(o.subTransectInfo))
+      throwError("ColumnInfo", "subTransectInfo", "array", o.subTransectInfo);
+    for (const transect of o.subTransectInfo) {
+      assertSubTransectInfo(transect);
     }
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -155,7 +155,7 @@ export type ColumnInfo = {
   name: string;
   editName: string;
   fontsInfo: FontsInfo;
-  fontOptions: Set<ValidFontOptions>;
+  fontOptions: ValidFontOptions[];
   on: boolean;
   popup: string;
   children: ColumnInfo[];
@@ -645,6 +645,15 @@ export function assertChartInfo(o: any): asserts o is ChartResponseInfo {
   if (typeof o.chartpath !== "string") throwError("ChartInfo", "chartpath", "string", o.chartpath);
   if (typeof o.hash !== "string") throwError("ChartInfo", "hash", "string", o.hash);
 }
+export function assertValidFontOptions(o: any): asserts o is ValidFontOptions {
+  if (!o || typeof o !== "string") throw new Error("ValidFontOptions must be a string");
+  if (
+    /^(Column Header|Age Label|Uncertainty Label|Zone Column Label|Sequence Column Label|Event Column Label|Popup Body|Ruler Label|Point Column Scale Label|Range Label|Ruler Tick Mark Label|Legend Title|Legend Column Name|Legend Column Source|Range Box Label)$/.test(
+      o
+    )
+  )
+    throw new Error("ValidFontOptions must be a valid font option");
+}
 
 export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   if (typeof o !== "object" || o === null) {
@@ -659,6 +668,10 @@ export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   if (typeof o.maxAge !== "number") throwError("ColumnInfo", "maxAge", "number", o.maxAge);
   if (typeof o.width !== "number") throwError("ColumnInfo", "width", "number", o.width);
   if (typeof o.enableTitle !== "boolean") throwError("ColumnInfo", "enableTitle", "boolean", o.enableTitle);
+  if (!Array.isArray(o.fontOptions)) throwError("ColumnInfo", "fontOptions", "array", o.fontOptions);
+  for (const fontOption of o.fontOptions) {
+    assertValidFontOptions(fontOption);
+  }
   assertRGB(o.rgb);
   for (const child of o.children) {
     assertColumnInfo(child);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -648,11 +648,11 @@ export function assertChartInfo(o: any): asserts o is ChartResponseInfo {
 export function assertValidFontOptions(o: any): asserts o is ValidFontOptions {
   if (!o || typeof o !== "string") throw new Error("ValidFontOptions must be a string");
   if (
-    /^(Column Header|Age Label|Uncertainty Label|Zone Column Label|Sequence Column Label|Event Column Label|Popup Body|Ruler Label|Point Column Scale Label|Range Label|Ruler Tick Mark Label|Legend Title|Legend Column Name|Legend Column Source|Range Box Label)$/.test(
+    !/^(Column Header|Age Label|Uncertainty Label|Zone Column Label|Sequence Column Label|Event Column Label|Popup Body|Ruler Label|Point Column Scale Label|Range Label|Ruler Tick Mark Label|Legend Title|Legend Column Name|Legend Column Source|Range Box Label)$/.test(
       o
     )
   )
-    throw new Error("ValidFontOptions must be a valid font option");
+    throwError("ValidFontOptions", "ValidFontOptions", "ValidFontOptions", o);
 }
 
 export function assertColumnInfo(o: any): asserts o is ColumnInfo {


### PR DESCRIPTION
depending on the column type, the font options that should show for the font menu are now correctly set
the java program tends to give all font options when given a column type that isn't recognized, but i did some trial and error to find out what actually matters in those columns and whittled it down. this could be wrong so i added todos for future reference. Depending if it is a meta column or an actual leaf column, different font menus will be shown.

also chron columns consist of multiple columns so i added functionality for that. 

also added `subTransect` onto `ColumnInfo` since it wasn't there before (bug)
<img width="742" alt="Screenshot 2024-04-13 at 5 50 22 PM" src="https://github.com/earthhistoryviz/tsconline/assets/89664317/17e73342-f93e-4b44-8311-282f93f4709a">
<img width="900" alt="Screenshot 2024-04-13 at 5 50 43 PM" src="https://github.com/earthhistoryviz/tsconline/assets/89664317/e7a3f2ec-9e7e-4241-a46f-6bf742068ba6">
<img width="322" alt="Screenshot 2024-04-13 at 5 51 07 PM" src="https://github.com/earthhistoryviz/tsconline/assets/89664317/dfe2c2c9-2861-4f4f-b8ca-2b6889173e56">
