### PR TITLE
 font inheritance, enable title, more error checking, column types, lone columns

### DIFF
--- a/app/src/SettingsTabs/ColumnMenu.css
+++ b/app/src/SettingsTabs/ColumnMenu.css
@@ -22,3 +22,10 @@
   align-items: center;
   justify-content: center;
 }
+
+.ShowTitlesContainer {
+  display: flex;
+  flex-direction: column;
+  margin-top: 10px;
+  margin-left: 10px;
+}

--- a/app/src/SettingsTabs/ColumnMenu.tsx
+++ b/app/src/SettingsTabs/ColumnMenu.tsx
@@ -7,7 +7,6 @@ import "./ColumnMenu.css";
 import { FontMenu } from "./FontMenu";
 import { ColumnInfo } from "@tsconline/shared";
 import { TSCCheckbox } from "../components";
-import { CheckBox } from "@mui/icons-material";
 
 const EditNameField = observer(() => {
   const { state, actions } = useContext(context);
@@ -94,23 +93,23 @@ export const ColumnMenu = observer(() => {
   );
 });
 
-const ShowTitles = observer(({ column }: { column: ColumnInfo}) => {
+const ShowTitles = observer(({ column }: { column: ColumnInfo }) => {
   const { actions } = useContext(context);
   return (
     <div className="ShowTitlesContainer">
-    <FormControlLabel
-    name="enableTitle"
-    label="Enable Title"
-    control={
-      <TSCCheckbox
-        outlineColor="gray"
-        checked={column.enableTitle}
-        onChange={() => {
-          actions.setEnableTitle(!column.enableTitle, column);
-        }}
+      <FormControlLabel
+        name="enableTitle"
+        label="Enable Title"
+        control={
+          <TSCCheckbox
+            outlineColor="gray"
+            checked={column.enableTitle}
+            onChange={() => {
+              actions.setEnableTitle(!column.enableTitle, column);
+            }}
+          />
+        }
       />
-    }
-    />
     </div>
   );
 });

--- a/app/src/SettingsTabs/ColumnMenu.tsx
+++ b/app/src/SettingsTabs/ColumnMenu.tsx
@@ -1,10 +1,13 @@
 import { observer } from "mobx-react-lite";
 import { useContext, useRef, useState } from "react";
 import { context } from "../state";
-import { Button, TextField, ToggleButton, Typography } from "@mui/material";
+import { Button, FormControlLabel, TextField, ToggleButton, Typography } from "@mui/material";
 import SettingsSharpIcon from "@mui/icons-material/SettingsSharp";
 import "./ColumnMenu.css";
 import { FontMenu } from "./FontMenu";
+import { ColumnInfo } from "@tsconline/shared";
+import { TSCCheckbox } from "../components";
+import { CheckBox } from "@mui/icons-material";
 
 const EditNameField = observer(() => {
   const { state, actions } = useContext(context);
@@ -85,7 +88,29 @@ export const ColumnMenu = observer(() => {
       <div id="ColumnMenuContent" className="column-menu-content">
         {column && <EditNameField />}
         {column && <FontMenu column={column} />}
+        {column && <ShowTitles column={column} />}
       </div>
+    </div>
+  );
+});
+
+const ShowTitles = observer(({ column }: { column: ColumnInfo}) => {
+  const { actions } = useContext(context);
+  return (
+    <div className="ShowTitlesContainer">
+    <FormControlLabel
+    name="enableTitle"
+    label="Enable Title"
+    control={
+      <TSCCheckbox
+        outlineColor="gray"
+        checked={column.enableTitle}
+        onChange={() => {
+          actions.setEnableTitle(!column.enableTitle, column);
+        }}
+      />
+    }
+    />
     </div>
   );
 });

--- a/app/src/SettingsTabs/FontMenu.tsx
+++ b/app/src/SettingsTabs/FontMenu.tsx
@@ -9,6 +9,7 @@ import {
   FormControlLabel,
   Grid,
   TextField,
+  TextFieldProps,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
@@ -21,11 +22,19 @@ import FormControl from "@mui/material/FormControl";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import FormatBoldIcon from "@mui/icons-material/FormatBold";
 import FormatItalicIcon from "@mui/icons-material/FormatItalic";
-import { MuiColorInput } from "mui-color-input";
+import { MuiColorInput, MuiColorInputColors } from "mui-color-input";
 import CloseIcon from "@mui/icons-material/Close";
 import "./FontMenu.css";
 import { ColumnInfo, ValidFontOptions } from "@tsconline/shared";
-
+import { NumericFormat } from "react-number-format";
+const FontSizeTextField = (({...props} : TextFieldProps) => (
+  <TextField
+    {...props}
+    className="FontSizeContainer"
+    label="Size"
+    variant="outlined"
+    />
+))
 const FontMenuRow: React.FC<{
   target: ValidFontOptions;
   column: ColumnInfo;
@@ -33,23 +42,18 @@ const FontMenuRow: React.FC<{
   const { actions } = useContext(context);
   const fontOpts = column.fontsInfo[target];
   const [font, setFont] = useState("Arial");
-  const [formats, setFormats] = useState([""]);
   const handleFontChange = (event: SelectChangeEvent) => {
     if (!/^(Arial|Courier|Verdana)$/.test(event.target.value)) return;
-    actions.setFontFace(target, event.target.value as "Arial" | "Courier" | "Verdana");
+    actions.setFontFace(target, event.target.value as "Arial" | "Courier" | "Verdana", column);
     setFont(event.target.value as string);
   };
   const handleFormat = (_event: React.MouseEvent<HTMLElement>, newFormats: string[]) => {
-    setFormats(newFormats);
-    if (newFormats.includes("bold")) actions.setBold(target, true);
-    else actions.setBold(target, false);
-
-    if (newFormats.includes("italic")) actions.setItalic(target, true);
-    else actions.setItalic(target, false);
+    actions.setBold(target, newFormats.includes("bold"), column);
+    actions.setItalic(target, newFormats.includes("italic"), column);
   };
 
-  const handleColor = (newColor: React.SetStateAction<string>) => {
-    actions.setColor(target, newColor);
+  const handleColor = (newColor: string) => {
+    actions.setColor(target, newColor, column);
   };
 
   return (
@@ -94,18 +98,19 @@ const FontMenuRow: React.FC<{
             <MenuItem value={"Verdana"}>Verdana</MenuItem>
           </Select>
         </FormControl>
-        <TextField
-          className="FontSizeContainer"
-          label="Size"
-          variant="outlined"
-          value={fontOpts.size}
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-            actions.setFontSize(target, Number(event.target.value));
-          }}
-          disabled={!fontOpts.on}
+        <NumericFormat
+        customInput={FontSizeTextField}
+        value={fontOpts.size}
+        onValueChange={(values) => {
+          if (!values.floatValue) {
+            return;
+          }
+          actions.setFontSize(target, values.floatValue, column);
+        }}
+        disabled={!fontOpts.on}
         />
         <ToggleButtonGroup
-          value={formats}
+          value={[fontOpts.bold ? "bold" : "", fontOpts.italic ? "italic" : ""]}
           onChange={handleFormat}
           aria-label="text formatting"
           sx={{ marginRight: "10px" }}

--- a/app/src/SettingsTabs/FontMenu.tsx
+++ b/app/src/SettingsTabs/FontMenu.tsx
@@ -22,19 +22,14 @@ import FormControl from "@mui/material/FormControl";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import FormatBoldIcon from "@mui/icons-material/FormatBold";
 import FormatItalicIcon from "@mui/icons-material/FormatItalic";
-import { MuiColorInput, MuiColorInputColors } from "mui-color-input";
+import { MuiColorInput } from "mui-color-input";
 import CloseIcon from "@mui/icons-material/Close";
 import "./FontMenu.css";
 import { ColumnInfo, ValidFontOptions } from "@tsconline/shared";
 import { NumericFormat } from "react-number-format";
-const FontSizeTextField = (({...props} : TextFieldProps) => (
-  <TextField
-    {...props}
-    className="FontSizeContainer"
-    label="Size"
-    variant="outlined"
-    />
-))
+const FontSizeTextField = ({ ...props }: TextFieldProps) => (
+  <TextField {...props} className="FontSizeContainer" label="Size" variant="outlined" />
+);
 const FontMenuRow: React.FC<{
   target: ValidFontOptions;
   column: ColumnInfo;
@@ -99,15 +94,15 @@ const FontMenuRow: React.FC<{
           </Select>
         </FormControl>
         <NumericFormat
-        customInput={FontSizeTextField}
-        value={fontOpts.size}
-        onValueChange={(values) => {
-          if (!values.floatValue) {
-            return;
-          }
-          actions.setFontSize(target, values.floatValue, column);
-        }}
-        disabled={!fontOpts.on}
+          customInput={FontSizeTextField}
+          value={fontOpts.size}
+          onValueChange={(values) => {
+            if (!values.floatValue) {
+              return;
+            }
+            actions.setFontSize(target, values.floatValue, column);
+          }}
+          disabled={!fontOpts.on}
         />
         <ToggleButtonGroup
           value={[fontOpts.bold ? "bold" : "", fontOpts.italic ? "italic" : ""]}

--- a/app/src/SettingsTabs/MapButtons.tsx
+++ b/app/src/SettingsTabs/MapButtons.tsx
@@ -1,6 +1,15 @@
 import { Button, IconButton, Theme, Tooltip, TooltipProps, styled, useTheme } from "@mui/material";
 import { FaciesOptions } from "../types";
-import { Bounds, ColumnInfo, InfoPoints, MapPoints, Transects, assertSubFaciesInfo, isRectBounds, isSubFaciesInfo, isSubFaciesInfoArray, isVertBounds } from "@tsconline/shared";
+import {
+  Bounds,
+  ColumnInfo,
+  InfoPoints,
+  MapPoints,
+  Transects,
+  isRectBounds,
+  isSubFaciesInfoArray,
+  isVertBounds
+} from "@tsconline/shared";
 import { useContext, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { actions, context } from "../state";

--- a/app/src/SettingsTabs/MapButtons.tsx
+++ b/app/src/SettingsTabs/MapButtons.tsx
@@ -1,6 +1,6 @@
 import { Button, IconButton, Theme, Tooltip, TooltipProps, styled, useTheme } from "@mui/material";
 import { FaciesOptions } from "../types";
-import { Bounds, ColumnInfo, InfoPoints, MapPoints, Transects, isRectBounds, isVertBounds } from "@tsconline/shared";
+import { Bounds, ColumnInfo, InfoPoints, MapPoints, Transects, assertSubFaciesInfo, isRectBounds, isSubFaciesInfo, isSubFaciesInfoArray, isVertBounds } from "@tsconline/shared";
 import { useContext, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { actions, context } from "../state";
@@ -476,13 +476,12 @@ function getRockTypeForAge(
   setSelectedMapAgeRange: (min: number, max: number) => void,
   pushPresentRockType: (rockType: string) => void
 ) {
-  if (!column.subFaciesInfo || column.subFaciesInfo.length === 0) {
+  if (!isSubFaciesInfoArray(column.subInfo) || column.subInfo.length === 0) {
     return "TOP"; // Return "TOP" if there's no subFaciesInfo or it's empty
   }
   setSelectedMapAgeRange(column.minAge, column.maxAge);
-
   // Find the nearest time block that does not exceed the current age
-  const suitableBlock = column.subFaciesInfo.find((timeBlock) => timeBlock.age >= currentAge);
+  const suitableBlock = column.subInfo.find((timeBlock) => timeBlock.age >= currentAge);
 
   if (!suitableBlock) {
     return "TOP";

--- a/app/src/components/TSCCheckbox.tsx
+++ b/app/src/components/TSCCheckbox.tsx
@@ -8,7 +8,13 @@ interface TSCCheckboxProps extends CheckboxProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const TSCCheckbox: React.FC<TSCCheckboxProps> = ({ outlineColor, checkedColor, checked, onChange, ...props}) => {
+export const TSCCheckbox: React.FC<TSCCheckboxProps> = ({
+  outlineColor,
+  checkedColor,
+  checked,
+  onChange,
+  ...props
+}) => {
   const theme = useTheme();
   outlineColor = outlineColor || theme.palette.primary.main;
   checkedColor = checkedColor || theme.palette.selection.main;

--- a/app/src/components/TSCCheckbox.tsx
+++ b/app/src/components/TSCCheckbox.tsx
@@ -8,15 +8,15 @@ interface TSCCheckboxProps extends CheckboxProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const TSCCheckbox: React.FC<TSCCheckboxProps> = (props: TSCCheckboxProps) => {
+export const TSCCheckbox: React.FC<TSCCheckboxProps> = ({ outlineColor, checkedColor, checked, onChange, ...props}) => {
   const theme = useTheme();
-  const outlineColor = props.outlineColor || theme.palette.primary.main;
-  const checkedColor = props.checkedColor || theme.palette.selection.main;
+  outlineColor = outlineColor || theme.palette.primary.main;
+  checkedColor = checkedColor || theme.palette.selection.main;
   return (
     <Checkbox
       {...props}
-      checked={props.checked}
-      onChange={props.onChange}
+      checked={checked}
+      onChange={onChange}
       size="small"
       sx={{
         color: outlineColor,

--- a/app/src/components/TSCCheckbox.tsx
+++ b/app/src/components/TSCCheckbox.tsx
@@ -2,13 +2,16 @@ import { Checkbox, CheckboxProps } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 
 interface TSCCheckboxProps extends CheckboxProps {
+  outlineColor?: string;
+  checkedColor?: string;
   checked?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export const TSCCheckbox: React.FC<TSCCheckboxProps> = (props: TSCCheckboxProps) => {
   const theme = useTheme();
-
+  const outlineColor = props.outlineColor || theme.palette.primary.main;
+  const checkedColor = props.checkedColor || theme.palette.selection.main;
   return (
     <Checkbox
       {...props}
@@ -16,9 +19,9 @@ export const TSCCheckbox: React.FC<TSCCheckboxProps> = (props: TSCCheckboxProps)
       onChange={props.onChange}
       size="small"
       sx={{
-        color: theme.palette.primary.main,
+        color: outlineColor,
         "&.Mui-checked": {
-          color: theme.palette.selection.main
+          color: checkedColor
         }
       }}
     />

--- a/app/src/state/actions/column-actions.ts
+++ b/app/src/state/actions/column-actions.ts
@@ -73,84 +73,22 @@ export const setFontOptionOn = action((target: ValidFontOptions, isOn: boolean, 
   column.fontsInfo[target].on = isOn;
 });
 
-export const setFontFace = action((target: ValidFontOptions, fontFace: "Arial" | "Courier" | "Verdana") => {
-  if (!state.settingsTabs.columnSelected) {
-    throw new Error("state.settingsTabs.columnSelected is null");
-  }
-
-  const columnHashMapEntry = state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected);
-
-  if (!columnHashMapEntry) {
-    throw new Error(`Entry for ${state.settingsTabs.columnSelected} not found in columnHashMap`);
-  }
-  assertFontsInfo(columnHashMapEntry.fontsInfo);
-
-  columnHashMapEntry.fontsInfo[target].fontFace = fontFace;
-  assertFontsInfo(columnHashMapEntry?.fontsInfo);
+export const setFontFace = action((target: ValidFontOptions, face: "Arial" | "Courier" | "Verdana", column: ColumnInfo) => {
+  column.fontsInfo[target].fontFace = face;
 });
 
-export const setFontSize = action((target: ValidFontOptions, fontSize: number) => {
-  if (state.settingsTabs.columnSelected === null) {
-    throw new Error("state.settingsTabs.columnSelected is null");
-  }
-
-  const columnHashMapEntry = state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected);
-
-  if (!columnHashMapEntry) {
-    throw new Error(`Entry for ${state.settingsTabs.columnSelected} not found in columnHashMap`);
-  }
-  assertFontsInfo(columnHashMapEntry.fontsInfo);
-
-  columnHashMapEntry.fontsInfo[target].size = fontSize;
-  assertFontsInfo(columnHashMapEntry?.fontsInfo);
+export const setFontSize = action((target: ValidFontOptions, fontSize: number, column: ColumnInfo) => {
+  column.fontsInfo[target].size = fontSize;
 });
 
-export const setBold = action((target: ValidFontOptions, isBold: boolean) => {
-  if (state.settingsTabs.columnSelected === null) {
-    throw new Error("state.settingsTabs.columnSelected is null");
-  }
-
-  const columnHashMapEntry = state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected);
-
-  if (!columnHashMapEntry) {
-    throw new Error(`Entry for ${state.settingsTabs.columnSelected} not found in columnHashMap`);
-  }
-  assertFontsInfo(columnHashMapEntry.fontsInfo);
-
-  columnHashMapEntry.fontsInfo[target].bold = isBold;
-  assertFontsInfo(columnHashMapEntry?.fontsInfo);
+export const setBold = action((target: ValidFontOptions, isBold: boolean, column: ColumnInfo) => {
+  column.fontsInfo[target].bold = isBold;
 });
 
-export const setItalic = action((target: ValidFontOptions, isItalic: boolean) => {
-  if (state.settingsTabs.columnSelected === null) {
-    throw new Error("state.settingsTabs.columnSelected is null");
-  }
-
-  const columnHashMapEntry = state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected);
-
-  if (!columnHashMapEntry) {
-    throw new Error(`Entry for ${state.settingsTabs.columnSelected} not found in columnHashMap`);
-  }
-  assertFontsInfo(columnHashMapEntry.fontsInfo);
-
-  columnHashMapEntry.fontsInfo[target].italic = isItalic;
-  assertFontsInfo(columnHashMapEntry?.fontsInfo);
+export const setItalic = action((target: ValidFontOptions, isItalic: boolean, column: ColumnInfo) => {
+  column.fontsInfo[target].italic = isItalic;
 });
 
-export const setColor = action((target: ValidFontOptions, color: React.SetStateAction<string>) => {
-  if (state.settingsTabs.columnSelected === null) {
-    throw new Error("state.settingsTabs.columnSelected is null");
-  }
-
-  const columnHashMapEntry = state.settingsTabs.columnHashMap.get(state.settingsTabs.columnSelected);
-
-  if (!columnHashMapEntry) {
-    throw new Error(`Entry for ${state.settingsTabs.columnSelected} not found in columnHashMap`);
-  }
-  assertFontsInfo(columnHashMapEntry.fontsInfo);
-
-  if (typeof color === "string") {
-    columnHashMapEntry.fontsInfo[target].color = color;
-  }
-  assertFontsInfo(columnHashMapEntry?.fontsInfo);
+export const setColor = action((target: ValidFontOptions, color: string, column: ColumnInfo) => {
+  column.fontsInfo[target].color = color;
 });

--- a/app/src/state/actions/column-actions.ts
+++ b/app/src/state/actions/column-actions.ts
@@ -1,7 +1,6 @@
 import { action } from "mobx";
 import { state } from "../state";
-import { assertFontsInfo, ColumnInfo, ValidFontOptions } from "@tsconline/shared";
-import React from "react";
+import { ColumnInfo, ValidFontOptions } from "@tsconline/shared";
 
 export const initializeColumnHashMap = action((columnInfo: ColumnInfo) => {
   state.settingsTabs.columnHashMap.set(columnInfo.name, columnInfo);
@@ -73,9 +72,11 @@ export const setFontOptionOn = action((target: ValidFontOptions, isOn: boolean, 
   column.fontsInfo[target].on = isOn;
 });
 
-export const setFontFace = action((target: ValidFontOptions, face: "Arial" | "Courier" | "Verdana", column: ColumnInfo) => {
-  column.fontsInfo[target].fontFace = face;
-});
+export const setFontFace = action(
+  (target: ValidFontOptions, face: "Arial" | "Courier" | "Verdana", column: ColumnInfo) => {
+    column.fontsInfo[target].fontFace = face;
+  }
+);
 
 export const setFontSize = action((target: ValidFontOptions, fontSize: number, column: ColumnInfo) => {
   column.fontsInfo[target].size = fontSize;
@@ -95,4 +96,4 @@ export const setColor = action((target: ValidFontOptions, color: string, column:
 
 export const setEnableTitle = action((isOn: boolean, column: ColumnInfo) => {
   column.enableTitle = isOn;
-})
+});

--- a/app/src/state/actions/column-actions.ts
+++ b/app/src/state/actions/column-actions.ts
@@ -92,3 +92,7 @@ export const setItalic = action((target: ValidFontOptions, isItalic: boolean, co
 export const setColor = action((target: ValidFontOptions, color: string, column: ColumnInfo) => {
   column.fontsInfo[target].color = color;
 });
+
+export const setEnableTitle = action((isOn: boolean, column: ColumnInfo) => {
+  column.enableTitle = isOn;
+})

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -272,7 +272,8 @@ export const setDatapackConfig = action(
         maxAge: Number.MIN_VALUE,
         children: [],
         parent: null,
-        units: ""
+        units: "",
+        columnDisplayType: "RootColumn"
       };
       // add everything together
       // uses preparsed data on server start and appends items together

--- a/app/src/state/actions/generate-chart-actions.ts
+++ b/app/src/state/actions/generate-chart-actions.ts
@@ -27,11 +27,23 @@ export const initiateChartGeneration = action("initiateChartGeneration", (naviga
 });
 
 export const fetchChartFromServer = action("fetchChartFromServer", async (navigate: NavigateFunction) => {
-  if (!state.config.datapacks || state.config.datapacks.length === 0) {
+  if (!state.config.datapacks || state.config.datapacks.length === 0 || !state.settingsTabs.columns) {
     generalActions.pushError(ErrorCodes.NO_DATAPACKS_SELECTED);
     return;
   }
   generalActions.removeError(ErrorCodes.NO_DATAPACKS_SELECTED);
+  let columnOn = false;
+  for (const column of state.settingsTabs.columns.children) {
+    if (column.on) {
+      columnOn = true;
+      break;
+    }
+  }
+  if (!columnOn) {
+    generalActions.pushError(ErrorCodes.NO_COLUMNS_SELECTED);
+    return;
+  }
+  generalActions.removeError(ErrorCodes.NO_COLUMNS_SELECTED);
   state.showSuggestedAgePopup = false;
   navigate("/chart");
   //set the loading screen and make sure the chart isn't up

--- a/app/src/state/actions/generate-chart-actions.ts
+++ b/app/src/state/actions/generate-chart-actions.ts
@@ -26,24 +26,31 @@ export const initiateChartGeneration = action("initiateChartGeneration", (naviga
   }
 });
 
-export const fetchChartFromServer = action("fetchChartFromServer", async (navigate: NavigateFunction) => {
+function areSettingsValidForGeneration() {
   if (!state.config.datapacks || state.config.datapacks.length === 0 || !state.settingsTabs.columns) {
     generalActions.pushError(ErrorCodes.NO_DATAPACKS_SELECTED);
-    return;
+    return false;
   }
   generalActions.removeError(ErrorCodes.NO_DATAPACKS_SELECTED);
-  let columnOn = false;
-  for (const column of state.settingsTabs.columns.children) {
-    if (column.on) {
-      columnOn = true;
-      break;
-    }
+  if (
+    Object.keys(state.settings.timeSettings).every(
+      (key) => state.settings.timeSettings[key].baseStageAge === state.settings.timeSettings[key].topStageAge
+    )
+  ) {
+    generalActions.pushError(ErrorCodes.UNIT_RANGE_EMPTY);
+    return false;
   }
-  if (!columnOn) {
+  generalActions.removeError(ErrorCodes.UNIT_RANGE_EMPTY);
+  if (!state.settingsTabs.columns.children.some((column) => column.on)) {
     generalActions.pushError(ErrorCodes.NO_COLUMNS_SELECTED);
-    return;
+    return false;
   }
   generalActions.removeError(ErrorCodes.NO_COLUMNS_SELECTED);
+  return true;
+}
+
+export const fetchChartFromServer = action("fetchChartFromServer", async (navigate: NavigateFunction) => {
+  if (!areSettingsValidForGeneration()) return;
   state.showSuggestedAgePopup = false;
   navigate("/chart");
   //set the loading screen and make sure the chart isn't up

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -314,54 +314,28 @@ function generateSettingsXml(stateSettings: ChartSettings, indent: string): stri
  * @param indent the amount of indent to place in the xml file
  * @returns xml string with fonts info
  */
-function generateFontsXml(fonts: any, colName: string, stateColumn: any, indent: string): string {
-  if (!stateColumn) {
+function generateFontsXml(indent: string, fontsInfo?: FontsInfo): string {
+  if (!fontsInfo) {
     return "";
   }
   let defInfo = JSON.parse(JSON.stringify(defaultFontsInfo));
-  if (
-    colName === "Chart Root" ||
-    colName === "Facies" ||
-    colName === "Members" ||
-    colName === "Facies Label" ||
-    colName === "Series Label"
-  ) {
-    let newStateColumn = {};
-    if (stateColumn) {
-      newStateColumn = JSON.parse(JSON.stringify(stateColumn));
-    }
-    return "";
-  }
-  let newStateColumn = JSON.parse(JSON.stringify(stateColumn));
   let xml = "";
-  for (const key in fonts) {
-    if (Object.prototype.hasOwnProperty.call(fonts, key)) {
-      const inheritable = fonts[key].inheritable;
-      if (JSON.stringify(newStateColumn[key]) === JSON.stringify(defInfo[key])) {
-        xml += `${indent}<font function="${key}" inheritable="${inheritable}"/>\n`;
+  for (const key in fontsInfo) {
+      const fontTarget = fontsInfo[key as keyof FontsInfo];
+      if (JSON.stringify(fontTarget) === JSON.stringify(defInfo[key])) {
+        xml += `${indent}<font function="${key}" inheritable="${fontTarget.inheritable}"/>\n`;
       } else {
-        xml += `${indent}<font function="${key}" inheritable="${inheritable}">`;
-        for (let fKey in newStateColumn[key]) {
-          if (JSON.stringify(newStateColumn[key][fKey]) !== JSON.stringify(defInfo[key][fKey])) {
-            if (fKey === "fontFace") {
-              xml += `font-family: ${newStateColumn[key][fKey]};`;
-            }
-            if (fKey === "size") {
-              xml += `font-size: ${newStateColumn[key][fKey]}px;`;
-            }
-            if (fKey === "italic") {
-              xml += `font-style: italic;`;
-            }
-            if (fKey === "bold") {
-              xml += `font-weight: bold;`;
-            }
-            if (fKey === "color") {
-              xml += `fill: ${newStateColumn[key][fKey]};`;
-            }
-          }
+        xml += `${indent}<font function="${key}" inheritable="${fontTarget.inheritable}">`;
+        xml += `font-family: ${fontTarget.fontFace};`;
+        xml += `font-size: ${fontTarget.size}px;`;
+        if (fontTarget.italic) {
+          xml += `font-style: italic;`;
         }
+        if (fontTarget.bold) {
+          xml += `font-weight: bold;`;
+        }
+        xml += `fill: ${fontTarget.color};`;
         xml += `</font>\n`;
-      }
     }
   }
   return xml;
@@ -437,7 +411,7 @@ function generateColumnXml(presetColumn: ColumnInfoTSC, stateColumn: ColumnInfo 
         xml += `${indent}<setting name="${xmlKey}" orientation="${presetColumn[key as keyof ColumnInfoTSC]}"/>\n`;
       } else if (key === "fonts") {
         xml += `${indent}<fonts>\n`;
-        xml += generateFontsXml(presetColumn[key], colName, stateColumn?.fontsInfo, `${indent}    `);
+        xml += generateFontsXml(`${indent}    `, stateColumn?.fontsInfo);
         xml += `${indent}</fonts>\n`;
       } else if (key === "children") {
         let currName = extractName(presetColumn._id);

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -349,7 +349,7 @@ function generateFontsXml(indent: string, fontsInfo?: FontsInfo): string {
  * @param indent the amount of indent to place in the xml file
  * @returns xml string with column info
  */
-function generateColumnXml(presetColumn: ColumnInfoTSC, stateColumn: ColumnInfo | undefined, indent: string): string {
+function generateColumnXml(presetColumn: ColumnInfoTSC, stateColumn: ColumnInfo, indent: string): string {
   let xml = "";
   for (let key in presetColumn) {
     if (Object.prototype.hasOwnProperty.call(presetColumn, key)) {
@@ -392,12 +392,6 @@ function generateColumnXml(presetColumn: ColumnInfoTSC, stateColumn: ColumnInfo 
         else if (stateColumn === undefined) {
           xml += `${indent}<setting name="${xmlKey}">${presetColumn["isSelected"]}</setting>\n`;
         }
-        //always display these things (the original tsc throws an error if not selected)
-        //(but online doesn't have option to deselect them)
-        else if (colName === "Chart Root" || colName === "Chart Title" || colName === "Ma") {
-          xml += `${indent}<setting name="${xmlKey}">true</setting>\n`;
-          continue;
-        }
         //check if column is checked or not, and change the isSelected field to true or false
         else if (stateColumn) {
           if (stateColumn.on) {
@@ -419,10 +413,12 @@ function generateColumnXml(presetColumn: ColumnInfoTSC, stateColumn: ColumnInfo 
         if (presetColumn.children) {
           for (let i = 0; i < presetColumn.children.length; i++) {
             xml += `${indent}<column id="${replaceSpecialChars(presetColumn.children[i]._id, 0)}">\n`;
-            xml += generateColumnXml(presetColumn.children[i], stateColumn?.children[i], `${indent}    `);
+            xml += generateColumnXml(presetColumn.children[i], stateColumn.children[i], `${indent}    `);
             xml += `${indent}</column>\n`;
           }
         }
+      } else if (key === "drawTitle"){
+        xml += `${indent}<setting name="${xmlKey}">${stateColumn.enableTitle}</setting>\n`;
       } else {
         xml += `${indent}<setting name="${xmlKey}">${presetColumn[key as keyof ColumnInfoTSC]}</setting>\n`;
       }
@@ -443,7 +439,7 @@ function generateColumnXml(presetColumn: ColumnInfoTSC, stateColumn: ColumnInfo 
  */
 export function jsonToXml(
   settingsTSC: ChartInfoTSC,
-  columnSettings: ColumnInfo | undefined,
+  columnSettings: ColumnInfo,
   chartSettings: ChartSettings,
   version: string = "PRO8.1"
 ): string {

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -322,7 +322,7 @@ function generateFontsXml(indent: string, fontsInfo?: FontsInfo): string {
   let xml = "";
   for (const key in fontsInfo) {
       const fontTarget = fontsInfo[key as keyof FontsInfo];
-      if (JSON.stringify(fontTarget) === JSON.stringify(defInfo[key])) {
+      if (!fontTarget.on || JSON.stringify(fontTarget) === JSON.stringify(defInfo[key])) {
         xml += `${indent}<font function="${key}" inheritable="${fontTarget.inheritable}"/>\n`;
       } else {
         xml += `${indent}<font function="${key}" inheritable="${fontTarget.inheritable}">`;

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -327,7 +327,8 @@ function generateFontsXml(indent: string, fontsInfo?: FontsInfo): string {
       } else {
         xml += `${indent}<font function="${key}" inheritable="${fontTarget.inheritable}">`;
         xml += `font-family: ${fontTarget.fontFace};`;
-        xml += `font-size: ${fontTarget.size}px;`;
+        // removed px from font size because jar uses parseDouble and doesn't parse px
+        xml += `font-size: ${fontTarget.size};`;
         if (fontTarget.italic) {
           xml += `font-style: italic;`;
         }

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -321,22 +321,22 @@ function generateFontsXml(indent: string, fontsInfo?: FontsInfo): string {
   let defInfo = JSON.parse(JSON.stringify(defaultFontsInfo));
   let xml = "";
   for (const key in fontsInfo) {
-      const fontTarget = fontsInfo[key as keyof FontsInfo];
-      if (!fontTarget.on || JSON.stringify(fontTarget) === JSON.stringify(defInfo[key])) {
-        xml += `${indent}<font function="${key}" inheritable="${fontTarget.inheritable}"/>\n`;
-      } else {
-        xml += `${indent}<font function="${key}" inheritable="${fontTarget.inheritable}">`;
-        xml += `font-family: ${fontTarget.fontFace};`;
-        // removed px from font size because jar uses parseDouble and doesn't parse px
-        xml += `font-size: ${fontTarget.size};`;
-        if (fontTarget.italic) {
-          xml += `font-style: italic;`;
-        }
-        if (fontTarget.bold) {
-          xml += `font-weight: bold;`;
-        }
-        xml += `fill: ${fontTarget.color};`;
-        xml += `</font>\n`;
+    const fontTarget = fontsInfo[key as keyof FontsInfo];
+    if (!fontTarget.on || JSON.stringify(fontTarget) === JSON.stringify(defInfo[key])) {
+      xml += `${indent}<font function="${key}" inheritable="${fontTarget.inheritable}"/>\n`;
+    } else {
+      xml += `${indent}<font function="${key}" inheritable="${fontTarget.inheritable}">`;
+      xml += `font-family: ${fontTarget.fontFace};`;
+      // removed px from font size because jar uses parseDouble and doesn't parse px
+      xml += `font-size: ${fontTarget.size};`;
+      if (fontTarget.italic) {
+        xml += `font-style: italic;`;
+      }
+      if (fontTarget.bold) {
+        xml += `font-weight: bold;`;
+      }
+      xml += `fill: ${fontTarget.color};`;
+      xml += `</font>\n`;
     }
   }
   return xml;
@@ -417,7 +417,7 @@ function generateColumnXml(presetColumn: ColumnInfoTSC, stateColumn: ColumnInfo,
             xml += `${indent}</column>\n`;
           }
         }
-      } else if (key === "drawTitle"){
+      } else if (key === "drawTitle") {
         xml += `${indent}<setting name="${xmlKey}">${stateColumn.enableTitle}</setting>\n`;
       } else {
         xml += `${indent}<setting name="${xmlKey}">${presetColumn[key as keyof ColumnInfoTSC]}</setting>\n`;

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -406,12 +406,19 @@ function generateColumnXml(presetColumn: ColumnInfoTSC, stateColumn: ColumnInfo,
         xml += `${indent}<setting name="${xmlKey}" orientation="${presetColumn[key as keyof ColumnInfoTSC]}"/>\n`;
       } else if (key === "fonts") {
         xml += `${indent}<fonts>\n`;
-        xml += generateFontsXml(`${indent}    `, stateColumn?.fontsInfo);
+        xml += generateFontsXml(`${indent}    `, stateColumn.fontsInfo);
         xml += `${indent}</fonts>\n`;
       } else if (key === "children") {
         let currName = extractName(presetColumn._id);
         if (presetColumn.children) {
           for (let i = 0; i < presetColumn.children.length; i++) {
+            // will need to remove this
+            if (!stateColumn.children[i]) {
+              console.error(
+                JSON.stringify(presetColumn.children[i]._id, null, 2) + "\n" + "doesn't exist in the state"
+              );
+              continue;
+            }
             xml += `${indent}<column id="${replaceSpecialChars(presetColumn.children[i]._id, 0)}">\n`;
             xml += generateColumnXml(presetColumn.children[i], stateColumn.children[i], `${indent}    `);
             xml += `${indent}</column>\n`;

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -22,7 +22,8 @@ export enum ErrorCodes {
   NO_DATAPACKS_SELECTED = "NO_DATAPACKS_SELECTED",
   UNABLE_TO_LOGIN = "UNABLE_TO_LOGIN",
   UNABLE_TO_LOGOUT = "UNABLE_TO_LOGOUT",
-  NO_COLUMNS_SELECTED = "NO_COLUMNS_SELECTED"
+  NO_COLUMNS_SELECTED = "NO_COLUMNS_SELECTED",
+  UNIT_RANGE_EMPTY = "UNIT_RANGE_EMPTY"
 }
 
 export const ErrorMessages = {
@@ -51,5 +52,6 @@ export const ErrorMessages = {
   [ErrorCodes.NO_DATAPACKS_SELECTED]: "No datapacks selected. Please select at least one datapack to generate.",
   [ErrorCodes.UNABLE_TO_LOGIN]: "Unable to login. Please try again later.",
   [ErrorCodes.UNABLE_TO_LOGOUT]: "Unable to logout. Please try again later.",
-  [ErrorCodes.NO_COLUMNS_SELECTED]: "No columns selected. Please select at least one column to generate."
+  [ErrorCodes.NO_COLUMNS_SELECTED]: "No columns selected. Please select at least one column to generate.",
+  [ErrorCodes.UNIT_RANGE_EMPTY]: "Unit range is empty. Please enter a valid unit range."
 };

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -21,7 +21,8 @@ export enum ErrorCodes {
   DATAPACK_ALREADY_EXISTS = "DATAPACK_ALREADY_EXISTS",
   NO_DATAPACKS_SELECTED = "NO_DATAPACKS_SELECTED",
   UNABLE_TO_LOGIN = "UNABLE_TO_LOGIN",
-  UNABLE_TO_LOGOUT = "UNABLE_TO_LOGOUT"
+  UNABLE_TO_LOGOUT = "UNABLE_TO_LOGOUT",
+  NO_COLUMNS_SELECTED = "NO_COLUMNS_SELECTED"
 }
 
 export const ErrorMessages = {
@@ -49,5 +50,6 @@ export const ErrorMessages = {
   [ErrorCodes.DATAPACK_ALREADY_EXISTS]: "Datapack already exists. Please upload a new datapack file.",
   [ErrorCodes.NO_DATAPACKS_SELECTED]: "No datapacks selected. Please select at least one datapack to generate.",
   [ErrorCodes.UNABLE_TO_LOGIN]: "Unable to login. Please try again later.",
-  [ErrorCodes.UNABLE_TO_LOGOUT]: "Unable to logout. Please try again later."
+  [ErrorCodes.UNABLE_TO_LOGOUT]: "Unable to logout. Please try again later.",
+  [ErrorCodes.NO_COLUMNS_SELECTED]: "No columns selected. Please select at least one column to generate."
 };

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -1247,7 +1247,7 @@
         }
     },
     "column-types-all-column-types-key": {
-        "Facies 1": {
+        "Facies": {
             "name": "Facies",
             "subFaciesInfo": [
                 {
@@ -1280,7 +1280,7 @@
             "popup": "Facies Popup",
             "on": false
         },
-        "Block 1": {
+        "Block": {
             "name": "Block",
             "subBlockInfo": [
                 {
@@ -1318,7 +1318,7 @@
             "minAge": 419.2,
             "maxAge": 433.35
         },
-        "Event 1": {
+        "Event": {
             "name": "Event",
             "on": true,
             "subEventInfo": [
@@ -1346,7 +1346,7 @@
             "maxAge": 0.4,
             "popup": "Event Popup"
         },
-        "Range 1": {
+        "Range": {
             "name": "Range",
             "subRangeInfo": [
               {
@@ -1374,7 +1374,7 @@
             "popup": "Range Popup",
             "on": true 
         }, 
-        "Chron 1": {
+        "Chron": {
             "name": "Chron",
             "subChronInfo": [
                 {
@@ -1407,7 +1407,7 @@
             },
             "popup": "Chron Popup"
         },
-        "Point 1": {
+        "Point": {
             "name": "Point",
             "minAge": 4,
             "maxAge": 5,
@@ -1433,7 +1433,7 @@
               }
             ]
         },
-        "Sequence 1": {
+        "Sequence": {
             "name": "Sequence",
             "minAge": 0,
             "maxAge": 2,
@@ -1462,7 +1462,7 @@
                 }
             ]
         },
-        "Transect 1": {
+        "Transect": {
             "name": "Transect",
             "minAge": 0,
             "maxAge": 9.22,
@@ -1487,7 +1487,7 @@
               }
             ]
         },
-        "Freehand 1": {
+        "Freehand": {
             "name": "Freehand",
             "minAge": 0,
             "maxAge": 1.3,
@@ -1510,7 +1510,8 @@
                 "baseAge": 1.3
                 }
             ]
-        }, "Blank 1": {
+        },
+        "Blank": {
             "name": "Blank",
             "minAge": 1.7976931348623157e+308,
             "maxAge": 5e-324,

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -45,7 +45,8 @@
             "parent": "Chart Title",
             "minAge": 5e-324,
             "maxAge": 1.7976931348623157e+308,
-            "units": "Ma"
+            "units": "Ma",
+            "columnDisplayType": "Ruler"
           },
           {
             "name": "Central Africa Cenozoic",
@@ -91,7 +92,8 @@
                       "g": 255,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Facies"
                   },
                   {
                     "name": "Nigeria Coast Members",
@@ -117,7 +119,8 @@
                       "g": 255,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   },
                   {
                     "name": "Nigeria Coast Facies Label",
@@ -143,7 +146,8 @@
                       "g": 255,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   },
                   {
                     "name": "Nigeria Coast Series Label",
@@ -169,10 +173,12 @@
                       "b": 255
                     },
                     "width": 42,
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   }
                 ],
                 "parent": "Central Africa Cenozoic",
+                "columnDisplayType": "BlockSeriesMetaColumn",
                 "minAge": 0,
                 "maxAge": 10,
                 "width": 210,
@@ -188,7 +194,7 @@
                   "Zone Column Label"
                 ],
                 "units": "Ma",
-                "subFaciesInfo": [
+                "subInfo": [
                   {
                     "rockType": "TOP",
                     "age": 0,
@@ -242,7 +248,8 @@
                       "g": 255,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Facies"
                   },
                   {
                     "name": "South Atlantic Members",
@@ -268,7 +275,8 @@
                       "g": 255,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   },
                   {
                     "name": "South Atlantic Facies Label",
@@ -294,7 +302,8 @@
                       "g": 255,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   },
                   {
                     "name": "South Atlantic Series Label",
@@ -320,10 +329,12 @@
                       "b": 255
                     },
                     "width": 42,
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   }
                 ],
                 "parent": "Central Africa Cenozoic",
+                "columnDisplayType": "BlockSeriesMetaColumn",
                 "minAge": 0,
                 "maxAge": 10,
                 "width": 210,
@@ -339,7 +350,7 @@
                   "Zone Column Label"
                 ],
                 "units": "Ma",
-                "subFaciesInfo": [
+                "subInfo": [
                   {
                     "rockType": "TOP",
                     "age": 0,
@@ -361,6 +372,7 @@
               }
             ],
             "parent": "Chart Title",
+            "columnDisplayType": "MetaColumn",
             "minAge": 0,
             "maxAge": 10,
             "width": 100,
@@ -376,7 +388,7 @@
               "Zone Column Label"
             ],
             "units": "Ma",
-            "subFaciesInfo": [
+            "subInfo": [
               {
                 "rockType": "TOP",
                 "age": 0,
@@ -400,7 +412,8 @@
         "parent": "Chart Root",
         "minAge": 0,
         "maxAge": 10,
-        "units": "Ma"
+        "units": "Ma",
+        "columnDisplayType": "RootColumn"
       },
       "datapackAgeInfo": {
         "datapackContainsSuggAge": false
@@ -458,7 +471,8 @@
             "parent": "Chart Title",
             "minAge": 5e-324,
             "maxAge": 1.7976931348623157e+308,
-            "units": "Ma"
+            "units": "Ma",
+            "columnDisplayType": "Ruler"
           },
           {
             "name": "Parent 1",
@@ -495,7 +509,8 @@
                   "Zone Column Label"
                 ],
                 "units": "Ma",
-                "subBlockInfo": [
+                "columnDisplayType": "Zone",
+                "subInfo": [
                   {
                     "label": "TOP",
                     "age": 419.2,
@@ -554,7 +569,8 @@
                       "g": 200,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Facies"
                   },
                   {
                     "name": "Facies Members",
@@ -580,7 +596,8 @@
                       "g": 200,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   },
                   {
                     "name": "Facies Facies Label",
@@ -606,7 +623,8 @@
                       "g": 200,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   },
                   {
                     "name": "Facies Series Label",
@@ -632,7 +650,8 @@
                       "b": 255
                     },
                     "width": 42,
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   }
                 ],
                 "parent": "Parent 1",
@@ -651,7 +670,8 @@
                   "Zone Column Label"
                 ],
                 "units": "Ma",
-                "subFaciesInfo": [
+                "columnDisplayType": "BlockSeriesMetaColumn",
+                "subInfo": [
                   {
                     "rockType": "TOP",
                     "age": 0,
@@ -698,7 +718,8 @@
                   "Range Label"
                 ],
                 "units": "Ma",
-                "subEventInfo": [
+                "columnDisplayType": "MetaColumn",
+                "subInfo": [
                   {
                     "label": "SubEventInfo 1",
                     "age": 0.02,
@@ -737,7 +758,8 @@
                   "Popup Body"
                 ],
                 "units": "Ma",
-                "subRangeInfo": [
+                "columnDisplayType": "Range",
+                "subInfo": [
                   {
                     "label": "SubRangeInfo 1",
                     "age": 10,
@@ -785,7 +807,8 @@
                       "g": 255,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Chron"
                   },
                   {
                     "name": "Chron Chron Label",
@@ -811,7 +834,8 @@
                       "g": 255,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   },
                   {
                     "name": "Chron Series Label",
@@ -837,7 +861,8 @@
                       "g": 255,
                       "b": 255
                     },
-                    "units": "Ma"
+                    "units": "Ma",
+                    "columnDisplayType": "Zone"
                   }
                 ],
                 "parent": "Parent 1",
@@ -855,7 +880,8 @@
                   "Zone Column Label"
                 ],
                 "units": "Ma",
-                "subChronInfo": [
+                "columnDisplayType": "MetaColumn",
+                "subInfo": [
                   {
                     "polarity": "TOP",
                     "age": 0,
@@ -899,7 +925,8 @@
                   "Point Column Scale Label"
                 ],
                 "units": "Ma",
-                "subPointInfo": [
+                "columnDisplayType": "MetaColumn",
+                "subInfo": [
                   {
                     "age": 4,
                     "xVal": 0,
@@ -937,7 +964,8 @@
                   "Sequence Column Label"
                 ],
                 "units": "Ma",
-                "subSequenceInfo": [
+                "columnDisplayType": "Sequence",
+                "subInfo": [
                   {
                     "direction": "MFS",
                     "age": 0,
@@ -976,7 +1004,8 @@
                   "Column Header"
                 ],
                 "units": "Ma",
-                "subFreehandInfo": [
+                "columnDisplayType": "MetaColumn",
+                "subInfo": [
                   {
                     "topAge": 0,
                     "baseAge": 1
@@ -1009,7 +1038,8 @@
                 "fontOptions": [
                   "Column Header"
                 ],
-                "units": "Ma"
+                "units": "Ma",
+                "columnDisplayType": "MetaColumn"
               },
               {
                 "name": "Transect",
@@ -1034,7 +1064,8 @@
                   "Column Header"
                 ],
                 "units": "Ma",
-                "subTransectInfo": [
+                "columnDisplayType": "Transect",
+                "subInfo": [
                   {
                     "age": 0
                   },
@@ -1068,7 +1099,8 @@
               "Sequence Column Label"
             ],
             "units": "Ma",
-            "subFaciesInfo": [
+            "columnDisplayType": "MetaColumn",
+            "subInfo": [
               {
                 "rockType": "TOP",
                 "age": 0,
@@ -1092,7 +1124,8 @@
         "parent": "Chart Root",
         "minAge": 0,
         "maxAge": 433.35,
-        "units": "Ma"
+        "units": "Ma",
+        "columnDisplayType": "RootColumn"
       },
       "datapackAgeInfo": {
         "datapackContainsSuggAge": true,
@@ -1964,13 +1997,15 @@
                   "parent": "Chart Title",
                   "minAge": 5e-324,
                   "maxAge": 1.7976931348623157e+308,
-                  "units": "Ma"
+                  "units": "Ma",
+                  "columnDisplayType": "Ruler"
                 }
               ],
               "parent": "Chart Root",
               "minAge": 99999,
               "maxAge": -99999,
-              "units": "Ma"
+              "units": "Ma",
+              "columnDisplayType": "RootColumn"
             },
             "datapackAgeInfo": {
               "datapackContainsSuggAge": false

--- a/server/__tests__/parse-datapacks.test.ts
+++ b/server/__tests__/parse-datapacks.test.ts
@@ -6,6 +6,7 @@ jest.mock("./util.js", () => ({
   })
 }));
 jest.mock("@tsconline/shared", () => ({
+  assertSubInfo: jest.fn().mockImplementation(() => true),
   assertSubEventInfo: jest.fn().mockImplementation(() => true),
   assertSubTransectInfo: jest.fn().mockImplementation(() => true),
   assertSubFreehandInfo: jest.fn().mockImplementation(() => true),
@@ -344,47 +345,50 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-all-column-types-key"]),
+      [],
+      "Ma"
     );
     expectedFaciesMap.set(
-      key["column-types-all-column-types-key"]["Facies 1"].name,
-      key["column-types-all-column-types-key"]["Facies 1"]
+      key["column-types-all-column-types-key"]["Facies"].name,
+      key["column-types-all-column-types-key"]["Facies"]
     );
     expectedBlockMap.set(
-      key["column-types-all-column-types-key"]["Block 1"].name,
-      key["column-types-all-column-types-key"]["Block 1"]
+      key["column-types-all-column-types-key"]["Block"].name,
+      key["column-types-all-column-types-key"]["Block"]
     );
     expectedEventMap.set(
-      key["column-types-all-column-types-key"]["Event 1"].name,
-      key["column-types-all-column-types-key"]["Event 1"]
+      key["column-types-all-column-types-key"]["Event"].name,
+      key["column-types-all-column-types-key"]["Event"]
     );
     expectedRangeMap.set(
-      key["column-types-all-column-types-key"]["Range 1"].name,
-      key["column-types-all-column-types-key"]["Range 1"]
+      key["column-types-all-column-types-key"]["Range"].name,
+      key["column-types-all-column-types-key"]["Range"]
     );
     expectedChronMap.set(
-      key["column-types-all-column-types-key"]["Chron 1"].name,
-      key["column-types-all-column-types-key"]["Chron 1"]
+      key["column-types-all-column-types-key"]["Chron"].name,
+      key["column-types-all-column-types-key"]["Chron"]
     );
     expectedPointMap.set(
-      key["column-types-all-column-types-key"]["Point 1"].name,
-      key["column-types-all-column-types-key"]["Point 1"]
+      key["column-types-all-column-types-key"]["Point"].name,
+      key["column-types-all-column-types-key"]["Point"]
     );
     expectedSequenceMap.set(
-      key["column-types-all-column-types-key"]["Sequence 1"].name,
-      key["column-types-all-column-types-key"]["Sequence 1"]
+      key["column-types-all-column-types-key"]["Sequence"].name,
+      key["column-types-all-column-types-key"]["Sequence"]
     );
     expectedTransectMap.set(
-      key["column-types-all-column-types-key"]["Transect 1"].name,
-      key["column-types-all-column-types-key"]["Transect 1"]
+      key["column-types-all-column-types-key"]["Transect"].name,
+      key["column-types-all-column-types-key"]["Transect"]
     );
     expectedFreehandMap.set(
-      key["column-types-all-column-types-key"]["Freehand 1"].name,
-      key["column-types-all-column-types-key"]["Freehand 1"]
+      key["column-types-all-column-types-key"]["Freehand"].name,
+      key["column-types-all-column-types-key"]["Freehand"]
     );
     expectedBlankMap.set(
-      key["column-types-all-column-types-key"]["Blank 1"].name,
-      key["column-types-all-column-types-key"]["Blank 1"]
+      key["column-types-all-column-types-key"]["Blank"].name,
+      key["column-types-all-column-types-key"]["Blank"]
     );
     expectMapsToBeEqual();
   });
@@ -405,7 +409,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-facies-key"]),
+      [],
+      "Ma"
     );
     for (const val in key["column-types-facies-key"]) {
       expectedFaciesMap.set(val, key["column-types-facies-key"][val]);
@@ -429,7 +436,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-block-key"]),
+      [],
+      "Ma"
     );
     for (const val in key["column-types-block-key"]) {
       expectedBlockMap.set(val, key["column-types-block-key"][val]);
@@ -453,7 +463,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-event-key"]),
+      [],
+      "Ma"
     );
     for (const val in key["column-types-event-key"]) {
       expectedEventMap.set(val, key["column-types-event-key"][val]);
@@ -474,7 +487,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-range-key"]),
+      [],
+      "Ma"
     );
     for (const val in key["column-types-range-key"]) {
       expectedRangeMap.set(val, key["column-types-range-key"][val]);
@@ -495,7 +511,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-chron-key"]),
+      [],
+      "Ma"
     );
     for (const val in key["column-types-chron-key"]) {
       expectedChronMap.set(val, key["column-types-chron-key"][val]);
@@ -516,7 +535,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-point-key"]),
+      [],
+      "Ma"
     );
     for (const val in key["column-types-point-key"]) {
       expectedPointMap.set(val, key["column-types-point-key"][val]);
@@ -537,7 +559,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-sequence-key"]),
+      [],
+      "Ma"
     );
     for (const val in key["column-types-sequence-key"]) {
       expectedSequenceMap.set(val, key["column-types-sequence-key"][val]);
@@ -558,7 +583,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-transect-key"]),
+      [],
+      "Ma"
     );
     for (const val in key["column-types-transect-key"]) {
       expectedTransectMap.set(val, key["column-types-transect-key"][val]);
@@ -579,7 +607,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      Object.keys(key["column-types-freehand-key"]),
+      [],
+      "Ma"
     );
     for (const val in key["column-types-freehand-key"]) {
       expectedFreehandMap.set(val, key["column-types-freehand-key"][val]);
@@ -603,7 +634,10 @@ describe("getColumnTypes tests", () => {
       sequenceMap,
       transectMap,
       freehandMap,
-      blankMap
+      blankMap,
+      [],
+      [],
+      "Ma"
     );
     expectMapsToBeEqual();
   });

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -227,7 +227,8 @@ export async function parseDatapacks(file: string, decryptFilePath: string): Pro
     parent: chartTitle,
     minAge: Number.MIN_VALUE,
     maxAge: Number.MAX_VALUE,
-    units: ageUnits
+    units: ageUnits,
+    columnDisplayType: "Ruler"
   });
   const chartColumn: ColumnInfo = {
     name: chartTitle,
@@ -247,7 +248,8 @@ export async function parseDatapacks(file: string, decryptFilePath: string): Pro
     parent: "Chart Root",
     minAge: returnValue.minAge,
     maxAge: returnValue.maxAge,
-    units: ageUnits
+    units: ageUnits,
+    columnDisplayType: "RootColumn"
   };
   return { columnInfo: chartColumn, datapackAgeInfo, ageUnits };
 }
@@ -1252,7 +1254,8 @@ function recursive(
       b: 255
     },
     fontOptions: ["Column Header"],
-    units
+    units,
+    columnDisplayType: "MetaColumn"
   };
   const returnValue: FaciesFoundAndAgeRange = {
     faciesFound: false,
@@ -1271,6 +1274,7 @@ function recursive(
     // TODO NOTE FOR FUTURE: @Paolo - Java file appends all fonts to this, but from trial and error, only column header makes sense. If this case changes here we would change it
     Object.assign(currentColumnInfo, {
       ...currentTransect,
+      columnDisplayType: "Transect",
       subInfo: JSON.parse(JSON.stringify(currentTransect.subTransectInfo))
     });
     returnValue.minAge = currentColumnInfo.minAge;
@@ -1281,6 +1285,7 @@ function recursive(
     Object.assign(currentColumnInfo, {
       ...currentSequence,
       fontOptions: getValidFontOptions("Sequence"),
+      columnDisplayType: "Sequence",
       subInfo: JSON.parse(JSON.stringify(currentSequence.subSequenceInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1292,6 +1297,7 @@ function recursive(
     Object.assign(currentColumnInfo, {
       ...currentBlock,
       fontOptions: getValidFontOptions("Block"),
+      columnDisplayType: "Zone",
       subInfo: JSON.parse(JSON.stringify(currentBlock.subBlockInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1303,6 +1309,7 @@ function recursive(
     Object.assign(currentColumnInfo, {
       ...currentRange,
       fontOptions: getValidFontOptions("Range"),
+      columnDisplayType: "Range",
       subInfo: JSON.parse(JSON.stringify(currentRange.subRangeInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
@@ -1313,6 +1320,7 @@ function recursive(
     const currentFacies = faciesMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentFacies,
+      columnDisplayType: "BlockSeriesMetaColumn",
       subInfo: JSON.parse(JSON.stringify(currentFacies.subFaciesInfo))
     });
     addFaciesChildren(
@@ -1487,7 +1495,8 @@ function addFaciesChildren(
     maxAge,
     width: width * 0.4,
     rgb,
-    units
+    units,
+    columnDisplayType: "Facies"
   });
   children.push({
     name: `${name} Members`,
@@ -1503,7 +1512,8 @@ function addFaciesChildren(
     maxAge,
     width,
     rgb,
-    units
+    units,
+    columnDisplayType: "Zone"
   });
   children.push({
     name: `${name} Facies Label`,
@@ -1519,7 +1529,8 @@ function addFaciesChildren(
     maxAge,
     width: width * 0.4,
     rgb,
-    units
+    units,
+    columnDisplayType: "Zone"
   });
   children.push({
     name: `${name} Series Label`,
@@ -1535,7 +1546,8 @@ function addFaciesChildren(
     maxAge,
     rgb,
     width: width * 0.2,
-    units
+    units,
+    columnDisplayType: "Zone"
   });
   for (const child of children) {
     for (const fontOption of child.fontOptions) {
@@ -1582,7 +1594,8 @@ function addChronChildren(
     maxAge,
     width: 60,
     rgb,
-    units
+    units,
+    columnDisplayType: "Chron"
   });
   children.push({
     name: `${name} Chron Label`,
@@ -1598,7 +1611,8 @@ function addChronChildren(
     maxAge,
     width: 40,
     rgb,
-    units
+    units,
+    columnDisplayType: "Zone"
   });
   children.push({
     name: `${name} Series Label`,
@@ -1614,7 +1628,8 @@ function addChronChildren(
     maxAge,
     width: 40,
     rgb,
-    units
+    units,
+    columnDisplayType: "Zone"
   });
   for (const child of children) {
     for (const fontOption of child.fontOptions) {
@@ -1637,8 +1652,11 @@ function createLoneColumn(
   props: ColumnHeaderProps,
   fontOptions: ValidFontOptions[],
   units: string,
-  subInfo: SubInfo[]
+  subInfo: SubInfo[],
+  type: DisplayedColumnTypes
 ): ColumnInfo {
+  // block changes to zone for display
+  if (type === "Block") type = "Zone"
   return {
     ...props,
     editName: props.name,
@@ -1647,7 +1665,8 @@ function createLoneColumn(
     children: [],
     parent: "",
     units,
-    subInfo
+    subInfo,
+    columnDisplayType: type
   };
 }
 
@@ -1696,7 +1715,7 @@ function processColumn<T extends ColumnInfoType>(
     const { [subInfoKey]: subInfo, ...columnHeaderProps } = column;
     assertColumnHeaderProps(columnHeaderProps);
     assertSubInfo(subInfo);
-    loneColumns.push(createLoneColumn(columnHeaderProps, getValidFontOptions(type), units, subInfo));
+    loneColumns.push(createLoneColumn(columnHeaderProps, getValidFontOptions(type), units, subInfo, type));
   }
   return false;
 }

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -1270,7 +1270,7 @@ function recursive(
     currentColumnInfo.enableTitle = parsedColumnEntry.enableTitle;
   }
   if (transectMap.has(currentColumn)) {
-    const {subTransectInfo, ...currentTransect } = transectMap.get(currentColumn)!;
+    const { subTransectInfo, ...currentTransect } = transectMap.get(currentColumn)!;
     // TODO NOTE FOR FUTURE: @Paolo - Java file appends all fonts to this, but from trial and error, only column header makes sense. If this case changes here we would change it
     Object.assign(currentColumnInfo, {
       ...currentTransect,
@@ -1281,7 +1281,7 @@ function recursive(
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (sequenceMap.has(currentColumn)) {
-    const {subSequenceInfo, ...currentSequence} = sequenceMap.get(currentColumn)!;
+    const { subSequenceInfo, ...currentSequence } = sequenceMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentSequence,
       fontOptions: getValidFontOptions("Sequence"),
@@ -1293,7 +1293,7 @@ function recursive(
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (blocksMap.has(currentColumn)) {
-    const {subBlockInfo, ...currentBlock} = blocksMap.get(currentColumn)!;
+    const { subBlockInfo, ...currentBlock } = blocksMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentBlock,
       fontOptions: getValidFontOptions("Block"),
@@ -1305,7 +1305,7 @@ function recursive(
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (rangeMap.has(currentColumn)) {
-    const {subRangeInfo, ...currentRange} = rangeMap.get(currentColumn)!;
+    const { subRangeInfo, ...currentRange } = rangeMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentRange,
       fontOptions: getValidFontOptions("Range"),
@@ -1317,7 +1317,7 @@ function recursive(
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (faciesMap.has(currentColumn)) {
-    const {subFaciesInfo, ...currentFacies} = faciesMap.get(currentColumn)!;
+    const { subFaciesInfo, ...currentFacies } = faciesMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentFacies,
       columnDisplayType: "BlockSeriesMetaColumn",
@@ -1339,7 +1339,7 @@ function recursive(
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (eventMap.has(currentColumn)) {
-    const {subEventInfo, ...currentEvent} = eventMap.get(currentColumn)!;
+    const { subEventInfo, ...currentEvent } = eventMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentEvent,
       fontOptions: getValidFontOptions("Event"),
@@ -1370,7 +1370,7 @@ function recursive(
     returnValue.minAge = currentColumnInfo.minAge;
   }
   if (pointMap.has(currentColumn)) {
-    const {subPointInfo, ...currentPoint} = pointMap.get(currentColumn)!;
+    const { subPointInfo, ...currentPoint } = pointMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentPoint,
       fontOptions: getValidFontOptions("Point"),
@@ -1381,7 +1381,7 @@ function recursive(
     returnValue.minAge = currentColumnInfo.minAge;
   }
   if (freehandMap.has(currentColumn)) {
-    const {subFreehandInfo, ...currentFreehand} = freehandMap.get(currentColumn)!;
+    const { subFreehandInfo, ...currentFreehand } = freehandMap.get(currentColumn)!;
     // TODO NOTE FOR FUTURE: @Paolo - Java file appends all fonts to this, but from trial and error, only column header makes sense. If this case changes here we would change it
     Object.assign(currentColumnInfo, {
       ...currentFreehand,
@@ -1656,7 +1656,7 @@ function createLoneColumn(
   type: DisplayedColumnTypes
 ): ColumnInfo {
   // block changes to zone for display
-  if (type === "Block") type = "Zone"
+  if (type === "Block") type = "Zone";
   return {
     ...props,
     editName: props.name,

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -1270,58 +1270,58 @@ function recursive(
     currentColumnInfo.enableTitle = parsedColumnEntry.enableTitle;
   }
   if (transectMap.has(currentColumn)) {
-    const currentTransect = transectMap.get(currentColumn)!;
+    const {subTransectInfo, ...currentTransect } = transectMap.get(currentColumn)!;
     // TODO NOTE FOR FUTURE: @Paolo - Java file appends all fonts to this, but from trial and error, only column header makes sense. If this case changes here we would change it
     Object.assign(currentColumnInfo, {
       ...currentTransect,
       columnDisplayType: "Transect",
-      subInfo: JSON.parse(JSON.stringify(currentTransect.subTransectInfo))
+      subInfo: JSON.parse(JSON.stringify(subTransectInfo))
     });
     returnValue.minAge = currentColumnInfo.minAge;
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (sequenceMap.has(currentColumn)) {
-    const currentSequence = sequenceMap.get(currentColumn)!;
+    const {subSequenceInfo, ...currentSequence} = sequenceMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentSequence,
       fontOptions: getValidFontOptions("Sequence"),
       columnDisplayType: "Sequence",
-      subInfo: JSON.parse(JSON.stringify(currentSequence.subSequenceInfo))
+      subInfo: JSON.parse(JSON.stringify(subSequenceInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
     returnValue.minAge = currentColumnInfo.minAge;
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (blocksMap.has(currentColumn)) {
-    const currentBlock = blocksMap.get(currentColumn)!;
+    const {subBlockInfo, ...currentBlock} = blocksMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentBlock,
       fontOptions: getValidFontOptions("Block"),
       columnDisplayType: "Zone",
-      subInfo: JSON.parse(JSON.stringify(currentBlock.subBlockInfo))
+      subInfo: JSON.parse(JSON.stringify(subBlockInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
     returnValue.minAge = currentColumnInfo.minAge;
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (rangeMap.has(currentColumn)) {
-    const currentRange = rangeMap.get(currentColumn)!;
+    const {subRangeInfo, ...currentRange} = rangeMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentRange,
       fontOptions: getValidFontOptions("Range"),
       columnDisplayType: "Range",
-      subInfo: JSON.parse(JSON.stringify(currentRange.subRangeInfo))
+      subInfo: JSON.parse(JSON.stringify(subRangeInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
     returnValue.minAge = currentColumnInfo.minAge;
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (faciesMap.has(currentColumn)) {
-    const currentFacies = faciesMap.get(currentColumn)!;
+    const {subFaciesInfo, ...currentFacies} = faciesMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentFacies,
       columnDisplayType: "BlockSeriesMetaColumn",
-      subInfo: JSON.parse(JSON.stringify(currentFacies.subFaciesInfo))
+      subInfo: JSON.parse(JSON.stringify(subFaciesInfo))
     });
     addFaciesChildren(
       currentColumnInfo.children,
@@ -1334,16 +1334,16 @@ function recursive(
       units
     );
     returnValue.fontOptions = currentColumnInfo.fontOptions;
-    returnValue.subFaciesInfo = currentFacies.subFaciesInfo;
+    returnValue.subFaciesInfo = subFaciesInfo;
     returnValue.minAge = currentColumnInfo.minAge;
     returnValue.maxAge = currentColumnInfo.maxAge;
   }
   if (eventMap.has(currentColumn)) {
-    const currentEvent = eventMap.get(currentColumn)!;
+    const {subEventInfo, ...currentEvent} = eventMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentEvent,
       fontOptions: getValidFontOptions("Event"),
-      subInfo: JSON.parse(JSON.stringify(currentEvent.subEventInfo))
+      subInfo: JSON.parse(JSON.stringify(subEventInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
     returnValue.maxAge = currentColumnInfo.maxAge;
@@ -1351,10 +1351,10 @@ function recursive(
   }
   if (chronMap.has(currentColumn)) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { width, ...currentChron } = chronMap.get(currentColumn)!;
+    const { width, subChronInfo, ...currentChron } = chronMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentChron,
-      subInfo: JSON.parse(JSON.stringify(currentChron.subChronInfo))
+      subInfo: JSON.parse(JSON.stringify(subChronInfo))
     });
     addChronChildren(
       currentColumnInfo.children,
@@ -1370,22 +1370,22 @@ function recursive(
     returnValue.minAge = currentColumnInfo.minAge;
   }
   if (pointMap.has(currentColumn)) {
-    const currentPoint = pointMap.get(currentColumn)!;
+    const {subPointInfo, ...currentPoint} = pointMap.get(currentColumn)!;
     Object.assign(currentColumnInfo, {
       ...currentPoint,
       fontOptions: getValidFontOptions("Point"),
-      subInfo: JSON.parse(JSON.stringify(currentPoint.subPointInfo))
+      subInfo: JSON.parse(JSON.stringify(subPointInfo))
     });
     returnValue.fontOptions = currentColumnInfo.fontOptions;
     returnValue.maxAge = currentColumnInfo.maxAge;
     returnValue.minAge = currentColumnInfo.minAge;
   }
   if (freehandMap.has(currentColumn)) {
-    const currentFreehand = freehandMap.get(currentColumn)!;
+    const {subFreehandInfo, ...currentFreehand} = freehandMap.get(currentColumn)!;
     // TODO NOTE FOR FUTURE: @Paolo - Java file appends all fonts to this, but from trial and error, only column header makes sense. If this case changes here we would change it
     Object.assign(currentColumnInfo, {
       ...currentFreehand,
-      subInfo: JSON.parse(JSON.stringify(currentFreehand.subFreehandInfo))
+      subInfo: JSON.parse(JSON.stringify(subFreehandInfo))
     });
     returnValue.maxAge = currentColumnInfo.maxAge;
     returnValue.minAge = currentColumnInfo.minAge;

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -45,7 +45,6 @@ import {
 } from "@tsconline/shared";
 import { trimInvisibleCharacters, grabFilepaths, hasVisibleCharacters, capitalizeFirstLetter } from "./util.js";
 import { createInterface } from "readline";
-import { get } from "http";
 const patternForColor = /^(\d+\/\d+\/\d+)$/;
 const patternForLineStyle = /^(solid|dashed|dotted)$/;
 const patternForAbundance = /^(TOP|missing|rare|common|frequent|abundant|sample|flood)$/;
@@ -428,7 +427,6 @@ export async function getColumnTypes(
           units,
           loneColumns
         );
-        continue;
       } else if (inBlockBlock) {
         inBlockBlock = processColumn(
           "Block",
@@ -440,7 +438,6 @@ export async function getColumnTypes(
           units,
           loneColumns
         );
-        continue;
       } else if (inEventBlock) {
         inEventBlock = processColumn(
           "Event",
@@ -452,7 +449,6 @@ export async function getColumnTypes(
           units,
           loneColumns
         );
-        continue;
       } else if (inRangeBlock) {
         inRangeBlock = processColumn(
           "Range",
@@ -464,7 +460,6 @@ export async function getColumnTypes(
           units,
           loneColumns
         );
-        continue;
       } else if (inChronBlock) {
         inChronBlock = processColumn(
           "Chron",
@@ -476,7 +471,6 @@ export async function getColumnTypes(
           units,
           loneColumns
         );
-        continue;
       } else if (inPointBlock) {
         inPointBlock = processColumn(
           "Point",
@@ -488,7 +482,6 @@ export async function getColumnTypes(
           units,
           loneColumns
         );
-        continue;
       } else if (inSequenceBlock) {
         inSequenceBlock = processColumn(
           "Sequence",
@@ -500,7 +493,6 @@ export async function getColumnTypes(
           units,
           loneColumns
         );
-        continue;
       } else if (inTransectBlock) {
         inTransectBlock = processColumn(
           "Transect",
@@ -512,7 +504,6 @@ export async function getColumnTypes(
           units,
           loneColumns
         );
-        continue;
       } else if (inFreehandBlock) {
         inFreehandBlock = processColumn(
           "Freehand",
@@ -524,8 +515,8 @@ export async function getColumnTypes(
           units,
           loneColumns
         );
-        continue;
       }
+      continue;
     }
 
     const tabSeparated = line.split("\t");
@@ -641,32 +632,60 @@ export async function getColumnTypes(
     }
   }
 
-  if (inTransectBlock) {
-    addTransectToTransectMap(transect, transectMap);
-  }
   if (inFaciesBlock) {
-    addFaciesToFaciesMap(facies, faciesMap);
-  }
-  if (inEventBlock) {
-    addEventToEventMap(event, eventMap);
-  }
-  if (inBlockBlock) {
-    addBlockToBlockMap(block, blocksMap);
-  }
-  if (inRangeBlock) {
-    addRangeToRangeMap(range, rangeMap);
-  }
-  if (inChronBlock) {
-    addChronToChronMap(chron, chronMap);
-  }
-  if (inPointBlock) {
-    addPointToPointMap(point, pointMap);
-  }
-  if (inSequenceBlock) {
-    addSequenceToSequenceMap(sequence, sequenceMap);
-  }
-  if (inFreehandBlock) {
-    addFreehandToFreehandMap(freehand, freehandMap);
+    processColumn(
+      "Facies",
+      facies,
+      "subFaciesInfo",
+      allParsedEntries,
+      addFaciesToFaciesMap,
+      faciesMap,
+      units,
+      loneColumns
+    );
+  } else if (inBlockBlock) {
+    processColumn("Block", block, "subBlockInfo", allParsedEntries, addBlockToBlockMap, blocksMap, units, loneColumns);
+  } else if (inEventBlock) {
+    processColumn("Event", event, "subEventInfo", allParsedEntries, addEventToEventMap, eventMap, units, loneColumns);
+  } else if (inRangeBlock) {
+    processColumn("Range", range, "subRangeInfo", allParsedEntries, addRangeToRangeMap, rangeMap, units, loneColumns);
+  } else if (inChronBlock) {
+    processColumn("Chron", chron, "subChronInfo", allParsedEntries, addChronToChronMap, chronMap, units, loneColumns);
+  } else if (inPointBlock) {
+    processColumn("Point", point, "subPointInfo", allParsedEntries, addPointToPointMap, pointMap, units, loneColumns);
+  } else if (inSequenceBlock) {
+    processColumn(
+      "Sequence",
+      sequence,
+      "subSequenceInfo",
+      allParsedEntries,
+      addSequenceToSequenceMap,
+      sequenceMap,
+      units,
+      loneColumns
+    );
+  } else if (inTransectBlock) {
+    processColumn(
+      "Transect",
+      transect,
+      "subTransectInfo",
+      allParsedEntries,
+      addTransectToTransectMap,
+      transectMap,
+      units,
+      loneColumns
+    );
+  } else if (inFreehandBlock) {
+    processColumn(
+      "Freehand",
+      freehand,
+      "subFreehandInfo",
+      allParsedEntries,
+      addFreehandToFreehandMap,
+      freehandMap,
+      units,
+      loneColumns
+    );
   }
 }
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -156,7 +156,7 @@ export type ColumnInfoTypeMap = {
 
 export type ColumnInfoType = keyof ColumnInfoTypeMap;
 
-export type DisplayedColumnTypes = ColumnInfoType | "Zone" | "Ruler" | "AgeAge";
+export type DisplayedColumnTypes = ColumnInfoType | "Zone" | "Ruler" | "AgeAge" | "MetaColumn" | "RootColumn" | "BlockSeriesMetaColumn";
 
 export type ValidFontOptions =
   | "Column Header"
@@ -199,6 +199,7 @@ export type ColumnInfo = {
   minAge: number;
   maxAge: number;
   enableTitle: boolean;
+  columnDisplayType: DisplayedColumnTypes;
   rgb: RGB;
   width: number;
   units: string;
@@ -793,6 +794,14 @@ export function assertSubInfo(o: any): asserts o is SubInfo[] {
     else throw new Error("SubInfo must be an array of valid subInfo objects");
   }
 }
+export function assertDisplayedColumnTypes(o: any): asserts o is DisplayedColumnTypes {
+  if (!o || !Array.isArray(o)) throw new Error("DisplayedColumnTypes must be an array");
+  for (const type of o) {
+    if (typeof type !== "string") throw new Error("DisplayedColumnTypes must be an array of strings");
+    if (!/^(Block|Facies|Event|Range|Chron|Point|Sequence|Transect|Freehand|Zone|Ruler|AgeAge|MetaColumn|BlockSeriesMetaColumn|RootColumn)$/.test(type))
+      throw new Error("DisplayedColumnTypes must be an array of valid column types");
+  }
+}
 
 export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   if (typeof o !== "object" || o === null) {
@@ -815,6 +824,7 @@ export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   for (const fontOption of o.fontOptions) {
     assertValidFontOptions(fontOption);
   }
+  assertDisplayedColumnTypes(o.displayedColumnTypes);
   assertRGB(o.rgb);
   for (const child of o.children) {
     assertColumnInfo(child);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -156,7 +156,14 @@ export type ColumnInfoTypeMap = {
 
 export type ColumnInfoType = keyof ColumnInfoTypeMap;
 
-export type DisplayedColumnTypes = ColumnInfoType | "Zone" | "Ruler" | "AgeAge" | "MetaColumn" | "RootColumn" | "BlockSeriesMetaColumn";
+export type DisplayedColumnTypes =
+  | ColumnInfoType
+  | "Zone"
+  | "Ruler"
+  | "AgeAge"
+  | "MetaColumn"
+  | "RootColumn"
+  | "BlockSeriesMetaColumn";
 
 export type ValidFontOptions =
   | "Column Header"
@@ -796,7 +803,11 @@ export function assertSubInfo(o: any): asserts o is SubInfo[] {
 }
 export function assertDisplayedColumnTypes(o: any): asserts o is DisplayedColumnTypes {
   if (!o || typeof o !== "string") throwError("DisplayedColumnTypes", "DisplayedColumnTypes", "string", o);
-  if (!/^(Block|Facies|Event|Range|Chron|Point|Sequence|Transect|Freehand|Zone|Ruler|AgeAge|MetaColumn|BlockSeriesMetaColumn|RootColumn)$/.test(o))
+  if (
+    !/^(Block|Facies|Event|Range|Chron|Point|Sequence|Transect|Freehand|Zone|Ruler|AgeAge|MetaColumn|BlockSeriesMetaColumn|RootColumn)$/.test(
+      o
+    )
+  )
     throw new Error("DisplayedColumnTypes must be a string of a valid column type");
 }
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -820,10 +820,7 @@ export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   if (typeof o.on !== "boolean") throwError("ColumnInfo", "on", "boolean", o.on);
   if (typeof o.popup !== "string") throwError("ColumnInfo", "popup", "string", o.popup);
   if (o.parent !== null && typeof o.parent !== "string") throwError("ColumnInfo", "parent", "string", o.parent);
-  if (typeof o.minAge !== "number") {
-    console.trace(o.name);
-    throwError("ColumnInfo", "minAge", "number", o.minAge);
-  }
+  if (typeof o.minAge !== "number") throwError("ColumnInfo", "minAge", "number", o.minAge);
   if (typeof o.maxAge !== "number") throwError("ColumnInfo", "maxAge", "number", o.maxAge);
   if (typeof o.width !== "number") throwError("ColumnInfo", "width", "number", o.width);
   if (typeof o.enableTitle !== "boolean") throwError("ColumnInfo", "enableTitle", "boolean", o.enableTitle);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -176,7 +176,7 @@ export type ValidFontOptions =
   | "Range Box Label";
 
 export type SubInfo =
-  SubBlockInfo
+  | SubBlockInfo
   | SubFaciesInfo
   | SubEventInfo
   | SubRangeInfo
@@ -804,7 +804,7 @@ export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   if (typeof o.popup !== "string") throwError("ColumnInfo", "popup", "string", o.popup);
   if (o.parent !== null && typeof o.parent !== "string") throwError("ColumnInfo", "parent", "string", o.parent);
   if (typeof o.minAge !== "number") {
-    console.trace(o.name)
+    console.trace(o.name);
     throwError("ColumnInfo", "minAge", "number", o.minAge);
   }
   if (typeof o.maxAge !== "number") throwError("ColumnInfo", "maxAge", "number", o.maxAge);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -795,12 +795,9 @@ export function assertSubInfo(o: any): asserts o is SubInfo[] {
   }
 }
 export function assertDisplayedColumnTypes(o: any): asserts o is DisplayedColumnTypes {
-  if (!o || !Array.isArray(o)) throw new Error("DisplayedColumnTypes must be an array");
-  for (const type of o) {
-    if (typeof type !== "string") throw new Error("DisplayedColumnTypes must be an array of strings");
-    if (!/^(Block|Facies|Event|Range|Chron|Point|Sequence|Transect|Freehand|Zone|Ruler|AgeAge|MetaColumn|BlockSeriesMetaColumn|RootColumn)$/.test(type))
-      throw new Error("DisplayedColumnTypes must be an array of valid column types");
-  }
+  if (!o || typeof o !== "string") throwError("DisplayedColumnTypes", "DisplayedColumnTypes", "string", o);
+  if (!/^(Block|Facies|Event|Range|Chron|Point|Sequence|Transect|Freehand|Zone|Ruler|AgeAge|MetaColumn|BlockSeriesMetaColumn|RootColumn)$/.test(o))
+    throw new Error("DisplayedColumnTypes must be a string of a valid column type");
 }
 
 export function assertColumnInfo(o: any): asserts o is ColumnInfo {
@@ -824,7 +821,7 @@ export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   for (const fontOption of o.fontOptions) {
     assertValidFontOptions(fontOption);
   }
-  assertDisplayedColumnTypes(o.displayedColumnTypes);
+  assertDisplayedColumnTypes(o.columnDisplayType);
   assertRGB(o.rgb);
   for (const child of o.children) {
     assertColumnInfo(child);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -139,6 +139,25 @@ export type ServerResponseError = {
   error: string; // any time an error is thrown on the server side
 };
 
+export type Blank = ColumnHeaderProps;
+
+export type ColumnInfoTypeMap = {
+  Block: Block;
+  Facies: Facies;
+  Event: Event;
+  Range: Range;
+  Chron: Chron;
+  Freehand: Freehand;
+  Point: Point;
+  Sequence: Sequence;
+  Transect: Transect;
+  Blank: Blank;
+};
+
+export type ColumnInfoType = keyof ColumnInfoTypeMap;
+
+export type DisplayedColumnTypes = ColumnInfoType | "Zone" | "Ruler" | "AgeAge";
+
 export type ValidFontOptions =
   | "Column Header"
   | "Age Label"
@@ -156,6 +175,17 @@ export type ValidFontOptions =
   | "Legend Column Source"
   | "Range Box Label";
 
+export type SubInfo =
+  SubBlockInfo
+  | SubFaciesInfo
+  | SubEventInfo
+  | SubRangeInfo
+  | SubChronInfo
+  | SubFreehandInfo
+  | SubPointInfo
+  | SubSequenceInfo
+  | SubTransectInfo;
+
 export type ColumnInfo = {
   name: string;
   editName: string;
@@ -165,15 +195,7 @@ export type ColumnInfo = {
   popup: string;
   children: ColumnInfo[];
   parent: string | null;
-  subBlockInfo?: SubBlockInfo[];
-  subFaciesInfo?: SubFaciesInfo[];
-  subEventInfo?: SubEventInfo[];
-  subRangeInfo?: SubRangeInfo[];
-  subChronInfo?: SubChronInfo[];
-  subPointInfo?: SubPointInfo[];
-  subFreehandInfo?: SubFreehandInfo[];
-  subSequenceInfo?: SubSequenceInfo[];
-  subTransectInfo?: SubTransectInfo[];
+  subInfo?: SubInfo[];
   minAge: number;
   maxAge: number;
   enableTitle: boolean;
@@ -377,8 +399,8 @@ export function assertTransect(o: any): asserts o is Transect {
 
 export function assertSubFreehandInfo(o: any): asserts o is SubFreehandInfo {
   if (!o || typeof o !== "object") throw new Error("SubFreehandInfo must be a non-null object");
-  if (typeof o.topAge !== "number") throwError("SubFreehandInfo", "topAge", "number", o.topAge);
-  if (typeof o.baseAge !== "number") throwError("SubFreehandInfo", "baseAge", "number", o.baseAge);
+  if (typeof o.topAge !== "number" || isNaN(o.topAge)) throwError("SubFreehandInfo", "topAge", "number", o.topAge);
+  if (typeof o.baseAge !== "number" || isNaN(o.baseAge)) throwError("SubFreehandInfo", "baseAge", "number", o.baseAge);
 }
 
 export function assertSubTransectInfo(o: any): asserts o is SubTransectInfo {
@@ -658,6 +680,120 @@ export function assertValidFontOptions(o: any): asserts o is ValidFontOptions {
     throwError("ValidFontOptions", "ValidFontOptions", "ValidFontOptions", o);
 }
 
+export function isRGB(o: any): o is RGB {
+  if (!o || typeof o !== "object") return false;
+  if (typeof o.r !== "number") return false;
+  if (o.r < 0 || o.r > 255) return false;
+  if (typeof o.g !== "number") return false;
+  if (o.g < 0 || o.g > 255) return false;
+  if (typeof o.b !== "number") return false;
+  if (o.b < 0 || o.b > 255) return false;
+  return true;
+}
+
+export function isSubBlockInfo(o: any): o is SubBlockInfo {
+  if (!o || typeof o !== "object") return false;
+  if (typeof o.label !== "string") return false;
+  if (typeof o.age !== "number") return false;
+  if (typeof o.popup !== "string") return false;
+  if (o.lineStyle !== "solid" && o.lineStyle !== "dotted" && o.lineStyle !== "dashed") return false;
+  if (!isRGB(o.rgb)) return false;
+  return true;
+}
+
+export function isSubFaciesInfoArray(o: any): o is SubFaciesInfo[] {
+  if (!o || !Array.isArray(o)) return false;
+  for (const sub of o) {
+    if (!isSubFaciesInfo(sub)) return false;
+  }
+  return true;
+}
+
+export function isSubFaciesInfo(o: any): o is SubFaciesInfo {
+  if (!o || typeof o !== "object") return false;
+  if (typeof o.rockType !== "string") return false;
+  if (typeof o.info !== "string") return false;
+  if ("label" in o && typeof o.label !== "string") return false;
+  if (typeof o.age !== "number") return false;
+  return true;
+}
+
+export function isSubEventInfo(o: any): o is SubEventInfo {
+  if (!o || typeof o !== "object") return false;
+  if (typeof o.label !== "string") return false;
+  if (typeof o.age !== "number") return false;
+  if (typeof o.popup !== "string") return false;
+  if (typeof o.lineStyle !== "string" || !/(^dotted|dashed|solid)$/.test(o.lineStyle)) return false;
+  return true;
+}
+
+export function isSubRangeInfo(o: any): o is SubRangeInfo {
+  if (!o || typeof o !== "object") return false;
+  if (typeof o.label !== "string") return false;
+  if (typeof o.age !== "number") return false;
+  if (typeof o.abundance !== "string") return false;
+  if (!/^(TOP|missing|rare|common|frequent|abundant|sample|flood)$/.test(o.abundance)) return false;
+  if (typeof o.popup !== "string") return false;
+  return true;
+}
+
+export function isSubChronInfo(o: any): o is SubChronInfo {
+  if (!o || typeof o !== "object") return false;
+  if (typeof o.polarity !== "string" || !/^(TOP|N|R|U|No Data)$/.test(o.polarity)) return false;
+  if (o.label && typeof o.label !== "string") return false;
+  if (typeof o.age !== "number") return false;
+  if (typeof o.popup !== "string") return false;
+  return true;
+}
+
+export function isSubPointInfo(o: any): o is SubPointInfo {
+  if (!o || typeof o !== "object") return false;
+  if (typeof o.age !== "number") return false;
+  if (typeof o.xVal !== "number") return false;
+  if (typeof o.popup !== "string") return false;
+  return true;
+}
+
+export function isSubSequenceInfo(o: any): o is SubSequenceInfo {
+  if (!o || typeof o !== "object") return false;
+  if (o.label && typeof o.label !== "string") return false;
+  if (typeof o.direction !== "string" || !/^(SB|MFS)$/.test(o.direction)) return false;
+  if (typeof o.age !== "number") return false;
+  if (typeof o.severity !== "string" || !/^(Major|Minor|Medium)$/.test(o.severity)) return false;
+  if (typeof o.popup !== "string") return false;
+  return true;
+}
+
+export function isSubTransectInfo(o: any): o is SubTransectInfo {
+  if (!o || typeof o !== "object") return false;
+  if (typeof o.age !== "number") return false;
+  return true;
+}
+
+export function isSubFreehandInfo(o: any): o is SubFreehandInfo {
+  if (!o || typeof o !== "object") return false;
+  if (typeof o.topAge !== "number") return false;
+  if (typeof o.baseAge !== "number") return false;
+  return true;
+}
+
+export function assertSubInfo(o: any): asserts o is SubInfo[] {
+  if (!o || !Array.isArray(o)) throw new Error("SubInfo must be an array");
+  for (const sub of o) {
+    if (typeof sub !== "object") throw new Error("SubInfo must be an array of objects");
+    if (isSubBlockInfo(sub)) assertSubBlockInfo(sub);
+    else if (isSubFaciesInfo(sub)) assertSubFaciesInfo(sub);
+    else if (isSubEventInfo(sub)) assertSubEventInfo(sub);
+    else if (isSubRangeInfo(sub)) assertSubRangeInfo(sub);
+    else if (isSubChronInfo(sub)) assertSubChronInfo(sub);
+    else if (isSubPointInfo(sub)) assertSubPointInfo(sub);
+    else if (isSubSequenceInfo(sub)) assertSubSequenceInfo(sub);
+    else if (isSubTransectInfo(sub)) assertSubTransectInfo(sub);
+    else if (isSubFreehandInfo(sub)) assertSubFreehandInfo(sub);
+    else throw new Error("SubInfo must be an array of valid subInfo objects");
+  }
+}
+
 export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   if (typeof o !== "object" || o === null) {
     throw new Error("ColumnInfo must be a non-null object");
@@ -667,7 +803,10 @@ export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   if (typeof o.on !== "boolean") throwError("ColumnInfo", "on", "boolean", o.on);
   if (typeof o.popup !== "string") throwError("ColumnInfo", "popup", "string", o.popup);
   if (o.parent !== null && typeof o.parent !== "string") throwError("ColumnInfo", "parent", "string", o.parent);
-  if (typeof o.minAge !== "number") throwError("ColumnInfo", "minAge", "number", o.minAge);
+  if (typeof o.minAge !== "number") {
+    console.trace(o.name)
+    throwError("ColumnInfo", "minAge", "number", o.minAge);
+  }
   if (typeof o.maxAge !== "number") throwError("ColumnInfo", "maxAge", "number", o.maxAge);
   if (typeof o.width !== "number") throwError("ColumnInfo", "width", "number", o.width);
   if (typeof o.enableTitle !== "boolean") throwError("ColumnInfo", "enableTitle", "boolean", o.enableTitle);
@@ -680,69 +819,8 @@ export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   for (const child of o.children) {
     assertColumnInfo(child);
   }
-  if ("subBlockInfo" in o) {
-    if (!o.subBlockInfo || !Array.isArray(o.subBlockInfo))
-      throwError("ColumnInfo", "subBlockInfo", "array", o.subBlockInfo);
-    for (const block of o.subBlockInfo) {
-      assertSubBlockInfo(block);
-    }
-  }
-  if ("subFaciesInfo" in o) {
-    if (!o.subFaciesInfo || !Array.isArray(o.subFaciesInfo))
-      throwError("ColumnInfo", "subFaciesInfo", "array", o.subFaciesInfo);
-    for (const facies of o.subFaciesInfo) {
-      assertSubFaciesInfo(facies);
-    }
-  }
-  if ("subEventInfo" in o) {
-    if (!o.subEventInfo || !Array.isArray(o.subEventInfo))
-      throwError("ColumnInfo", "subEventInfo", "array", o.subEventInfo);
-    for (const event of o.subEventInfo) {
-      assertSubEventInfo(event);
-    }
-  }
-  if ("subRangeInfo" in o) {
-    if (!o.subRangeInfo || !Array.isArray(o.subRangeInfo))
-      throwError("ColumnInfo", "subRangeInfo", "array", o.subRangeInfo);
-    for (const range of o.subRangeInfo) {
-      assertSubRangeInfo(range);
-    }
-  }
-  if ("subChronInfo" in o) {
-    if (!o.subChronInfo || !Array.isArray(o.subChronInfo))
-      throwError("ColumnInfo", "subChronInfo", "array", o.subChronInfo);
-    for (const chron of o.subChronInfo) {
-      assertSubChronInfo(chron);
-    }
-  }
-  if ("subPointInfo" in o) {
-    if (!o.subPointInfo || !Array.isArray(o.subPointInfo))
-      throwError("ColumnInfo", "subPointInfo", "array", o.subPointInfo);
-    for (const point of o.subPointInfo) {
-      assertSubPointInfo(point);
-    }
-  }
-  if ("subFreehandInfo" in o) {
-    if (!o.subFreehandInfo || !Array.isArray(o.subFreehandInfo))
-      throwError("ColumnInfo", "subFreehandInfo", "array", o.subFreehandInfo);
-    for (const freehand of o.subFreehandInfo) {
-      assertSubFreehandInfo(freehand);
-    }
-  }
-  if ("subSequenceInfo" in o) {
-    if (!o.subSequenceInfo || !Array.isArray(o.subSequenceInfo))
-      throwError("ColumnInfo", "subSequenceInfo", "array", o.subSequenceInfo);
-    for (const sequence of o.subSequenceInfo) {
-      assertSubSequenceInfo(sequence);
-    }
-  }
-  if ("subTransectInfo" in o) {
-    if (!o.subTransectInfo || !Array.isArray(o.subTransectInfo))
-      throwError("ColumnInfo", "subTransectInfo", "array", o.subTransectInfo);
-    for (const transect of o.subTransectInfo) {
-      assertSubTransectInfo(transect);
-    }
-  }
+  assertFontsInfo(o.fontsInfo);
+  if (o.subInfo) assertSubInfo(o.subInfo);
 }
 
 export function assertFontsInfo(o: any): asserts o is FontsInfo {


### PR DESCRIPTION
- fixed font changes with inheritance and backend restructuring
- font inheritance works, (doesn't show the children inheriting on the front end but changes xml to chart propogation)
- added enable title checkbox
- removed some general parse setting assumptions
- added error if no columns are selected on generation
- added error if all charts have unit ranges of 0 (top: 0, base: 0)
- added column types for display (Zone, MetaColumn, etc)
- refactored a lot of the code to now parse datapacks that are LONE which means they do not have a parent-child hierarchy

https://github.com/earthhistoryviz/tsconline/assets/89664317/249ac527-046f-4bb5-8143-6e8287c59d73

