### PR TITLE
Tsc 295 general chart fonts change chart root

### DIFF
--- a/app/src/SettingsTabs/Font.css
+++ b/app/src/SettingsTabs/Font.css
@@ -1,17 +1,18 @@
 .root-font-options {
-    align-items: center;
-    justify-content: center;
-    display: grid;
-    margin-top: 40px;
+  align-items: center;
+  justify-content: center;
+  display: grid;
+  margin-top: 40px;
+  padding-bottom: 80px;
 }
 .root-font-description {
-    text-align: center;
-    margin-bottom: 10px;
+  text-align: center;
+  margin-bottom: 10px;
 }
 .chart-root-not-available {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  min-height: 100vh;
 }

--- a/app/src/SettingsTabs/Font.css
+++ b/app/src/SettingsTabs/Font.css
@@ -1,0 +1,17 @@
+.root-font-options {
+    align-items: center;
+    justify-content: center;
+    display: grid;
+    margin-top: 40px;
+}
+.root-font-description {
+    text-align: center;
+    margin-bottom: 10px;
+}
+.chart-root-not-available {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    min-height: 100vh;
+}

--- a/app/src/SettingsTabs/Font.tsx
+++ b/app/src/SettingsTabs/Font.tsx
@@ -1,23 +1,39 @@
 import { observer } from "mobx-react-lite";
 import { Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+import { context } from "../state";
+import { useContext } from "react";
+import { LeafColumnFontMenu } from "./FontMenu";
+import "./Font.css"
 export const Font = observer(function Font() {
   const theme = useTheme();
+  const { state } = useContext(context)
+  const rootColumn = state.settingsTabs.columns
   return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        width: "100%",
-        minHeight: "100vh"
-      }}>
+    <>
+    {rootColumn ? 
+    (
+    <div className="root-font-options">
+      <div className="root-font-description">
+        <Typography> These are the default systemwide fonts.</Typography>
+        <Typography> Changing one here will affect the entire chart.</Typography>
+        <Typography> NOTE: These fonts can be changed on a column by column basis by using the Font button for each column</Typography>
+      </div>
+      <LeafColumnFontMenu column={rootColumn} />
+    </div>
+    )
+    :
+    (    
+    <div className="chart-root-not-available">
       <Typography
         sx={{
           fontSize: theme.typography.pxToRem(18)
         }}>
-        Font Settings are currently not supported
+          No Datapack is Selected
       </Typography>
     </div>
+)
+    }
+    </>
   );
 });

--- a/app/src/SettingsTabs/Font.tsx
+++ b/app/src/SettingsTabs/Font.tsx
@@ -4,36 +4,35 @@ import { useTheme } from "@mui/material/styles";
 import { context } from "../state";
 import { useContext } from "react";
 import { LeafColumnFontMenu } from "./FontMenu";
-import "./Font.css"
+import "./Font.css";
 export const Font = observer(function Font() {
   const theme = useTheme();
-  const { state } = useContext(context)
-  const rootColumn = state.settingsTabs.columns
+  const { state } = useContext(context);
+  const rootColumn = state.settingsTabs.columns;
   return (
     <>
-    {rootColumn ? 
-    (
-    <div className="root-font-options">
-      <div className="root-font-description">
-        <Typography> These are the default systemwide fonts.</Typography>
-        <Typography> Changing one here will affect the entire chart.</Typography>
-        <Typography> NOTE: These fonts can be changed on a column by column basis by using the Font button for each column</Typography>
-      </div>
-      <LeafColumnFontMenu column={rootColumn} />
-    </div>
-    )
-    :
-    (    
-    <div className="chart-root-not-available">
-      <Typography
-        sx={{
-          fontSize: theme.typography.pxToRem(18)
-        }}>
-          No Datapack is Selected
-      </Typography>
-    </div>
-)
-    }
+      {rootColumn ? (
+        <div className="root-font-options">
+          <div className="root-font-description">
+            <Typography> These are the default systemwide fonts.</Typography>
+            <Typography> Changing one here will affect the entire chart.</Typography>
+            <Typography>
+              {" "}
+              NOTE: These fonts can be changed on a column by column basis by using the Font button for each column
+            </Typography>
+          </div>
+          <LeafColumnFontMenu column={rootColumn} />
+        </div>
+      ) : (
+        <div className="chart-root-not-available">
+          <Typography
+            sx={{
+              fontSize: theme.typography.pxToRem(18)
+            }}>
+            No Datapack is Selected
+          </Typography>
+        </div>
+      )}
     </>
   );
 });

--- a/app/src/SettingsTabs/FontMenu.css
+++ b/app/src/SettingsTabs/FontMenu.css
@@ -36,6 +36,7 @@
 #FontRowContainer {
   display: flex;
   align-items: center;
+  margin-bottom: 10px;
 }
 
 #TargetInput {

--- a/app/src/SettingsTabs/FontMenu.tsx
+++ b/app/src/SettingsTabs/FontMenu.tsx
@@ -36,11 +36,9 @@ const FontMenuRow: React.FC<{
 }> = observer(({ target, column }) => {
   const { actions } = useContext(context);
   const fontOpts = column.fontsInfo[target];
-  const [font, setFont] = useState("Arial");
   const handleFontChange = (event: SelectChangeEvent) => {
     if (!/^(Arial|Courier|Verdana)$/.test(event.target.value)) return;
     actions.setFontFace(target, event.target.value as "Arial" | "Courier" | "Verdana", column);
-    setFont(event.target.value as string);
   };
   const handleFormat = (_event: React.MouseEvent<HTMLElement>, newFormats: string[]) => {
     actions.setBold(target, newFormats.includes("bold"), column);
@@ -75,7 +73,7 @@ const FontMenuRow: React.FC<{
                 actions.setInheritable(target, !fontOpts.inheritable, column);
               }}
               inputProps={{ "aria-label": "controlled" }}
-              disabled={!fontOpts.on}
+              disabled={!fontOpts.on || column.name === "Chart Root"}
             />
           }
           label="Inheritable"
@@ -134,7 +132,7 @@ const FontMenuRow: React.FC<{
             fontSize: fontOpts.size,
             color: fontOpts.color
           }}
-          id={font}>
+          id={fontOpts.fontFace}>
           Sample Text
         </Typography>
       </div>
@@ -203,7 +201,7 @@ const MetaColumnFontMenu: React.FC<FontMenuProps> = observer(({ column }) => {
   );
 });
 
-const LeafColumnFontMenu: React.FC<FontMenuProps> = observer(({ column }) => {
+export const LeafColumnFontMenu: React.FC<FontMenuProps> = observer(({ column }) => {
   return (
     <Grid container rowSpacing={2} columnSpacing={0}>
       <Grid item xs={12}>

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -1,5 +1,5 @@
 import { action } from "mobx";
-import { ChartInfoTSC, ChartSettingsInfoTSC, TimescaleItem } from "@tsconline/shared";
+import { ChartInfoTSC, ChartSettingsInfoTSC, FontsInfo, TimescaleItem, allFontOptions } from "@tsconline/shared";
 
 import {
   type MapInfo,
@@ -258,7 +258,7 @@ export const setDatapackConfig = action(
         name: "Chart Root", // if you change this, change parse-datapacks.ts :69
         editName: "Chart Root",
         fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
-        fontOptions: ["Column Header"],
+        fontOptions: [...allFontOptions],
         popup: "",
         on: true,
         width: 100,
@@ -275,6 +275,10 @@ export const setDatapackConfig = action(
         units: "",
         columnDisplayType: "RootColumn"
       };
+      // all chart root font options have inheritable on
+      for (const opt in columnInfo.fontsInfo) {
+        columnInfo.fontsInfo[opt as keyof FontsInfo].inheritable = true
+      }
       // add everything together
       // uses preparsed data on server start and appends items together
       for (const datapack of datapacks) {

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -1,5 +1,5 @@
 import { action } from "mobx";
-import { ChartInfoTSC, ChartSettingsInfoTSC, FontsInfo, TimescaleItem, allFontOptions } from "@tsconline/shared";
+import { ChartInfoTSC, ChartSettingsInfoTSC, FontsInfo, TimescaleItem } from "@tsconline/shared";
 
 import {
   type MapInfo,

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -277,7 +277,7 @@ export const setDatapackConfig = action(
       };
       // all chart root font options have inheritable on
       for (const opt in columnInfo.fontsInfo) {
-        columnInfo.fontsInfo[opt as keyof FontsInfo].inheritable = true
+        columnInfo.fontsInfo[opt as keyof FontsInfo].inheritable = true;
       }
       // add everything together
       // uses preparsed data on server start and appends items together

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -258,7 +258,7 @@ export const setDatapackConfig = action(
         name: "Chart Root", // if you change this, change parse-datapacks.ts :69
         editName: "Chart Root",
         fontsInfo: JSON.parse(JSON.stringify(defaultFontsInfo)),
-        fontOptions: [...allFontOptions],
+        fontOptions: ["Column Header"],
         popup: "",
         on: true,
         width: 100,
@@ -311,6 +311,7 @@ export const setDatapackConfig = action(
             child.parent = column.name;
           }
         }
+        columnInfo.fontOptions = Array.from(new Set([...columnInfo.fontOptions, ...column.fontOptions]));
         columnInfo.children.push(column);
       }
       assertDatapackAgeInfo(datapackAgeInfo);


### PR DESCRIPTION
this is the fonts tab in the java file that allows you to change the font options for the whole chart (every possible unit/chart inside chart root)

basically used `FontRows` that's used for individual columns, but locked it if it was `Chart Root`

i've made it so it only displays the font menu rows that apply to the whole chart (not default all)

<img width="1398" alt="Screenshot 2024-04-24 at 2 28 15 AM" src="https://github.com/earthhistoryviz/tsconline/assets/89664317/ea9b35bd-dd38-449e-80cd-4529c3a3d73a">
<img width="1432" alt="Screenshot 2024-04-24 at 2 30 55 AM" src="https://github.com/earthhistoryviz/tsconline/assets/89664317/4ba60e12-3ef3-4637-b7c6-57351502894c">
