### PR TITLE
bug fixes, grab datapack properties if it exists from datapack, apply defaults, chunk loading datapack info

### DIFF
--- a/app/src/Home.tsx
+++ b/app/src/Home.tsx
@@ -106,7 +106,7 @@ const TSCPresetHighlights = observer(function TSCPresetHighlights({
                       );
                       // wait to see if we can grab necessary data
                       if (success) {
-                        actions.initiateChartGeneration(navigate);
+                        actions.initiateChartGeneration(navigate, "/home");
                       }
                       //TODO add an error message saying the data is irregular and can't be loaded
                     }}

--- a/app/src/NavBar.tsx
+++ b/app/src/NavBar.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { observer } from "mobx-react-lite";
 import AppBar from "@mui/material/AppBar";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import Toolbar from "@mui/material/Toolbar";
 import { useTheme } from "@mui/material/styles";
 import HomeIcon from "@mui/icons-material/Home";
@@ -16,6 +16,7 @@ export const NavBar = observer(function Navbar() {
   const theme = useTheme();
   const { state, actions } = useContext(context);
   const navigate = useNavigate();
+  const location = useLocation();
   return (
     <AppBar position="fixed" sx={{ background: theme.palette.navbar.main, display: "flex" }}>
       <Toolbar>
@@ -62,7 +63,9 @@ export const NavBar = observer(function Navbar() {
           </TSCTabs>
         }
         <div style={{ flexGrow: 1 }} />
-        <TSCButton onClick={() => actions.initiateChartGeneration(navigate)}>Generate Chart</TSCButton>
+        <TSCButton onClick={() => actions.initiateChartGeneration(navigate, location.pathname)}>
+          Generate Chart
+        </TSCButton>
         {state.isLoggedIn ? (
           <Tab
             className="login-tab"

--- a/app/src/SettingsTabs/BackgroundColor.tsx
+++ b/app/src/SettingsTabs/BackgroundColor.tsx
@@ -15,17 +15,6 @@ export const ChangeBackgroundColor: React.FC<ChangeBGColorProps> = observer(({ c
   const handleColorChange = (color: string) => {
     actions.setRGB(column, convertHexToRGB(color, false));
   };
-
-  if (column.children.length != 0) {
-    return (
-      <>
-        <FormLabel>
-          Background Color:
-          <Typography className="not-avail">Not Available</Typography>
-        </FormLabel>
-      </>
-    );
-  } else {
     return (
       <div>
         <FormLabel>Background Color:&nbsp;</FormLabel>
@@ -36,5 +25,4 @@ export const ChangeBackgroundColor: React.FC<ChangeBGColorProps> = observer(({ c
         />
       </div>
     );
-  }
 });

--- a/app/src/SettingsTabs/BackgroundColor.tsx
+++ b/app/src/SettingsTabs/BackgroundColor.tsx
@@ -15,14 +15,14 @@ export const ChangeBackgroundColor: React.FC<ChangeBGColorProps> = observer(({ c
   const handleColorChange = (color: string) => {
     actions.setRGB(column, convertHexToRGB(color, false));
   };
-    return (
-      <div>
-        <FormLabel>Background Color:&nbsp;</FormLabel>
-        <TSCColorPicker
-          key={column.name}
-          color={`rgb(${column.rgb.r}, ${column.rgb.g}, ${column.rgb.b})`}
-          onColorChange={handleColorChange}
-        />
-      </div>
-    );
+  return (
+    <div>
+      <FormLabel>Background Color:&nbsp;</FormLabel>
+      <TSCColorPicker
+        key={column.name}
+        color={`rgb(${column.rgb.r}, ${column.rgb.g}, ${column.rgb.b})`}
+        onColorChange={handleColorChange}
+      />
+    </div>
+  );
 });

--- a/app/src/SettingsTabs/BackgroundColor.tsx
+++ b/app/src/SettingsTabs/BackgroundColor.tsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react-lite";
 import React, { useContext } from "react";
-import { FormLabel, Typography } from "@mui/material";
+import { FormLabel } from "@mui/material";
 import TSCColorPicker from "../components/TSCColorPicker";
 import "./BackgroundColor.css";
 import { convertHexToRGB } from "../util/util";

--- a/app/src/SettingsTabs/ColumnMenu.tsx
+++ b/app/src/SettingsTabs/ColumnMenu.tsx
@@ -92,7 +92,7 @@ export const ColumnMenu = observer(() => {
       </div>
       <div id="ColumnMenuContent" className="column-menu-content">
         {column && <EditNameField />}
-        {column && <ChangeBackgroundColor column={column} />}
+        {column && column.children.length === 0 && <ChangeBackgroundColor column={column} />}
         {column && <FontMenu column={column} />}
         {column && <ShowTitles column={column} />}
         {column && column.width !== undefined && column.columnDisplayType !== "Ruler" && (

--- a/app/src/SettingsTabs/ColumnMenu.tsx
+++ b/app/src/SettingsTabs/ColumnMenu.tsx
@@ -96,7 +96,7 @@ export const ColumnMenu = observer(() => {
         {column && <FontMenu column={column} />}
         {column && <ShowTitles column={column} />}
         {column && column.width !== undefined && column.columnDisplayType !== "Ruler" && (
-          <EditWidthField width={column.width} key={column.name} columnObject={column} />
+          <EditWidthField key={column.name} columnObject={column} />
         )}
         {!!info && <InfoBox info={info} />}
       </div>

--- a/app/src/SettingsTabs/EditWidthField.tsx
+++ b/app/src/SettingsTabs/EditWidthField.tsx
@@ -11,19 +11,18 @@ const WidthTextField = ({ ...props }: TextFieldProps) => (
 );
 
 export const EditWidthField: React.FC<{
-  width: number;
-  columnObject: ColumnInfo | undefined;
-}> = observer(({ width, columnObject }) => {
+  columnObject: ColumnInfo;
+}> = observer(({ columnObject }) => {
   const { actions } = useContext(context);
   return (
     <div>
       <Typography id="edit-width-text">Edit Width</Typography>
       <NumericFormat
-        value={width || ""}
+        value={columnObject.width || ""}
         customInput={WidthTextField}
         onValueChange={(values) => {
           const floatValue = values.floatValue;
-          if (columnObject) actions.updateWidth(columnObject, floatValue ?? NaN);
+          actions.updateWidth(columnObject, floatValue ?? NaN);
         }}
         style={{ height: "20px" }}
       />

--- a/app/src/SettingsTabs/Font.css
+++ b/app/src/SettingsTabs/Font.css
@@ -1,9 +1,11 @@
 .root-font-options {
+  display: flex;
   align-items: center;
+  flex-direction: column;
   justify-content: center;
-  display: grid;
   margin-top: 40px;
   padding-bottom: 80px;
+  min-height: 100vh;
 }
 .root-font-description {
   text-align: center;
@@ -12,7 +14,6 @@
 .chart-root-not-available {
   display: flex;
   justify-content: center;
-  align-items: center;
   width: 100%;
   min-height: 100vh;
 }

--- a/app/src/SettingsTabs/FontMenu.css
+++ b/app/src/SettingsTabs/FontMenu.css
@@ -81,6 +81,10 @@
   margin-right: 10px;
 }
 
+#LeafColumnGridContainer {
+  width: auto;
+}
+
 #FontFaceForm {
   width: 150px;
   margin-right: 10px;

--- a/app/src/SettingsTabs/FontMenu.tsx
+++ b/app/src/SettingsTabs/FontMenu.tsx
@@ -209,11 +209,11 @@ export const LeafColumnFontMenu: React.FC<FontMenuProps> = observer(({ column })
       <Grid item xs={12}>
         <Typography id="Bold">Change Font</Typography>
       </Grid>
-        {Array.from(column.fontOptions).map((target) => (
-          <Grid item xs={12} key={target}>
-            <FontMenuRow column={column} target={target} />
-          </Grid>
-        ))}
+      {Array.from(column.fontOptions).map((target) => (
+        <Grid item xs={12} key={target}>
+          <FontMenuRow column={column} target={target} />
+        </Grid>
+      ))}
     </Grid>
   );
 });

--- a/app/src/SettingsTabs/FontMenu.tsx
+++ b/app/src/SettingsTabs/FontMenu.tsx
@@ -205,15 +205,15 @@ const MetaColumnFontMenu: React.FC<FontMenuProps> = observer(({ column }) => {
 
 export const LeafColumnFontMenu: React.FC<FontMenuProps> = observer(({ column }) => {
   return (
-    <Grid container rowSpacing={2} columnSpacing={0}>
+    <Grid id="LeafColumnGridContainer" container rowSpacing={2} columnSpacing={0}>
       <Grid item xs={12}>
         <Typography id="Bold">Change Font</Typography>
+      </Grid>
         {Array.from(column.fontOptions).map((target) => (
           <Grid item xs={12} key={target}>
             <FontMenuRow column={column} target={target} />
           </Grid>
         ))}
-      </Grid>
     </Grid>
   );
 });

--- a/app/src/SettingsTabs/MapControls.css
+++ b/app/src/SettingsTabs/MapControls.css
@@ -77,7 +77,7 @@
   padding-right: 30px;
 }
 .MuiTextField-root.dot-input-form {
-  padding-right: 20px;
+  margin-right: 20px;
   width: 45px;
 }
 .MuiTextField-root.age-text-field {

--- a/app/src/components/TSCSnackbar.css
+++ b/app/src/components/TSCSnackbar.css
@@ -1,5 +1,5 @@
 :root {
-  --snackbar-width: 300px;
+  --snackbar-width: 320px;
   --snackbar-height: 60px;
 }
 
@@ -8,6 +8,7 @@
   height: var(--snackbar-height);
   align-items: center;
   font-size: 0.8rem;
+  padding: 0px 16px;
   border-radius: 10px;
   box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.2);
 }

--- a/app/src/components/TSCSnackbar.tsx
+++ b/app/src/components/TSCSnackbar.tsx
@@ -43,7 +43,6 @@ export const TSCSnackbar: React.FC<TSCSnackbarProps> = observer(({ text, count, 
         zIndex: `${100000 - index}`
       }}
       onClose={handleCloseSnackbar}
-      autoHideDuration={5000}
       TransitionComponent={Slide}>
       <Alert
         style={{

--- a/app/src/components/TSCSnackbar.tsx
+++ b/app/src/components/TSCSnackbar.tsx
@@ -42,6 +42,7 @@ export const TSCSnackbar: React.FC<TSCSnackbarProps> = observer(({ text, count, 
         marginBottom: `${margin}px`,
         zIndex: `${100000 - index}`
       }}
+      autoHideDuration={5000}
       onClose={handleCloseSnackbar}
       TransitionComponent={Slide}>
       <Alert

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -643,12 +643,6 @@ async function fetchSVGStatus(): Promise<boolean> {
   return data.ready;
 }
 
-export const setMapPackIndex = action("setMapPackIndex", (mapPackIndex: State["mapPackIndex"]) => {
-  state.mapPackIndex = mapPackIndex;
-});
-export const setDatapackIndex = action("setDatapackIndex", (datapackIndex: State["datapackIndex"]) => {
-  state.datapackIndex = datapackIndex;
-});
 export const removeAllErrors = action("removeAllErrors", () => {
   state.errors.errorAlerts.clear();
 });

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -293,7 +293,12 @@ export const setDatapackConfig = action(
           const columnsToAdd = newUnitChart.children.slice(1);
           existingUnitColumnInfo.children = existingUnitColumnInfo.children.concat(columnsToAdd);
         } else {
-          if (((datapackParsingPack.topAge || datapackParsingPack.topAge === 0) && (datapackParsingPack.baseAge || datapackParsingPack.baseAge === 0)) || datapackParsingPack.verticalScale) foundDefaultAge = true;
+          if (
+            ((datapackParsingPack.topAge || datapackParsingPack.topAge === 0) &&
+              (datapackParsingPack.baseAge || datapackParsingPack.baseAge === 0)) ||
+            datapackParsingPack.verticalScale
+          )
+            foundDefaultAge = true;
           unitMap.set(datapackParsingPack.ageUnits, datapackParsingPack.columnInfo);
         }
         const mapPack = state.mapPackIndex[datapack]!;

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -1,5 +1,14 @@
-import { action, set } from "mobx";
-import { ChartInfoTSC, ChartSettingsInfoTSC, Datapack, DatapackIndex, FontsInfo, MapPackIndex, TimescaleItem, assertDatapackIndex, assertDatapackInfoChunk, assertMapPackInfoChunk } from "@tsconline/shared";
+import { action } from "mobx";
+import {
+  ChartInfoTSC,
+  ChartSettingsInfoTSC,
+  DatapackIndex,
+  FontsInfo,
+  MapPackIndex,
+  TimescaleItem,
+  assertDatapackInfoChunk,
+  assertMapPackInfoChunk
+} from "@tsconline/shared";
 
 import {
   type MapInfo,
@@ -73,11 +82,7 @@ export const fetchDatapackIndex = action("fetchDatapackIndex", async () => {
         if (total == -1) total = index.totalChunks;
         start += increment;
       } catch (e) {
-        displayServerError(
-          index,
-          ErrorCodes.INVALID_DATAPACK_INFO,
-          ErrorMessages[ErrorCodes.INVALID_DATAPACK_INFO]
-        );
+        displayServerError(index, ErrorCodes.INVALID_DATAPACK_INFO, ErrorMessages[ErrorCodes.INVALID_DATAPACK_INFO]);
         return;
       }
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -88,7 +93,7 @@ export const fetchDatapackIndex = action("fetchDatapackIndex", async () => {
     displayServerError(null, ErrorCodes.SERVER_RESPONSE_ERROR, ErrorMessages[ErrorCodes.SERVER_RESPONSE_ERROR]);
     console.error(e);
   }
-})
+});
 
 export const fetchMapPackIndex = action("fetchMapPackIndex", async () => {
   let start = 0;
@@ -106,11 +111,7 @@ export const fetchMapPackIndex = action("fetchMapPackIndex", async () => {
         if (total == -1) total = index.totalChunks;
         start += increment;
       } catch (e) {
-        displayServerError(
-          index,
-          ErrorCodes.INVALID_MAPPACK_INFO,
-          ErrorMessages[ErrorCodes.INVALID_MAPPACK_INFO]
-        );
+        displayServerError(index, ErrorCodes.INVALID_MAPPACK_INFO, ErrorMessages[ErrorCodes.INVALID_MAPPACK_INFO]);
         return;
       }
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -228,7 +229,7 @@ export const setMapPackIndex = action("setMapPackIndex", async (mapPackIndex: Ma
     state.mapPackIndex[key] = mapPackIndex[key];
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
-})
+});
 
 export const setDatapackIndex = action("setDatapackIndex", async (datapackIndex: DatapackIndex) => {
   // This is to prevent the UI from lagging
@@ -237,7 +238,7 @@ export const setDatapackIndex = action("setDatapackIndex", async (datapackIndex:
     state.datapackIndex[key] = datapackIndex[key];
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
-})
+});
 
 export const loadIndexResponse = action("loadIndexResponse", async (response: IndexResponse) => {
   setDatapackIndex(response.datapackIndex);

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -293,7 +293,7 @@ export const setDatapackConfig = action(
           const columnsToAdd = newUnitChart.children.slice(1);
           existingUnitColumnInfo.children = existingUnitColumnInfo.children.concat(columnsToAdd);
         } else {
-          if ((datapackParsingPack.topAge && datapackParsingPack.baseAge) || datapackParsingPack.verticalScale) foundDefaultAge = true;
+          if (((datapackParsingPack.topAge || datapackParsingPack.topAge === 0) && (datapackParsingPack.baseAge || datapackParsingPack.baseAge === 0)) || datapackParsingPack.verticalScale) foundDefaultAge = true;
           unitMap.set(datapackParsingPack.ageUnits, datapackParsingPack.columnInfo);
         }
         const mapPack = state.mapPackIndex[datapack]!;

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -293,7 +293,7 @@ export const setDatapackConfig = action(
           const columnsToAdd = newUnitChart.children.slice(1);
           existingUnitColumnInfo.children = existingUnitColumnInfo.children.concat(columnsToAdd);
         } else {
-          if (datapackParsingPack.topAge && datapackParsingPack.baseAge) foundDefaultAge = true;
+          if ((datapackParsingPack.topAge && datapackParsingPack.baseAge) || datapackParsingPack.verticalScale) foundDefaultAge = true;
           unitMap.set(datapackParsingPack.ageUnits, datapackParsingPack.columnInfo);
         }
         const mapPack = state.mapPackIndex[datapack]!;

--- a/app/src/state/actions/generate-chart-actions.ts
+++ b/app/src/state/actions/generate-chart-actions.ts
@@ -52,7 +52,6 @@ function setDatapackTimeDefaults() {
 
   // apply the combined values to the settings
   for (const [unit, values] of unitMap) {
-    const timeSettings = state.settings.timeSettings[unit];
     if (values.topStageAge !== Number.MAX_SAFE_INTEGER && values.baseStageAge !== Number.MIN_SAFE_INTEGER) {
       generalActions.setBaseStageAge(values.baseStageAge, unit);
       generalActions.setTopStageAge(values.topStageAge, unit);

--- a/app/src/state/actions/generate-chart-actions.ts
+++ b/app/src/state/actions/generate-chart-actions.ts
@@ -43,7 +43,7 @@ function setDatapackTimeDefaults() {
       });
     }
     const unitValues = unitMap.get(pack.ageUnits)!;
-    if (pack.topAge && pack.baseAge) {
+    if ((pack.topAge || pack.topAge === 0) && (pack.baseAge || pack.baseAge === 0)) {
       timeSettings.topStageAge = Math.min(unitValues.topStageAge, pack.topAge);
       timeSettings.baseStageAge = Math.max(unitValues.baseStageAge, pack.baseAge);
     }

--- a/app/src/state/actions/generate-chart-actions.ts
+++ b/app/src/state/actions/generate-chart-actions.ts
@@ -195,7 +195,9 @@ function changeManuallyAddedColumns(column: ColumnInfo) {
 function normalizeColumnProperties(column: ColumnInfo) {
   if (column.width !== undefined && (isNaN(column.width) || column.width < 20)) {
     column.width = 20;
-    pushSnackbar("Invalid width input found, updating column width to 20", "warning");
+    let name = column.name.substring(0, 17);
+    if (name.length < column.name.length) name += "...";
+    pushSnackbar("Invalid width input found, updating " + name + " width to 20", "warning");
   }
   for (const child of column.children) {
     normalizeColumnProperties(child);

--- a/app/src/state/actions/generate-chart-actions.ts
+++ b/app/src/state/actions/generate-chart-actions.ts
@@ -44,8 +44,8 @@ function setDatapackTimeDefaults() {
     }
     const unitValues = unitMap.get(pack.ageUnits)!;
     if ((pack.topAge || pack.topAge === 0) && (pack.baseAge || pack.baseAge === 0)) {
-      timeSettings.topStageAge = Math.min(unitValues.topStageAge, pack.topAge);
-      timeSettings.baseStageAge = Math.max(unitValues.baseStageAge, pack.baseAge);
+      unitValues.topStageAge = Math.min(unitValues.topStageAge, pack.topAge);
+      unitValues.baseStageAge = Math.max(unitValues.baseStageAge, pack.baseAge);
     }
     if (pack.verticalScale) unitValues.verticalScale = Math.max(unitValues.verticalScale, pack.verticalScale);
   }
@@ -54,23 +54,30 @@ function setDatapackTimeDefaults() {
   for (const [unit, values] of unitMap) {
     const timeSettings = state.settings.timeSettings[unit];
     if (values.topStageAge !== Number.MAX_SAFE_INTEGER && values.baseStageAge !== Number.MIN_SAFE_INTEGER) {
-      timeSettings.topStageAge = values.topStageAge;
-      timeSettings.baseStageAge = values.baseStageAge;
+      generalActions.setBaseStageAge(values.baseStageAge, unit);
+      generalActions.setTopStageAge(values.topStageAge, unit);
     }
     if (values.verticalScale !== Number.MIN_SAFE_INTEGER) {
-      timeSettings.unitsPerMY = values.verticalScale;
+      generalActions.setUnitsPerMY(values.verticalScale, unit);
     }
   }
 }
 
 // Shows the user a popup before chart generation if there are age spans on the datapack
-export const initiateChartGeneration = action("initiateChartGeneration", (navigate: NavigateFunction) => {
-  if (state.settings.datapackContainsSuggAge) {
-    state.showSuggestedAgePopup = true;
-  } else {
-    fetchChartFromServer(navigate);
+// only pops up if they are in the configure datapacks page, or not in the settings page
+export const initiateChartGeneration = action(
+  "initiateChartGeneration",
+  (navigate: NavigateFunction, location: string) => {
+    if (
+      state.settings.datapackContainsSuggAge &&
+      ((location === "/settings" && state.settingsTabs.selected === "datapacks") || location !== "/settings")
+    ) {
+      state.showSuggestedAgePopup = true;
+    } else {
+      fetchChartFromServer(navigate);
+    }
   }
-});
+);
 
 function areSettingsValidForGeneration() {
   if (!state.config.datapacks || state.config.datapacks.length === 0 || !state.settingsTabs.columns) {

--- a/app/src/state/initialize.ts
+++ b/app/src/state/initialize.ts
@@ -4,7 +4,8 @@ export async function initialize() {
   // If we're running in dev mode (yarn dev), then the app is not served from the same URL
   // as the server hosts the /charts endpoint.  So, we'll hard-code that for ourselves here.
   actions.sessionCheck();
-  actions.fetchDatapackInfo();
+  actions.fetchDatapackIndex();
+  actions.fetchMapPackIndex();
   actions.fetchPresets();
   actions.setDatapackConfig([], "");
   actions.fetchFaciesPatterns();

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -22,6 +22,7 @@ export enum ErrorCodes {
   NO_DATAPACKS_SELECTED = "NO_DATAPACKS_SELECTED",
   NO_COLUMNS_SELECTED = "NO_COLUMNS_SELECTED",
   UNIT_RANGE_EMPTY = "UNIT_RANGE_EMPTY",
+  INVALID_MAPPACK_INFO = "INVALID_MAPPACK_INFO",
   UNABLE_TO_LOGIN_SERVER = "UNABLE_TO_LOGIN_SERVER",
   UNABLE_TO_LOGIN_USERNAME_OR_PASSWORD = "UNABLE_TO_LOGIN_USERNAME_OR_PASSWORD",
   UNABLE_TO_LOGIN_GOOGLE_CREDENTIAL = "UNABLE_TO_LOGIN_GOOGLE_CREDENTIAL",
@@ -63,6 +64,8 @@ export const ErrorMessages = {
   [ErrorCodes.DATAPACK_ALREADY_EXISTS]: "Datapack already exists. Please upload a new datapack file.",
   [ErrorCodes.NO_DATAPACKS_SELECTED]: "No datapacks selected. Please select at least one datapack to generate.",
   [ErrorCodes.NO_COLUMNS_SELECTED]: "No columns selected. Please select at least one column to generate.",
+  [ErrorCodes.UNIT_RANGE_EMPTY]: "Unit range is empty. Please enter a valid unit range.",
+  [ErrorCodes.INVALID_MAPPACK_INFO]: "Invalid mappack info received from server. Please try again later."
   [ErrorCodes.UNIT_RANGE_EMPTY]: "Unit range is empty. Please enter a valid unit range.",
   [ErrorCodes.UNABLE_TO_LOGIN_SERVER]: "Unable to login due to server error. Please try again later.",
   [ErrorCodes.UNABLE_TO_LOGIN_GOOGLE_CREDENTIAL]: "Unable to login with Google credentials. Please try again.",

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -65,8 +65,7 @@ export const ErrorMessages = {
   [ErrorCodes.NO_DATAPACKS_SELECTED]: "No datapacks selected. Please select at least one datapack to generate.",
   [ErrorCodes.NO_COLUMNS_SELECTED]: "No columns selected. Please select at least one column to generate.",
   [ErrorCodes.UNIT_RANGE_EMPTY]: "Unit range is empty. Please enter a valid unit range.",
-  [ErrorCodes.INVALID_MAPPACK_INFO]: "Invalid mappack info received from server. Please try again later."
-  [ErrorCodes.UNIT_RANGE_EMPTY]: "Unit range is empty. Please enter a valid unit range.",
+  [ErrorCodes.INVALID_MAPPACK_INFO]: "Invalid mappack info received from server. Please try again later.",
   [ErrorCodes.UNABLE_TO_LOGIN_SERVER]: "Unable to login due to server error. Please try again later.",
   [ErrorCodes.UNABLE_TO_LOGIN_GOOGLE_CREDENTIAL]: "Unable to login with Google credentials. Please try again.",
   [ErrorCodes.UNABLE_TO_LOGIN_USERNAME_OR_PASSWORD]: "Invalid username or password. Please try again.",

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -415,7 +415,9 @@
       "datapackAgeInfo": {
         "datapackContainsSuggAge": false
       },
-      "ageUnits": "Ma"
+      "ageUnits": "Ma",
+      "defaultChronostrat": "UNESCO",
+      "formatVersion": 1.5
     },
     "general-parse-datapacks-test-2-key": {
       "columnInfo": {
@@ -1126,7 +1128,10 @@
         "topAge": 0,
         "bottomAge": 5
       },
-      "ageUnits": "Ma"
+      "ageUnits": "Ma",
+      "defaultChronostrat": "UNESCO",
+      "formatVersion": 1.5,
+      "verticalScale": 6
     },
     "column-types-facies-key": {
         "FaciesOne": {
@@ -2004,6 +2009,8 @@
             "datapackAgeInfo": {
               "datapackContainsSuggAge": false
             },
-            "ageUnits": "Ma"
+            "ageUnits": "Ma",
+            "defaultChronostrat": "UNESCO",
+            "formatVersion": 1.5
     }
 }

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -1129,9 +1129,10 @@
         "bottomAge": 5
       },
       "ageUnits": "Ma",
-      "defaultChronostrat": "UNESCO",
-      "formatVersion": 1.5,
-      "verticalScale": 6
+      "defaultChronostrat": "USGS",
+      "formatVersion": 1,
+      "verticalScale": 6,
+      "date": "2015-03-15"
     },
     "column-types-facies-key": {
         "FaciesOne": {

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -412,9 +412,6 @@
         "units": "Ma",
         "columnDisplayType": "RootColumn"
       },
-      "datapackAgeInfo": {
-        "datapackContainsSuggAge": false
-      },
       "ageUnits": "Ma",
       "defaultChronostrat": "UNESCO",
       "formatVersion": 1.5
@@ -1123,11 +1120,8 @@
         "units": "Ma",
         "columnDisplayType": "RootColumn"
       },
-      "datapackAgeInfo": {
-        "datapackContainsSuggAge": true,
-        "topAge": 0,
-        "bottomAge": 5
-      },
+      "topAge": 0,
+      "baseAge": 5,
       "ageUnits": "Ma",
       "defaultChronostrat": "USGS",
       "formatVersion": 1,
@@ -2006,9 +2000,6 @@
               "maxAge": -99999,
               "units": "Ma",
               "columnDisplayType": "RootColumn"
-            },
-            "datapackAgeInfo": {
-              "datapackContainsSuggAge": false
             },
             "ageUnits": "Ma",
             "defaultChronostrat": "UNESCO",

--- a/server/__tests__/__data__/parse-datapacks-test-2.txt
+++ b/server/__tests__/__data__/parse-datapacks-test-2.txt
@@ -2,6 +2,9 @@ age units:	Ma
 SetTop:	0
 SetBase:	5
 SetScale:	6
+date:	15/03/2015
+format version:	1.0
+default chronostrat:	USGS
 
 Parent 1	:	Block	Facies	Event	Range	Chron	Point	Sequence	Freehand	Blank	Transect
 

--- a/server/__tests__/parse-datapacks.test.ts
+++ b/server/__tests__/parse-datapacks.test.ts
@@ -17,6 +17,7 @@ jest.mock("@tsconline/shared", () => ({
   assertSubFaciesInfo: jest.fn().mockImplementation(() => true),
   assertSubBlockInfo: jest.fn().mockImplementation(() => true),
   assertSubRangeInfo: jest.fn().mockImplementation(() => true),
+  assertDatapackParsingPack: jest.fn().mockReturnValue(true),
   assertRGB: jest.fn().mockImplementation((o) => {
     if (!o || typeof o !== "object") throw new Error("RGB must be a non-null object");
     if (typeof o.r !== "number") throw new Error("Invalid rgb");

--- a/server/__tests__/parse-datapacks.test.ts
+++ b/server/__tests__/parse-datapacks.test.ts
@@ -51,7 +51,6 @@ import { readFileSync } from "fs";
 import {
   Block,
   Range,
-  DatapackAgeInfo,
   Facies,
   Event,
   Chron,
@@ -658,10 +657,9 @@ describe("getColumnTypes tests", () => {
 });
 
 describe("getAllEntries tests", () => {
-  let entriesMap: Map<string, ParsedColumnEntry>, datapackAgeInfo: DatapackAgeInfo, isChild: Set<string>;
+  let entriesMap: Map<string, ParsedColumnEntry>, isChild: Set<string>;
   beforeEach(() => {
     entriesMap = new Map<string, ParsedColumnEntry>();
-    datapackAgeInfo = { datapackContainsSuggAge: false };
     isChild = new Set<string>();
   });
 
@@ -670,7 +668,7 @@ describe("getAllEntries tests", () => {
    */
   it("should create correct basic entries map", async () => {
     const file = "server/__tests__/__data__/get-all-entries-test-1.txt";
-    await getAllEntries(file, entriesMap, isChild, datapackAgeInfo);
+    await getAllEntries(file, entriesMap, isChild);
     const expectedEntriesMap = new Map<string, ParsedColumnEntry>();
     expectedEntriesMap.set("Parent 1", {
       children: ["Child 11", "Child 12"],
@@ -692,7 +690,7 @@ describe("getAllEntries tests", () => {
    */
   it("should create correct entries map with meta and title", async () => {
     const file = "server/__tests__/__data__/get-all-entries-test-2.txt";
-    await getAllEntries(file, entriesMap, isChild, datapackAgeInfo);
+    await getAllEntries(file, entriesMap, isChild);
     const expectedEntriesMap = new Map<string, ParsedColumnEntry>();
     expectedEntriesMap.set("Parent 1", {
       children: ["Child 11", "Child 12"],
@@ -715,7 +713,7 @@ describe("getAllEntries tests", () => {
    */
   it("should create correct entries map with meta and title and info", async () => {
     const file = "server/__tests__/__data__/get-all-entries-test-3.txt";
-    await getAllEntries(file, entriesMap, isChild, datapackAgeInfo);
+    await getAllEntries(file, entriesMap, isChild);
     const expectedEntriesMap = new Map<string, ParsedColumnEntry>();
     expectedEntriesMap.set("Parent 1", {
       children: ["Child 11", "Child 12"],
@@ -739,22 +737,11 @@ describe("getAllEntries tests", () => {
   });
 
   /**
-   * Simply checks for the correct creation of the datapackAgeInfo object
-   * Given SetTopAge and SetBaseAge headers
-   */
-  it("should create correct datapackAgeInfo", async () => {
-    const file = "server/__tests__/__data__/get-all-entries-test-4.txt";
-    await getAllEntries(file, entriesMap, isChild, datapackAgeInfo);
-    const correctDatapackInfo = { datapackContainsSuggAge: true, topAge: 100, bottomAge: 200 };
-    expect(datapackAgeInfo).toEqual(correctDatapackInfo);
-  });
-
-  /**
    * Bad file should not initialize maps
    */
   it("should not initialize maps on bad file", async () => {
     const file = "server/__tests__/__data__/bad-data.txt";
-    await getAllEntries(file, entriesMap, isChild, datapackAgeInfo);
+    await getAllEntries(file, entriesMap, isChild);
     expect(entriesMap.size).toBe(0);
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -142,6 +142,9 @@ server.post("/upload", routes.uploadDatapack);
 //fetches json object of requested settings file
 server.get<{ Params: { file: string } }>("/settingsXml/:file", routes.fetchSettingsXml);
 
+server.get("/datapack-index", routes.fetchServerDatapackInfo);
+server.get("/map-pack-index", routes.fetchServerMapPackInfo);
+
 server.get("/datapackinfoindex", (_request, reply) => {
   if (!datapackIndex || !mapPackIndex) {
     reply.send({ error: "datapackIndex/mapPackIndex is null" });

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -65,7 +65,6 @@ type FaciesFoundAndAgeRange = {
 };
 /**
  * parses the METACOLUMN and info of the children string
- * TODO: add TITLEOFF
  * @param array the children string to parse
  * @returns the correctly parsed children string array
  */

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -145,7 +145,7 @@ export async function parseDatapacks(file: string, decryptFilePath: string): Pro
   let chartTitle = "Chart Title";
   let ageUnits = "Ma";
   let defaultChronostrat = "UNESCO"
-  let date: Date | null = null
+  let date: string | null = null
   let verticalScale: number | null = null
   let formatVersion = 1.5;
   try {
@@ -285,7 +285,7 @@ export async function getAllEntries(
   const readline = createInterface({ input: fileStream, crlfDelay: Infinity });
   let topAge: number | null = null;
   let bottomAge: number | null = null;
-  let date: Date | null = null;
+  let date: string | null = null;
   let ageUnits: string = "Ma";
   let chartTitle: string = "Chart Title";
   let defaultChronostrat = "UNESCO";
@@ -321,7 +321,7 @@ export async function getAllEntries(
           break
         case "date:":
           if (/^\d{2}\/\d{2}\/\d{4}$/.test(value)) value = value.split('/').reverse().join('-')
-          date = new Date(value)
+          date = new Date(value).toISOString().split('T')[0] || null
           break
         case "format version:":
           formatVersion = Number(value.trim())

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -266,8 +266,8 @@ export async function parseDatapacks(file: string, decryptFilePath: string): Pro
   const datapackParsingPack = { columnInfo: chartColumn, ageUnits, defaultChronostrat, formatVersion };
   assertDatapackParsingPack(datapackParsingPack);
   if (date) datapackParsingPack.date = date;
-  if (topAge) datapackParsingPack.topAge = topAge;
-  if (baseAge) datapackParsingPack.baseAge = baseAge;
+  if (topAge || topAge === 0) datapackParsingPack.topAge = topAge;
+  if (baseAge || baseAge === 0) datapackParsingPack.baseAge = baseAge;
   if (verticalScale) datapackParsingPack.verticalScale = verticalScale;
   return datapackParsingPack;
 }
@@ -303,10 +303,10 @@ export async function getAllEntries(
     if (value) {
       switch (split[0]) {
         case "SetTop:":
-          if (!isNaN(Number(value))) top = Number(value);
+          if (!isNaN(Number(value.trim()))) top = Number(value);
           break;
         case "SetBase:":
-          if (!isNaN(Number(value))) base = Number(value);
+          if (!isNaN(Number(value.trim()))) base = Number(value);
           break;
         case "chart title:":
           chartTitle = value.trim();

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -144,19 +144,24 @@ export async function parseDatapacks(file: string, decryptFilePath: string): Pro
   };
   let chartTitle = "Chart Title";
   let ageUnits = "Ma";
-  let defaultChronostrat = "UNESCO"
-  let date: string | null = null
-  let verticalScale: number | null = null
+  let defaultChronostrat = "UNESCO";
+  let date: string | null = null;
+  let verticalScale: number | null = null;
   let formatVersion = 1.5;
   try {
     for (const decryptPath of decryptPaths) {
-      const { units, title, chronostrat, datapackDate, vertScale, version } = await getAllEntries(decryptPath, allEntries, isChild, datapackAgeInfo);
+      const { units, title, chronostrat, datapackDate, vertScale, version } = await getAllEntries(
+        decryptPath,
+        allEntries,
+        isChild,
+        datapackAgeInfo
+      );
       ageUnits = units;
       chartTitle = title;
-      defaultChronostrat = chronostrat
-      if (datapackDate) date = datapackDate
-      if (vertScale) verticalScale = vertScale
-      if (version) formatVersion = version
+      defaultChronostrat = chronostrat;
+      if (datapackDate) date = datapackDate;
+      if (vertScale) verticalScale = vertScale;
+      if (version) formatVersion = version;
       const allParsedEntries = Array.from(allEntries.keys()).concat(Array.from(isChild));
       await getColumnTypes(
         decryptPath,
@@ -261,10 +266,10 @@ export async function parseDatapacks(file: string, decryptFilePath: string): Pro
     columnDisplayType: "RootColumn"
   };
   const datapackParsingPack = { columnInfo: chartColumn, datapackAgeInfo, ageUnits, defaultChronostrat, formatVersion };
-  assertDatapackParsingPack(datapackParsingPack)
-  if (date) datapackParsingPack.date = date
-  if (verticalScale) datapackParsingPack.verticalScale = verticalScale
-  return datapackParsingPack
+  assertDatapackParsingPack(datapackParsingPack);
+  if (date) datapackParsingPack.date = date;
+  if (verticalScale) datapackParsingPack.verticalScale = verticalScale;
+  return datapackParsingPack;
 }
 /**
  * This will populate a mapping of all parents : childen[]
@@ -294,47 +299,47 @@ export async function getAllEntries(
   for await (const line of readline) {
     if (!line) continue;
     // grab any datapack properties
-    const split = line.split("\t")
-    let value = split[1]
+    const split = line.split("\t");
+    let value = split[1];
     if (value) {
       switch (split[0]) {
         case "SetTop:":
-          const parsedTopAge = Number(value)
-          if (!isNaN(parsedTopAge)) topAge = parsedTopAge
-          break
+          if (!isNaN(Number(value))) topAge = Number(value);
+          break;
         case "SetBase:":
-          const parsedBaseAge = Number(value)
-          if (!isNaN(parsedBaseAge)) bottomAge = parsedBaseAge
-          break
+          if (!isNaN(Number(value))) bottomAge = Number(value);
+          break;
         case "chart title:":
-          chartTitle = value.trim()
-          break
+          chartTitle = value.trim();
+          break;
         case "age units:":
-          ageUnits = value.trim()
-          break
+          ageUnits = value.trim();
+          break;
         case "default chronostrat:":
           if (!/^(USGS|UNESCO)$/.test(value.trim())) {
-            console.error("Default chronostrat value in datapack is neither USGS nor UNESCO, setting to default UNESCO")
-            break
+            console.error(
+              "Default chronostrat value in datapack is neither USGS nor UNESCO, setting to default UNESCO"
+            );
+            break;
           }
-          defaultChronostrat = value.trim()
-          break
+          defaultChronostrat = value.trim();
+          break;
         case "date:":
-          if (/^\d{2}\/\d{2}\/\d{4}$/.test(value)) value = value.split('/').reverse().join('-')
-          date = new Date(value).toISOString().split('T')[0] || null
-          break
+          if (/^\d{2}\/\d{2}\/\d{4}$/.test(value)) value = value.split("/").reverse().join("-");
+          date = new Date(value).toISOString().split("T")[0] || null;
+          break;
         case "format version:":
-          formatVersion = Number(value.trim())
+          formatVersion = Number(value.trim());
           if (isNaN(formatVersion)) {
-            console.error("Format version is not a number, setting to default 1.5")
-            formatVersion = 1.5
+            console.error("Format version is not a number, setting to default 1.5");
+            formatVersion = 1.5;
           }
-          break
+          break;
         case "SetScale:":
-          vertScale = Number(value)
+          vertScale = Number(value);
           if (isNaN(vertScale)) {
-            console.error("Vertical scale is not a number, setting to default null")
-            vertScale = null
+            console.error("Vertical scale is not a number, setting to default null");
+            vertScale = null;
           }
           break;
       }
@@ -368,7 +373,14 @@ export async function getAllEntries(
     datapackAgeInfo.topAge = topAge;
     datapackAgeInfo.bottomAge = bottomAge;
   }
-  return { title: chartTitle, units: ageUnits, chronostrat: defaultChronostrat, datapackDate: date, vertScale, version: formatVersion };
+  return {
+    title: chartTitle,
+    units: ageUnits,
+    chronostrat: defaultChronostrat,
+    datapackDate: date,
+    vertScale,
+    version: formatVersion
+  };
 }
 /**
  * This function will populate the maps with the parsed entries in the filename

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -91,7 +91,6 @@ export const fetchServerMapPackInfo = async function fetchServerMapPackInfo(
   reply.status(200).send(mapPackInfoChunk);
 };
 
-
 export const fetchUserDatapacks = async function fetchUserDatapacks(request: FastifyRequest, reply: FastifyReply) {
   const uuid = request.session.get("uuid");
   if (!uuid) {

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -304,7 +304,7 @@ export const fetchChart = async function fetchChart(request: FastifyRequest, rep
     });
     return;
   }
-  const { useCache, useSuggestedAge } = chartrequest;
+  const { useCache } = chartrequest;
   const uuid = request.session.get("uuid");
   const settingsXml = chartrequest.settings;
   // Compute the paths: chart directory, chart file, settings file, and URL equivalent for chart
@@ -380,7 +380,7 @@ export const fetchChart = async function fetchChart(request: FastifyRequest, rep
     // Tell it where to save chart
     `-o ${chartFilePath} ` +
     // Don't use datapacks suggested age (if useSuggestedAge is true then ignore datapack ages)
-    `${!useSuggestedAge ? "-a" : ""}`;
+    `-a`;
 
   // Exec Java command and send final reply to browser
   await new Promise<void>((resolve) => {

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -51,7 +51,7 @@ export const fetchServerDatapackInfo = async function fetchServerDatapackInfo(
     }
     chunk[key] = serverDatapackindex[key]!;
   }
-  if (!chunk) {
+  if (Object.keys(chunk).length === 0) {
     reply.status(404).send({ error: "No datapacks found" });
     return;
   }
@@ -83,7 +83,7 @@ export const fetchServerMapPackInfo = async function fetchServerMapPackInfo(
     }
     chunk[key] = serverMapPackIndex[key]!;
   }
-  if (!chunk) {
+  if (Object.keys(chunk).length === 0) {
     reply.status(404).send({ error: "No map packs found" });
     return;
   }

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -28,7 +28,7 @@ import { datapackIndex as serverDatapackindex, mapPackIndex as serverMapPackInde
 import { glob } from "glob";
 
 export const fetchServerDatapackInfo = async function fetchServerDatapackInfo(
-  request: FastifyRequest<{ Querystring: { start?: string; increment?: string }}>,
+  request: FastifyRequest<{ Querystring: { start?: string; increment?: string } }>,
   reply: FastifyReply
 ) {
   const { start = 0, increment = 1 } = request.query;
@@ -57,10 +57,10 @@ export const fetchServerDatapackInfo = async function fetchServerDatapackInfo(
   }
   const datapackInfoChunk: DatapackInfoChunk = { datapackIndex: chunk!, totalChunks: allDatapackKeys.length };
   reply.status(200).send(datapackInfoChunk);
-}
+};
 
 export const fetchServerMapPackInfo = async function fetchServerMapPackInfo(
-  request: FastifyRequest<{ Querystring: { start?: number; increment?: number }}>,
+  request: FastifyRequest<{ Querystring: { start?: number; increment?: number } }>,
   reply: FastifyReply
 ) {
   const { start = 0, increment = 1 } = request.query;
@@ -87,9 +87,9 @@ export const fetchServerMapPackInfo = async function fetchServerMapPackInfo(
     reply.status(404).send({ error: "No map packs found" });
     return;
   }
-  const mapPackInfoChunk: MapPackInfoChunk = { mapPackIndex: chunk!, totalChunks: allMapPackKeys.length};
+  const mapPackInfoChunk: MapPackInfoChunk = { mapPackIndex: chunk!, totalChunks: allMapPackKeys.length };
   reply.status(200).send(mapPackInfoChunk);
-}
+};
 
 
 export const fetchUserDatapacks = async function fetchUserDatapacks(request: FastifyRequest, reply: FastifyReply) {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,5 +1,6 @@
 // Shared types between app and server (i.e. messages they send back and forth)
 
+import { isDate } from "util/types";
 import { defaultFontsInfoConstant } from "./constants.js";
 
 export * from "./constants.js";
@@ -16,6 +17,10 @@ export type DatapackParsingPack = {
   columnInfo: ColumnInfo;
   datapackAgeInfo: DatapackAgeInfo;
   ageUnits: string;
+  defaultChronostrat: "USGS" | "UNESCO";
+  formatVersion?: number;
+  date?: Date;
+  verticalScale?: number;
 };
 
 export type IndexResponse = {
@@ -618,6 +623,11 @@ export function assertFacies(o: any): asserts o is Facies {
 export function assertDatapackParsingPack(o: any): asserts o is DatapackParsingPack {
   if (!o || typeof o !== "object") throw new Error("DatapackParsingPack must be a non-null object");
   if (typeof o.ageUnits !== "string") throwError("DatapackParsingPack", "ageUnits", "string", o.ageUnits);
+  if (typeof o.defaultChronostrat !== "string") throwError("DatapackParsingPack", "defaultChronostrat", "string", o.defaultChronostrat);
+  if (!/^(USGS|UNESCO)$/.test(o.defaultChronostrat)) throwError("DatapackParsingPack", "defaultChronostrat", "USGS | UNESCO", o.defaultChronostrat);
+  if ("formatVersion" in o && typeof o.formatVersion !== "number") throwError("DatapackParsingPack", "formatVersion", "number", o.formatVersion);
+  if ("verticalScale" in o && typeof o.verticalScale !== "number") throwError("DatapackParsingPack", "verticalScale", "number", o.verticalScale);
+  if ("date" in o && !isDate(o.date)) throwError("DatapackParsingPack", "date", "Date", o.date);
   assertColumnInfo(o.columnInfo);
   assertDatapackAgeInfo(o.datapackAgeInfo);
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -622,12 +622,17 @@ export function assertFacies(o: any): asserts o is Facies {
 export function assertDatapackParsingPack(o: any): asserts o is DatapackParsingPack {
   if (!o || typeof o !== "object") throw new Error("DatapackParsingPack must be a non-null object");
   if (typeof o.ageUnits !== "string") throwError("DatapackParsingPack", "ageUnits", "string", o.ageUnits);
-  if (typeof o.defaultChronostrat !== "string") throwError("DatapackParsingPack", "defaultChronostrat", "string", o.defaultChronostrat);
-  if (!/^(USGS|UNESCO)$/.test(o.defaultChronostrat)) throwError("DatapackParsingPack", "defaultChronostrat", "USGS | UNESCO", o.defaultChronostrat);
-  if (typeof o.formatVersion !== "number") throwError("DatapackParsingPack", "formatVersion", "number", o.formatVersion);
-  if ("verticalScale" in o && typeof o.verticalScale !== "number") throwError("DatapackParsingPack", "verticalScale", "number", o.verticalScale);
+  if (typeof o.defaultChronostrat !== "string")
+    throwError("DatapackParsingPack", "defaultChronostrat", "string", o.defaultChronostrat);
+  if (!/^(USGS|UNESCO)$/.test(o.defaultChronostrat))
+    throwError("DatapackParsingPack", "defaultChronostrat", "USGS | UNESCO", o.defaultChronostrat);
+  if (typeof o.formatVersion !== "number")
+    throwError("DatapackParsingPack", "formatVersion", "number", o.formatVersion);
+  if ("verticalScale" in o && typeof o.verticalScale !== "number")
+    throwError("DatapackParsingPack", "verticalScale", "number", o.verticalScale);
   if ("date" in o && typeof o.date !== "string") throwError("DatapackParsingPack", "date", "string", o.date);
-  if ("date" in o && !/^(\d{4}-\d{2}-\d{2})$/.test(o.date)) throwError("DatapackParsingPack", "date", "YYYY-MM-DD", o.date);
+  if ("date" in o && !/^(\d{4}-\d{2}-\d{2})$/.test(o.date))
+    throwError("DatapackParsingPack", "date", "YYYY-MM-DD", o.date);
   assertColumnInfo(o.columnInfo);
   assertDatapackAgeInfo(o.datapackAgeInfo);
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,6 +1,5 @@
 // Shared types between app and server (i.e. messages they send back and forth)
 
-import { isDate } from "util/types";
 import { defaultFontsInfoConstant } from "./constants.js";
 
 export * from "./constants.js";
@@ -18,7 +17,7 @@ export type DatapackParsingPack = {
   datapackAgeInfo: DatapackAgeInfo;
   ageUnits: string;
   defaultChronostrat: "USGS" | "UNESCO";
-  formatVersion?: number;
+  formatVersion: number;
   date?: Date;
   verticalScale?: number;
 };
@@ -625,9 +624,9 @@ export function assertDatapackParsingPack(o: any): asserts o is DatapackParsingP
   if (typeof o.ageUnits !== "string") throwError("DatapackParsingPack", "ageUnits", "string", o.ageUnits);
   if (typeof o.defaultChronostrat !== "string") throwError("DatapackParsingPack", "defaultChronostrat", "string", o.defaultChronostrat);
   if (!/^(USGS|UNESCO)$/.test(o.defaultChronostrat)) throwError("DatapackParsingPack", "defaultChronostrat", "USGS | UNESCO", o.defaultChronostrat);
-  if ("formatVersion" in o && typeof o.formatVersion !== "number") throwError("DatapackParsingPack", "formatVersion", "number", o.formatVersion);
+  if (typeof o.formatVersion !== "number") throwError("DatapackParsingPack", "formatVersion", "number", o.formatVersion);
   if ("verticalScale" in o && typeof o.verticalScale !== "number") throwError("DatapackParsingPack", "verticalScale", "number", o.verticalScale);
-  if ("date" in o && !isDate(o.date)) throwError("DatapackParsingPack", "date", "Date", o.date);
+  if ("date" in o && !(o.date instanceof Date)) throwError("DatapackParsingPack", "date", "Date", o.date);
   assertColumnInfo(o.columnInfo);
   assertDatapackAgeInfo(o.datapackAgeInfo);
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -10,6 +10,15 @@ export type SuccessfulServerResponse = {
   message: string;
 };
 
+export type DatapackInfoChunk = {
+  datapackIndex: DatapackIndex;
+  totalChunks: number;
+}
+export type MapPackInfoChunk = {
+  mapPackIndex: MapPackIndex;
+  totalChunks: number;
+}
+
 export type ServerResponse = SuccessfulServerResponse | ServerResponseError;
 
 export type DatapackParsingPack = {
@@ -400,6 +409,18 @@ export function assertTransect(o: any): asserts o is Transect {
   for (const subTransect of o.subTransectInfo) {
     assertSubTransectInfo(subTransect);
   }
+}
+
+export function assertMapPackInfoChunk(o: any): asserts o is MapPackInfoChunk {
+  if (!o || typeof o !== "object") throw new Error("MapPackInfoChunk must be a non-null object");
+  if (typeof o.totalChunks !== "number") throwError("MapPackInfoChunk", "totalChunks", "number", o.totalChunks);
+  assertMapPackIndex(o.mapPackIndex);
+}
+
+export function assertDatapackInfoChunk(o: any): asserts o is DatapackInfoChunk {
+  if (!o || typeof o !== "object") throw new Error("DatapackInfoChunk must be a non-null object");
+  if (typeof o.totalChunks !== "number") throwError("DatapackInfoChunk", "totalChunks", "number", o.totalChunks);
+  assertDatapackIndex(o.datapackIndex);
 }
 
 export function assertSubFreehandInfo(o: any): asserts o is SubFreehandInfo {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -13,11 +13,11 @@ export type SuccessfulServerResponse = {
 export type DatapackInfoChunk = {
   datapackIndex: DatapackIndex;
   totalChunks: number;
-}
+};
 export type MapPackInfoChunk = {
   mapPackIndex: MapPackIndex;
   totalChunks: number;
-}
+};
 
 export type ServerResponse = SuccessfulServerResponse | ServerResponseError;
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -130,7 +130,6 @@ export type ChartRequest = {
   settings: string; // JSON string representing the settings file you want to use to make a chart
   datapacks: string[]; // active datapacks to be used on chart
   useCache: boolean; // whether to use the cache or not
-  useSuggestedAge: boolean; // whether to use the suggested age or not
 };
 
 export type ServerResponseError = {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -14,10 +14,11 @@ export type ServerResponse = SuccessfulServerResponse | ServerResponseError;
 
 export type DatapackParsingPack = {
   columnInfo: ColumnInfo;
-  datapackAgeInfo: DatapackAgeInfo;
   ageUnits: string;
   defaultChronostrat: "USGS" | "UNESCO";
   formatVersion: number;
+  topAge?: number;
+  baseAge?: number;
   date?: string;
   verticalScale?: number;
 };
@@ -59,12 +60,6 @@ export type RGB = {
 };
 export type Presets = {
   [type: string]: ChartConfig[];
-};
-
-export type DatapackAgeInfo = {
-  datapackContainsSuggAge: boolean; //Default Age is not age located in datapack. Should be false if age exists, otherwise true.
-  topAge?: number;
-  bottomAge?: number;
 };
 
 export type ColumnHeaderProps = {
@@ -582,16 +577,6 @@ export function assertDatapack(o: any): asserts o is Datapack {
   if (typeof o.file !== "string") throw new Error("Datapack must have a field file of type string");
 }
 
-export function assertDatapackAgeInfo(o: any): asserts o is DatapackAgeInfo {
-  if (typeof o !== "object") throw new Error("DatapackAgeInfo must be an object");
-  if (typeof o.datapackContainsSuggAge !== "boolean")
-    throwError("DatapackAgeInfo", "datapackContainsSuggAge", "boolean", o.datapackContainsSuggAge);
-  if (o.datapackContainsSuggAge) {
-    if (typeof o.bottomAge !== "number") throwError("DatapackAgeInfo", "bottomAge", "number", o.bottomAge);
-    if (typeof o.topAge !== "number") throwError("DatapackAgeInfo", "topAge", "number", o.topAge);
-  }
-}
-
 export function assertSubBlockInfo(o: any): asserts o is SubBlockInfo {
   if (!o || typeof o !== "object") throw new Error("SubBlockInfo must be a non-null object");
   if (typeof o.label !== "string") throwError("SubBlockInfo", "label", "string", o.label);
@@ -633,8 +618,10 @@ export function assertDatapackParsingPack(o: any): asserts o is DatapackParsingP
   if ("date" in o && typeof o.date !== "string") throwError("DatapackParsingPack", "date", "string", o.date);
   if ("date" in o && !/^(\d{4}-\d{2}-\d{2})$/.test(o.date))
     throwError("DatapackParsingPack", "date", "YYYY-MM-DD", o.date);
+  if ("topAge" in o && typeof o.topAge !== "number") throwError("DatapackParsingPack", "topAge", "number", o.topAge);
+  if ("baseAge" in o && typeof o.baseAge !== "number")
+    throwError("DatapackParsingPack", "baseAge", "number", o.baseAge);
   assertColumnInfo(o.columnInfo);
-  assertDatapackAgeInfo(o.datapackAgeInfo);
 }
 export function assertDatapackIndex(o: any): asserts o is DatapackIndex {
   if (!o || typeof o !== "object") throw new Error("DatapackIndex must be a non-null object");

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -18,7 +18,7 @@ export type DatapackParsingPack = {
   ageUnits: string;
   defaultChronostrat: "USGS" | "UNESCO";
   formatVersion: number;
-  date?: Date;
+  date?: string;
   verticalScale?: number;
 };
 
@@ -626,7 +626,8 @@ export function assertDatapackParsingPack(o: any): asserts o is DatapackParsingP
   if (!/^(USGS|UNESCO)$/.test(o.defaultChronostrat)) throwError("DatapackParsingPack", "defaultChronostrat", "USGS | UNESCO", o.defaultChronostrat);
   if (typeof o.formatVersion !== "number") throwError("DatapackParsingPack", "formatVersion", "number", o.formatVersion);
   if ("verticalScale" in o && typeof o.verticalScale !== "number") throwError("DatapackParsingPack", "verticalScale", "number", o.verticalScale);
-  if ("date" in o && !(o.date instanceof Date)) throwError("DatapackParsingPack", "date", "Date", o.date);
+  if ("date" in o && typeof o.date !== "string") throwError("DatapackParsingPack", "date", "string", o.date);
+  if ("date" in o && !/^(\d{4}-\d{2}-\d{2})$/.test(o.date)) throwError("DatapackParsingPack", "date", "YYYY-MM-DD", o.date);
   assertColumnInfo(o.columnInfo);
   assertDatapackAgeInfo(o.datapackAgeInfo);
 }


### PR DESCRIPTION
* Fixed default setting application on datapacks with different units
* Popup for default age only shows if not on the settings tab or on the settings tab with data pack tab selected
* Popup also includes vertical scale ( ask aaron if we want to include this in the popup directive? )
* Other properties are parsed in the data pack (vertical scale, date, etc)
* Deprecated the data pack age info to flatten the information for easier use
* Column background doesn’t show if not applicable
* Fixed dot text field padding in map points (issue opened up that the value in the text box can't be controlled from outside but that's a minor bug, functionality still works)
* Profiling for ui stalling due to fetching all datapacks from the server lead to an implementation of chunk loading during the fetch and setting of the variables. However, at the moment the chunk loading of the fetch is actually slower than the normal fetch (both use the chunk loading of the setting) I left both in just in case, but left the chunk loading in as a future proof method and because it `awaits` which would allow for the event loop to not be blocked and for the ui to hopefully not stall.