### PR TITLE
support for customization of data mining column on the front and backend and datamining range calculations

### DIFF
--- a/app/__tests__/data-mining.test.ts
+++ b/app/__tests__/data-mining.test.ts
@@ -57,6 +57,15 @@ describe("computeWindowStatistics tests", () => {
         { windowStart: 7, windowEnd: 10, value: 3 },
         { windowStart: 10, windowEnd: 10, value: 1 }
       ]
+    ],
+    [[-1, 0, 0, 0, 0, 0, 0, 0, 0, 0], 3, "rateOfChange", [{ windowStart: -1, windowEnd: 2, value: -1 }]],
+    [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 3, "rateOfChange", [{ windowStart: 0, windowEnd: 3, value: 0 }]],
+    [[], 3, "rateOfChange", []],
+    [
+      [-10, -10, -10, -10, -10, -10, -10, -10, -10, -10],
+      3,
+      "rateOfChange",
+      [{ windowStart: -10, windowEnd: -7, value: 0 }]
     ]
   ])("Computes %s %s %s %s correctly", (data, windowSize, stat, expected) => {
     assertDataMiningStatisticApproach(stat);
@@ -132,6 +141,26 @@ describe("computeWindowStatisticsForDataSet tests", () => {
         { windowStart: 7, windowEnd: 10, value: -0.5 },
         { windowStart: 10, windowEnd: 10, value: 0 }
       ]
+    ],
+    [
+      [
+        { age: 1, value: 0 },
+        { age: 2, value: 0 },
+        { age: 3, value: 0 }
+      ],
+      3,
+      "rateOfChange",
+      [{ windowStart: 1, windowEnd: 4, value: 0 }]
+    ],
+    [
+      [
+        { age: 1, value: 0 },
+        { age: 2, value: 0 },
+        { age: 3, value: -10 }
+      ],
+      3,
+      "rateOfChange",
+      [{ windowStart: 1, windowEnd: 4, value: 0 }]
     ]
   ])(`Computes %s %s %s correctly`, (data, windowSize, stat, expected) => {
     assertDataMiningStatisticApproach(stat);

--- a/app/__tests__/data-mining.test.ts
+++ b/app/__tests__/data-mining.test.ts
@@ -1,5 +1,5 @@
 import { assertDataMiningStatisticApproach } from "../src/types";
-import { computeWindowStatistics, computeWindowStatisticsForDataSet } from "../src/util/data-mining";
+import { computeWindowStatistics, computeWindowStatisticsForDataPoints } from "../src/util/data-mining";
 describe("computeWindowStatistics tests", () => {
   const dataArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   test.each([
@@ -76,7 +76,7 @@ describe("computeWindowStatisticsForDataSet tests", () => {
     { age: 8, value: 3 },
     { age: 9, value: 2 },
     { age: 10, value: 1 }
-  ]
+  ];
   test.each([
     [
       dataPoints,
@@ -131,10 +131,10 @@ describe("computeWindowStatisticsForDataSet tests", () => {
         { windowStart: 4, windowEnd: 7, value: -0.29 },
         { windowStart: 7, windowEnd: 10, value: -0.5 },
         { windowStart: 10, windowEnd: 10, value: 0 }
-      ],
-    ],
+      ]
+    ]
   ])(`Computes %s %s %s correctly`, (data, windowSize, stat, expected) => {
     assertDataMiningStatisticApproach(stat);
-    expect(computeWindowStatisticsForDataSet(data, windowSize, stat)).toEqual(expected);
+    expect(computeWindowStatisticsForDataPoints(data, windowSize, stat)).toEqual(expected);
   });
 });

--- a/app/__tests__/data-mining.test.ts
+++ b/app/__tests__/data-mining.test.ts
@@ -8,7 +8,9 @@ describe("computeWindowStatistics tests", () => {
       "average",
       [
         { windowStart: 1, windowEnd: 4, value: 2 },
-        { windowStart: 4, windowEnd: 7, value: 5.5 }
+        { windowStart: 4, windowEnd: 7, value: 5 },
+        { windowStart: 7, windowEnd: 10, value: 8 },
+        { windowStart: 10, windowEnd: 10, value: 10 }
       ]
     ],
     [
@@ -17,7 +19,9 @@ describe("computeWindowStatistics tests", () => {
       "minimum",
       [
         { windowStart: 1, windowEnd: 4, value: 1 },
-        { windowStart: 4, windowEnd: 7, value: 4 }
+        { windowStart: 4, windowEnd: 7, value: 4 },
+        { windowStart: 7, windowEnd: 10, value: 7 },
+        { windowStart: 10, windowEnd: 10, value: 10}
       ]
     ],
     [
@@ -26,7 +30,9 @@ describe("computeWindowStatistics tests", () => {
       "maximum",
       [
         { windowStart: 1, windowEnd: 4, value: 3 },
-        { windowStart: 4, windowEnd: 7, value: 7 }
+        { windowStart: 4, windowEnd: 7, value: 6 },
+        { windowStart: 7, windowEnd: 10, value: 9 },
+        { windowStart: 10, windowEnd: 10, value: 10}
       ]
     ],
     [
@@ -35,7 +41,9 @@ describe("computeWindowStatistics tests", () => {
       "rateOfChange",
       [
         { windowStart: 1, windowEnd: 4, value: 2 },
-        { windowStart: 4, windowEnd: 7, value: 0.75 }
+        { windowStart: 4, windowEnd: 7, value: 0.5 },
+        { windowStart: 7, windowEnd: 10, value: 0.29},
+        { windowStart: 10, windowEnd: 10, value: 0 }
       ]
     ],
     [

--- a/app/__tests__/data-mining.test.ts
+++ b/app/__tests__/data-mining.test.ts
@@ -4,7 +4,6 @@ describe("computeWindowStatistics tests", () => {
   test.each([
     [
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-      2,
       3,
       "average",
       [
@@ -14,7 +13,6 @@ describe("computeWindowStatistics tests", () => {
     ],
     [
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-      2,
       3,
       "minimum",
       [
@@ -24,7 +22,6 @@ describe("computeWindowStatistics tests", () => {
     ],
     [
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-      2,
       3,
       "maximum",
       [
@@ -34,7 +31,6 @@ describe("computeWindowStatistics tests", () => {
     ],
     [
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-      2,
       3,
       "rateOfChange",
       [
@@ -44,16 +40,17 @@ describe("computeWindowStatistics tests", () => {
     ],
     [
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-      2,
       3,
       "frequency",
       [
         { windowStart: 1, windowEnd: 4, value: 3 },
-        { windowStart: 4, windowEnd: 7, value: 4 }
+        { windowStart: 4, windowEnd: 7, value: 3 },
+        { windowStart: 7, windowEnd: 10, value: 3 },
+        { windowStart: 10, windowEnd: 10, value: 1 }
       ]
     ]
-  ])("Computes %s %s %s %s correctly", (data, windows, windowSize, stat, expected) => {
+  ])("Computes %s %s %s %s correctly", (data, windowSize, stat, expected) => {
     assertDataMiningStatisticApproach(stat);
-    expect(computeWindowStatistics(data, windows, windowSize, stat)).toEqual(expected);
+    expect(computeWindowStatistics(data, windowSize, stat)).toEqual(expected);
   });
 });

--- a/app/__tests__/data-mining.test.ts
+++ b/app/__tests__/data-mining.test.ts
@@ -1,9 +1,10 @@
 import { assertDataMiningStatisticApproach } from "../src/types";
-import { computeWindowStatistics } from "../src/util/data-mining";
+import { computeWindowStatistics, computeWindowStatisticsForDataSet } from "../src/util/data-mining";
 describe("computeWindowStatistics tests", () => {
+  const dataArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   test.each([
     [
-      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      dataArray,
       3,
       "average",
       [
@@ -14,40 +15,40 @@ describe("computeWindowStatistics tests", () => {
       ]
     ],
     [
-      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      dataArray,
       3,
       "minimum",
       [
         { windowStart: 1, windowEnd: 4, value: 1 },
         { windowStart: 4, windowEnd: 7, value: 4 },
         { windowStart: 7, windowEnd: 10, value: 7 },
-        { windowStart: 10, windowEnd: 10, value: 10}
+        { windowStart: 10, windowEnd: 10, value: 10 }
       ]
     ],
     [
-      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      dataArray,
       3,
       "maximum",
       [
         { windowStart: 1, windowEnd: 4, value: 3 },
         { windowStart: 4, windowEnd: 7, value: 6 },
         { windowStart: 7, windowEnd: 10, value: 9 },
-        { windowStart: 10, windowEnd: 10, value: 10}
+        { windowStart: 10, windowEnd: 10, value: 10 }
       ]
     ],
     [
-      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      dataArray,
       3,
       "rateOfChange",
       [
         { windowStart: 1, windowEnd: 4, value: 2 },
         { windowStart: 4, windowEnd: 7, value: 0.5 },
-        { windowStart: 7, windowEnd: 10, value: 0.29},
+        { windowStart: 7, windowEnd: 10, value: 0.29 },
         { windowStart: 10, windowEnd: 10, value: 0 }
       ]
     ],
     [
-      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      dataArray,
       3,
       "frequency",
       [
@@ -60,5 +61,80 @@ describe("computeWindowStatistics tests", () => {
   ])("Computes %s %s %s %s correctly", (data, windowSize, stat, expected) => {
     assertDataMiningStatisticApproach(stat);
     expect(computeWindowStatistics(data, windowSize, stat)).toEqual(expected);
+  });
+});
+
+describe("computeWindowStatisticsForDataSet tests", () => {
+  const dataPoints = [
+    { age: 1, value: 10 },
+    { age: 2, value: 9 },
+    { age: 3, value: 8 },
+    { age: 4, value: 7 },
+    { age: 5, value: 6 },
+    { age: 6, value: 5 },
+    { age: 7, value: 4 },
+    { age: 8, value: 3 },
+    { age: 9, value: 2 },
+    { age: 10, value: 1 }
+  ]
+  test.each([
+    [
+      dataPoints,
+      3,
+      "frequency",
+      [
+        { windowStart: 1, windowEnd: 4, value: 3 },
+        { windowStart: 4, windowEnd: 7, value: 3 },
+        { windowStart: 7, windowEnd: 10, value: 3 },
+        { windowStart: 10, windowEnd: 10, value: 1 }
+      ]
+    ],
+    [
+      dataPoints,
+      3,
+      "minimum",
+      [
+        { windowStart: 1, windowEnd: 4, value: 8 },
+        { windowStart: 4, windowEnd: 7, value: 5 },
+        { windowStart: 7, windowEnd: 10, value: 2 },
+        { windowStart: 10, windowEnd: 10, value: 1 }
+      ]
+    ],
+    [
+      dataPoints,
+      3,
+      "maximum",
+      [
+        { windowStart: 1, windowEnd: 4, value: 10 },
+        { windowStart: 4, windowEnd: 7, value: 7 },
+        { windowStart: 7, windowEnd: 10, value: 4 },
+        { windowStart: 10, windowEnd: 10, value: 1 }
+      ]
+    ],
+    [
+      dataPoints,
+      3,
+      "average",
+      [
+        { windowStart: 1, windowEnd: 4, value: 9 },
+        { windowStart: 4, windowEnd: 7, value: 6 },
+        { windowStart: 7, windowEnd: 10, value: 3 },
+        { windowStart: 10, windowEnd: 10, value: 1 }
+      ]
+    ],
+    [
+      dataPoints,
+      3,
+      "rateOfChange",
+      [
+        { windowStart: 1, windowEnd: 4, value: -0.2 },
+        { windowStart: 4, windowEnd: 7, value: -0.29 },
+        { windowStart: 7, windowEnd: 10, value: -0.5 },
+        { windowStart: 10, windowEnd: 10, value: 0 }
+      ],
+    ],
+  ])(`Computes %s %s %s correctly`, (data, windowSize, stat, expected) => {
+    assertDataMiningStatisticApproach(stat);
+    expect(computeWindowStatisticsForDataSet(data, windowSize, stat)).toEqual(expected);
   });
 });

--- a/app/__tests__/data-mining.test.ts
+++ b/app/__tests__/data-mining.test.ts
@@ -1,0 +1,59 @@
+import { assertDataMiningStatisticApproach } from "../src/types";
+import { computeWindowStatistics } from "../src/util/data-mining";
+describe("computeWindowStatistics tests", () => {
+  test.each([
+    [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      2,
+      3,
+      "average",
+      [
+        { windowStart: 1, windowEnd: 4, value: 2 },
+        { windowStart: 4, windowEnd: 7, value: 5.5 }
+      ]
+    ],
+    [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      2,
+      3,
+      "minimum",
+      [
+        { windowStart: 1, windowEnd: 4, value: 1 },
+        { windowStart: 4, windowEnd: 7, value: 4 }
+      ]
+    ],
+    [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      2,
+      3,
+      "maximum",
+      [
+        { windowStart: 1, windowEnd: 4, value: 3 },
+        { windowStart: 4, windowEnd: 7, value: 7 }
+      ]
+    ],
+    [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      2,
+      3,
+      "rateOfChange",
+      [
+        { windowStart: 1, windowEnd: 4, value: 2 },
+        { windowStart: 4, windowEnd: 7, value: 0.75 }
+      ]
+    ],
+    [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      2,
+      3,
+      "frequency",
+      [
+        { windowStart: 1, windowEnd: 4, value: 3 },
+        { windowStart: 4, windowEnd: 7, value: 4 }
+      ]
+    ]
+  ])("Computes %s %s %s %s correctly", (data, windows, windowSize, stat, expected) => {
+    assertDataMiningStatisticApproach(stat);
+    expect(computeWindowStatistics(data, windows, windowSize, stat)).toEqual(expected);
+  });
+});

--- a/app/src/settings_tabs/EditNameField.tsx
+++ b/app/src/settings_tabs/EditNameField.tsx
@@ -15,7 +15,7 @@ export const EditNameField: React.FC<{
       <TextField
         hiddenLabel
         id="editNameTextField"
-        defaultValue={column.editName}
+        value={column.editName}
         onChange={(event) => {
           actions.setEditName(event.target.value, column);
         }}

--- a/app/src/settings_tabs/advanced_settings/DataMiningSettings.tsx
+++ b/app/src/settings_tabs/advanced_settings/DataMiningSettings.tsx
@@ -69,19 +69,26 @@ export const EventDataMiningOptions: React.FC<DataMiningSettingsProps> = observe
   assertEventSettings(eventSettings);
   const handleFrequencyChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!isEventFrequency(event.target.value)) return;
+    if (eventSettings.frequency !== null) actions.removeDataMiningColumn(column, eventSettings.frequency);
     actions.setEventColumnSettings(eventSettings, { frequency: event.target.value });
+    actions.addDataMiningColumn(column, event.target.value);
+  };
+  const clearDataMiningColumn = () => {
+    if (eventSettings.frequency === null) return;
+    actions.setEventColumnSettings(eventSettings, { frequency: null });
+    actions.removeDataMiningColumn(column, eventSettings.frequency);
   };
   return (
     <Box className="data-mining-type-container">
       <TSCRadioGroup
         onChange={handleFrequencyChange}
-        onClear={() => actions.setEventColumnSettings(eventSettings, { frequency: null })}
+        onClear={clearDataMiningColumn}
         name="Event Type"
         value={eventSettings.frequency}
         radioArray={[
           { value: "FAD", label: "Frequency of FAD" },
           { value: "LAD", label: "Frequency of LAD" },
-          { value: "Combined", label: "Combined Events" }
+          { value: "Combined Events", label: "Combined Events" }
         ]}
       />
     </Box>
@@ -95,13 +102,21 @@ export const PointDataMiningOptions: React.FC<DataMiningSettingsProps> = observe
   assertPointSettings(pointSettings);
   const handleDataTypeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!isDataMiningPointDataType(event.target.value)) return;
+    if (pointSettings.dataMiningPointDataType !== null)
+      actions.removeDataMiningColumn(column, pointSettings.dataMiningPointDataType);
     actions.setPointColumnSettings(pointSettings, { dataMiningPointDataType: event.target.value });
+    actions.addDataMiningColumn(column, event.target.value);
+  };
+  const clearDataMiningColumn = () => {
+    if (pointSettings.dataMiningPointDataType === null) return;
+    actions.setPointColumnSettings(pointSettings, { dataMiningPointDataType: null });
+    actions.removeDataMiningColumn(column, pointSettings.dataMiningPointDataType);
   };
   return (
     <Box className="data-mining-type-container">
       <TSCRadioGroup
         onChange={handleDataTypeChange}
-        onClear={() => actions.setPointColumnSettings(pointSettings, { dataMiningPointDataType: null })}
+        onClear={clearDataMiningColumn}
         name="Data Type to Plot"
         value={pointSettings.dataMiningPointDataType}
         radioArray={[

--- a/app/src/state/actions/column-actions.ts
+++ b/app/src/state/actions/column-actions.ts
@@ -19,7 +19,8 @@ import {
   calculateAutoScale,
   convertPointTypeToPointShape,
   defaultPointSettings,
-  isDataMiningPointDataType
+  isDataMiningPointDataType,
+  isEventFrequency
 } from "@tsconline/shared";
 import { cloneDeep } from "lodash";
 import { pushSnackbar } from "./general-actions";
@@ -240,8 +241,17 @@ export const addDataMiningColumn = action((column: ColumnInfo, type: EventFreque
     case "Event":
       assertEventSettings(column.columnSpecificSettings);
       assertSubEventInfoArray(column.subInfo);
+      if (!isEventFrequency(type)) {
+        console.log("WARNING: unknown event frequency associated with an event", type);
+        return;
+      }
       windowStats = computeWindowStatistics(
-        column.subInfo.map((subEvent) => subEvent.age),
+        column.subInfo
+          .filter((subEvent) => {
+            if (type === "Combined Events") return true;
+            else return subEvent.subEventType === type;
+          })
+          .map((subEvent) => subEvent.age),
         column.columnSpecificSettings.windowSize,
         "frequency"
       );

--- a/app/src/state/actions/column-actions.ts
+++ b/app/src/state/actions/column-actions.ts
@@ -236,12 +236,12 @@ export const addDataMiningColumn = action((column: ColumnInfo, type: EventFreque
     case "Event":
       assertEventSettings(column.columnSpecificSettings);
       assertSubEventInfoArray(column.subInfo);
-      data = column.subInfo.filter(subEvent => subEvent.subEventType === type).map(subEvent => subEvent.age);
+      data = column.subInfo.filter((subEvent) => subEvent.subEventType === type).map((subEvent) => subEvent.age);
       break;
     case "Point":
       assertPointSettings(column.columnSpecificSettings);
       assertSubPointInfoArray(column.subInfo);
-      data = column.subInfo.map(subPoint => subPoint.age);
+      data = column.subInfo.map((subPoint) => subPoint.age);
       break;
     default:
       console.log("WARNING: unknown column display type", column.columnDisplayType);

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -385,6 +385,12 @@ export const setDatapackConfig = action(
         if (!datapack || !state.datapackIndex[datapack])
           throw new Error(`File requested doesn't exist on server: ${datapack}`);
         const datapackParsingPack = state.datapackIndex[datapack]!;
+        if (
+          ((datapackParsingPack.topAge || datapackParsingPack.topAge === 0) &&
+            (datapackParsingPack.baseAge || datapackParsingPack.baseAge === 0)) ||
+          datapackParsingPack.verticalScale
+        )
+          foundDefaultAge = true;
         if (unitMap.has(datapackParsingPack.ageUnits)) {
           const existingUnitColumnInfo = unitMap.get(datapackParsingPack.ageUnits)!;
           const newUnitChart = datapackParsingPack.columnInfo;
@@ -395,13 +401,9 @@ export const setDatapackConfig = action(
           }
           existingUnitColumnInfo.children = existingUnitColumnInfo.children.concat(columnsToAdd);
         } else {
-          if (
-            ((datapackParsingPack.topAge || datapackParsingPack.topAge === 0) &&
-              (datapackParsingPack.baseAge || datapackParsingPack.baseAge === 0)) ||
-            datapackParsingPack.verticalScale
-          )
-            foundDefaultAge = true;
-          unitMap.set(datapackParsingPack.ageUnits, cloneDeep(datapackParsingPack.columnInfo));
+          const columnInfo = cloneDeep(datapackParsingPack.columnInfo);
+          columnInfo.parent = columnRoot.name;
+          unitMap.set(datapackParsingPack.ageUnits, columnInfo);
         }
         const mapPack = state.mapPackIndex[datapack]!;
         if (!mapInfo) mapInfo = mapPack.mapInfo;

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -390,6 +390,9 @@ export const setDatapackConfig = action(
           const newUnitChart = datapackParsingPack.columnInfo;
           // slice off the existing unit column
           const columnsToAdd = cloneDeep(newUnitChart.children.slice(1));
+          for (const child of columnsToAdd) {
+            child.parent = existingUnitColumnInfo.name;
+          }
           existingUnitColumnInfo.children = existingUnitColumnInfo.children.concat(columnsToAdd);
         } else {
           if (

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -373,7 +373,8 @@ export function translateColumnInfoToColumnInfoTSC(state: ColumnInfo): ColumnInf
         rangeSort: state.columnSpecificSettings.rangeSort,
         drawExtraColumn: state.columnSpecificSettings.frequency,
         windowSize: state.columnSpecificSettings.windowSize,
-        stepSize: state.columnSpecificSettings.stepSize
+        stepSize: state.columnSpecificSettings.stepSize,
+        isDataMiningColumn: state.columnSpecificSettings.isDataMiningColumn
       };
       break;
     case "Zone":
@@ -413,7 +414,8 @@ export function translateColumnInfoToColumnInfoTSC(state: ColumnInfo): ColumnInf
         scaleStep: state.columnSpecificSettings.scaleStep,
         drawExtraColumn: state.columnSpecificSettings.dataMiningPointDataType,
         windowSize: state.columnSpecificSettings.windowSize,
-        stepSize: state.columnSpecificSettings.stepSize
+        stepSize: state.columnSpecificSettings.stepSize,
+        isDataMiningColumn: state.columnSpecificSettings.isDataMiningColumn
       };
   }
   //TODO: check with Ogg about quote usage
@@ -551,9 +553,11 @@ function columnInfoTSCToXml(column: ColumnInfoTSC, indent: string): string {
       xml += generateFontsXml(`${indent}    `, column.fonts);
       xml += `${indent}</fonts>\n`;
     } else if (key === "children") {
-      for (let i = 0; i < column.children.length; i++) {
-        xml += `${indent}<column id="${escapeHtmlChars(column.children[i]._id, "attribute")}">\n`;
-        xml += columnInfoTSCToXml(column.children[i], `${indent}    `);
+      for (const child of column.children) {
+        const isDataMiningColumn =
+          "isDataMiningColumn" in child ? `isDataMiningColumn="${child.isDataMiningColumn}"` : "";
+        xml += `${indent}<column id="${escapeHtmlChars(child._id, "attribute")}" ${isDataMiningColumn}>\n`;
+        xml += columnInfoTSCToXml(child, `${indent}    `);
         xml += `${indent}</column>\n`;
       }
     } else if (key === "justification") {
@@ -565,7 +569,7 @@ function columnInfoTSCToXml(column: ColumnInfoTSC, indent: string): string {
     } else if (key === "pointType") {
       assertPointColumnInfoTSC(column);
       xml += `${indent}<setting name="pointType" pointType="${column.pointType}"/>\n`;
-    } else if (key === "drawExtraColumn" && !keyValue) {
+    } else if ((key === "drawExtraColumn" && !keyValue) || key === "isDataMiningColumn") {
       continue;
     } else if (isRGB(keyValue)) {
       xml += `${indent}<setting name="${key}">${convertRgbToString(keyValue)}</setting>\n`;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -1,3 +1,11 @@
+export type WindowStats = {
+  windowStart: number;
+  windowEnd: number;
+  value: number;
+};
+
+export type DataMiningStatisticApproach = "average" | "minimum" | "maximum" | "rateOfChange" | "frequency";
+
 export type FaciesOptions = {
   faciesAge: number;
   dotSize: number;
@@ -75,6 +83,7 @@ export function equalTimeSettings(a: TimeSettings, b: TimeSettings): boolean {
     Object.keys(a).every((key) => {
       const aValue = a[key];
       const bValue = b[key];
+      if (bValue === undefined || aValue === undefined) return false;
       return (
         aValue.selectedStage === bValue.selectedStage &&
         aValue.topStageAge === bValue.topStageAge &&
@@ -86,6 +95,11 @@ export function equalTimeSettings(a: TimeSettings, b: TimeSettings): boolean {
       );
     })
   );
+}
+export function assertDataMiningStatisticApproach(value: string): asserts value is DataMiningStatisticApproach {
+  if (/^(average|minimum|maximum|rateOfChange|frequency)$/.test(value) === false) {
+    throw new Error(`Invalid statistic: ${value}`);
+  }
 }
 export function equalChartSettings(a: ChartSettings, b: ChartSettings): boolean {
   return (

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -1,3 +1,5 @@
+import { DataMiningPointDataType } from "@tsconline/shared";
+
 export type WindowStats = {
   windowStart: number;
   windowEnd: number;
@@ -76,6 +78,25 @@ export type ChartSettings = {
   datapackContainsSuggAge: boolean;
   useDatapackSuggestedAge: boolean;
 };
+
+export function convertDataMiningPointDataTypeToDataMiningStatisticApproach(
+  value: DataMiningPointDataType
+): DataMiningStatisticApproach {
+  switch (value) {
+    case "Average Value":
+      return "average";
+    case "Minimum Value":
+      return "minimum";
+    case "Maximum Value":
+      return "maximum";
+    case "Rate of Change":
+      return "rateOfChange";
+    case "Frequency":
+      return "frequency";
+    default:
+      throw new Error(`Invalid DataMiningPointDataType: ${value}`);
+  }
+}
 
 export function equalTimeSettings(a: TimeSettings, b: TimeSettings): boolean {
   return (

--- a/app/src/util/data-mining.ts
+++ b/app/src/util/data-mining.ts
@@ -63,7 +63,7 @@ type DataPoint = {
   value: number;
 };
 
-export function computeWindowStatisticsForDataSet(
+export function computeWindowStatisticsForDataPoints(
   data: DataPoint[],
   windowSize: number,
   stat: DataMiningStatisticApproach

--- a/app/src/util/data-mining.ts
+++ b/app/src/util/data-mining.ts
@@ -1,5 +1,6 @@
 import { round } from "lodash";
 import { DataMiningStatisticApproach, WindowStats } from "../types";
+import { normalizeZero } from "./util";
 
 /**
  * This function computes the statistics of a data set in a moving window.
@@ -19,8 +20,9 @@ export function computeWindowStatistics(
     return [];
   }
   data = data.sort((a, b) => a - b);
+  const firstDataPoint = data[0]!;
   const lastDataPoint = data[data.length - 1]!;
-  const windows = Math.ceil(lastDataPoint / windowSize);
+  const windows = Math.ceil((lastDataPoint - firstDataPoint + 1) / windowSize);
   const results: WindowStats[] = [];
   let start = data[0]!; // inclusive
   let end = start + windowSize; // exclusive
@@ -31,8 +33,8 @@ export function computeWindowStatistics(
     if (window.length === 0) {
       results.push({ windowStart: start, windowEnd: end, value: 0 });
     } else {
-      const firstWindowPoint = window[0];
-      const lastWindowPoint = window[window.length - 1];
+      const firstWindowPoint = window[0]!;
+      const lastWindowPoint = window[window.length - 1]!;
       let value = 0;
       switch (stat) {
         case "frequency":
@@ -48,11 +50,11 @@ export function computeWindowStatistics(
           value = window.reduce((a, b) => a + b, 0) / window.length;
           break;
         case "rateOfChange":
-          if (!firstWindowPoint || !lastWindowPoint) value = 0;
+          if (!firstWindowPoint) value = 0;
           else value = (lastWindowPoint - firstWindowPoint) / firstWindowPoint;
           break;
       }
-      results.push({ windowStart: start, windowEnd: end, value: round(value, 2) });
+      results.push({ windowStart: start, windowEnd: end, value: round(normalizeZero(value), 2) });
     }
     if (end > lastDataPoint) break;
     start = end;
@@ -82,8 +84,9 @@ export function computeWindowStatisticsForDataPoints(
   if (data.length === 0 || windowSize <= 0 || data.some((d) => isNaN(d.value) || isNaN(d.age))) {
     return [];
   }
+  const firstDataPoint = data[0]!.age;
   const lastDataPointAge = data[data.length - 1]!.age;
-  const windows = Math.ceil(lastDataPointAge / windowSize);
+  const windows = Math.ceil((lastDataPointAge - firstDataPoint + 1) / windowSize);
   data = data.sort((a, b) => a.age - b.age);
   const results: WindowStats[] = [];
   let start = data[0]!.age;
@@ -99,8 +102,8 @@ export function computeWindowStatisticsForDataPoints(
     if (window.length === 0) {
       results.push({ windowStart: start, windowEnd: end, value: 0 });
     } else {
-      const firstWindowPoint = window[0];
-      const lastWindowPoint = window[window.length - 1];
+      const firstWindowPoint = window[0]!;
+      const lastWindowPoint = window[window.length - 1]!;
       let value = 0;
       switch (stat) {
         case "minimum":
@@ -113,7 +116,7 @@ export function computeWindowStatisticsForDataPoints(
           value = window.reduce((a, b) => a + b.value, 0) / window.length;
           break;
         case "rateOfChange":
-          if (!firstWindowPoint || !lastWindowPoint) value = 0;
+          if (!firstWindowPoint.value) value = 0;
           else value = (lastWindowPoint.value - firstWindowPoint.value) / firstWindowPoint.value;
           break;
       }

--- a/app/src/util/data-mining.ts
+++ b/app/src/util/data-mining.ts
@@ -1,0 +1,58 @@
+import { DataMiningStatisticApproach, WindowStats } from "../types";
+
+/**
+ * This function computes the statistics of a data set in a moving window.
+ * assume data isn't sorted
+ * @param data the data set
+ * @param windows the number of windows
+ * @param windowSize the size of the window
+ * @param stat The statistic to compute in the window
+ * @returns
+ */
+export function computeWindowStatistics(
+  data: number[],
+  windows: number,
+  windowSize: number,
+  stat: DataMiningStatisticApproach
+): WindowStats[] {
+  if (data.length === 0 || windows === 0 || windowSize === 0 || data.some((d) => isNaN(d))) {
+    return [];
+  }
+  data = data.sort((a, b) => a - b);
+  const results: WindowStats[] = [];
+  let start = data[0]!;
+  let end = start + windowSize;
+
+  for (let i = 0; i < windows; i++) {
+    // make sure to include the last value in the last window
+    const window = data.filter((d) => d >= start && (d < end || (i === windows - 1 && d === end)));
+    if (window.length === 0) results.push({ windowStart: start, windowEnd: end, value: 0 });
+    const firstWindowPoint = window[0];
+    const lastWindowPoint = window[window.length - 1];
+    let value = 0;
+    switch (stat) {
+      case "frequency":
+        value = window.length;
+        break;
+      case "minimum":
+        value = Math.min(...window);
+        break;
+      case "maximum":
+        value = Math.max(...window);
+        break;
+      case "average":
+        value = window.reduce((a, b) => a + b, 0) / window.length;
+        break;
+      case "rateOfChange":
+        if (!firstWindowPoint || !lastWindowPoint) value = 0;
+        else value = (lastWindowPoint - firstWindowPoint) / firstWindowPoint;
+        break;
+    }
+    results.push({ windowStart: start, windowEnd: end, value: value });
+    const lastDataPoint = data[data.length - 1];
+    if (!lastDataPoint || end >= lastDataPoint) break;
+    start = end;
+    end = Math.min(end + windowSize, lastDataPoint);
+  }
+  return results;
+}

--- a/app/src/util/data-mining.ts
+++ b/app/src/util/data-mining.ts
@@ -15,7 +15,7 @@ export function computeWindowStatistics(
   windowSize: number,
   stat: DataMiningStatisticApproach
 ): WindowStats[] {
-  if (data.length === 0 || windowSize === 0 || data.some((d) => isNaN(d))) {
+  if (data.length === 0 || windowSize <= 0 || data.some((d) => isNaN(d))) {
     return [];
   }
   data = data.sort((a, b) => a - b);
@@ -28,30 +28,33 @@ export function computeWindowStatistics(
   for (let i = 0; i < windows; i++) {
     // make sure to include the last value in the last window
     const window = data.filter((d) => d >= start && (d < end || (i === windows - 1 && d === end)));
-    if (window.length === 0) results.push({ windowStart: start, windowEnd: end, value: 0 });
-    const firstWindowPoint = window[0];
-    const lastWindowPoint = window[window.length - 1];
-    let value = 0;
-    switch (stat) {
-      case "frequency":
-        value = window.length;
-        break;
-      case "minimum":
-        value = Math.min(...window);
-        break;
-      case "maximum":
-        value = Math.max(...window);
-        break;
-      case "average":
-        value = window.reduce((a, b) => a + b, 0) / window.length;
-        break;
-      case "rateOfChange":
-        if (!firstWindowPoint || !lastWindowPoint) value = 0;
-        else value = (lastWindowPoint - firstWindowPoint) / firstWindowPoint;
-        break;
+    if (window.length === 0) {
+      results.push({ windowStart: start, windowEnd: end, value: 0 });
+    } else {
+      const firstWindowPoint = window[0];
+      const lastWindowPoint = window[window.length - 1];
+      let value = 0;
+      switch (stat) {
+        case "frequency":
+          value = window.length;
+          break;
+        case "minimum":
+          value = Math.min(...window);
+          break;
+        case "maximum":
+          value = Math.max(...window);
+          break;
+        case "average":
+          value = window.reduce((a, b) => a + b, 0) / window.length;
+          break;
+        case "rateOfChange":
+          if (!firstWindowPoint || !lastWindowPoint) value = 0;
+          else value = (lastWindowPoint - firstWindowPoint) / firstWindowPoint;
+          break;
+      }
+      results.push({ windowStart: start, windowEnd: end, value: round(value, 2) });
     }
-    results.push({ windowStart: start, windowEnd: end, value: round(value, 2) });
-    if (!lastDataPoint || end > lastDataPoint) break;
+    if (end > lastDataPoint) break;
     start = end;
     end = Math.min(end + windowSize, lastDataPoint);
   }
@@ -76,7 +79,7 @@ export function computeWindowStatisticsForDataPoints(
   windowSize: number,
   stat: DataMiningStatisticApproach
 ) {
-  if (data.length === 0 || windowSize === 0 || data.some((d) => isNaN(d.value) || isNaN(d.age))) {
+  if (data.length === 0 || windowSize <= 0 || data.some((d) => isNaN(d.value) || isNaN(d.age))) {
     return [];
   }
   const lastDataPointAge = data[data.length - 1]!.age;
@@ -93,27 +96,30 @@ export function computeWindowStatisticsForDataPoints(
     );
   for (let i = 0; i < windows; i++) {
     const window = data.filter((d) => d.age >= start && (d.age < end || (i === windows - 1 && d.age === end)));
-    if (window.length === 0) results.push({ windowStart: start, windowEnd: end, value: 0 });
-    const firstWindowPoint = window[0];
-    const lastWindowPoint = window[window.length - 1];
-    let value = 0;
-    switch (stat) {
-      case "minimum":
-        value = Math.min(...window.map((d) => d.value));
-        break;
-      case "maximum":
-        value = Math.max(...window.map((d) => d.value));
-        break;
-      case "average":
-        value = window.reduce((a, b) => a + b.value, 0) / window.length;
-        break;
-      case "rateOfChange":
-        if (!firstWindowPoint || !lastWindowPoint) value = 0;
-        else value = (lastWindowPoint.value - firstWindowPoint.value) / firstWindowPoint.value;
-        break;
+    if (window.length === 0) {
+      results.push({ windowStart: start, windowEnd: end, value: 0 });
+    } else {
+      const firstWindowPoint = window[0];
+      const lastWindowPoint = window[window.length - 1];
+      let value = 0;
+      switch (stat) {
+        case "minimum":
+          value = Math.min(...window.map((d) => d.value));
+          break;
+        case "maximum":
+          value = Math.max(...window.map((d) => d.value));
+          break;
+        case "average":
+          value = window.reduce((a, b) => a + b.value, 0) / window.length;
+          break;
+        case "rateOfChange":
+          if (!firstWindowPoint || !lastWindowPoint) value = 0;
+          else value = (lastWindowPoint.value - firstWindowPoint.value) / firstWindowPoint.value;
+          break;
+      }
+      results.push({ windowStart: start, windowEnd: end, value: round(value, 2) });
     }
-    results.push({ windowStart: start, windowEnd: end, value: round(value, 2) });
-    if (!lastDataPointAge || end > lastDataPointAge) break;
+    if (end > lastDataPointAge) break;
     start = end;
     end = Math.min(end + windowSize, lastDataPointAge);
   }

--- a/app/src/util/data-mining.ts
+++ b/app/src/util/data-mining.ts
@@ -4,7 +4,7 @@ import { DataMiningStatisticApproach, WindowStats } from "../types";
 /**
  * This function computes the statistics of a data set in a moving window.
  * assume data isn't sorted
- * @param data the data set
+ * @param data the data set, only considering the age of the data points (only one axis supported)
  * @param windows the number of windows
  * @param windowSize the size of the window
  * @param stat The statistic to compute in the window
@@ -63,6 +63,14 @@ type DataPoint = {
   value: number;
 };
 
+/**
+ * computes the statistics of a data set in a moving window
+ * considers age for windows and values for statistics
+ * @param data dataset to compute statistics on (age, value)
+ * @param windowSize size of the window
+ * @param stat statistic to compute in the window
+ * @returns window statistics (start, end, value)
+ */
 export function computeWindowStatisticsForDataPoints(
   data: DataPoint[],
   windowSize: number,

--- a/app/src/util/data-mining.ts
+++ b/app/src/util/data-mining.ts
@@ -11,13 +11,13 @@ import { DataMiningStatisticApproach, WindowStats } from "../types";
  */
 export function computeWindowStatistics(
   data: number[],
-  windows: number,
   windowSize: number,
   stat: DataMiningStatisticApproach
 ): WindowStats[] {
-  if (data.length === 0 || windows === 0 || windowSize === 0 || data.some((d) => isNaN(d))) {
+  if (data.length === 0 || windowSize === 0 || data.some((d) => isNaN(d))) {
     return [];
   }
+  const windows = Math.ceil(data.length / windowSize);
   data = data.sort((a, b) => a - b);
   const results: WindowStats[] = [];
   let start = data[0]!;
@@ -50,7 +50,7 @@ export function computeWindowStatistics(
     }
     results.push({ windowStart: start, windowEnd: end, value: value });
     const lastDataPoint = data[data.length - 1];
-    if (!lastDataPoint || end >= lastDataPoint) break;
+    if (!lastDataPoint || end > lastDataPoint) break;
     start = end;
     end = Math.min(end + windowSize, lastDataPoint);
   }

--- a/app/src/util/util.ts
+++ b/app/src/util/util.ts
@@ -117,3 +117,7 @@ export function convertTSCColorToRGB(text: string): RGB {
     b: Number(rgb[2])
   };
 }
+
+export function normalizeZero(value: number): number {
+  return value === 0 ? 0 : value;
+}

--- a/app/src/util/util.ts
+++ b/app/src/util/util.ts
@@ -118,6 +118,11 @@ export function convertTSCColorToRGB(text: string): RGB {
   };
 }
 
+/**
+ * needed for display purposes since -0 == 0 but we want to display -0 as 0 and not -0
+ * @param value
+ * @returns
+ */
 export function normalizeZero(value: number): number {
   return value === 0 ? 0 : value;
 }

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -788,13 +788,15 @@
                     "label": "SubEventInfo 1",
                     "age": 0.02,
                     "popup": "Event SubEventInfo Popup 1",
-                    "lineStyle": "solid"
+                    "lineStyle": "solid",
+                    "subEventType": "EVENT"
                   },
                   {
                     "label": "SubEventInfo 2",
                     "age": 0.4,
                     "popup": "Event SubEventInfo Popup 2",
-                    "lineStyle": "solid"
+                    "lineStyle": "solid",
+                    "subEventType": "EVENT"
                   }
                 ]
               },
@@ -1795,13 +1797,15 @@
                 "label": "Event 1 SubEvent 1",
                 "age": 2,
                 "popup": "Event 1 SubEvent 1 Popup",
-                "lineStyle": "dashed"
+                "lineStyle": "dashed",
+                "subEventType": "EVENT"
                 },
                 {
                 "label": "Event 1 SubEvent 2",
                 "age": 4,
                 "popup": "Event 1 SubEvent 2 Popup",
-                "lineStyle": "solid"
+                "lineStyle": "solid",
+                "subEventType": "EVENT"
                 }
             ],
             "enableTitle": true,
@@ -1844,13 +1848,15 @@
                 "label": "Event 2 SubEvent 1",
                 "age": 5,
                 "popup": "",
-                "lineStyle": "solid"
+                "lineStyle": "solid",
+                "subEventType": "FAD"
                 },
                 {
                 "label": "Event 2 SubEvent 2",
                 "age": 6,
                 "popup": "",
-                "lineStyle": "solid"
+                "lineStyle": "solid",
+                "subEventType": "FAD"
                 }
             ],
             "enableTitle": false,

--- a/server/__tests__/parse-datapacks.test.ts
+++ b/server/__tests__/parse-datapacks.test.ts
@@ -33,6 +33,10 @@ jest.mock("@tsconline/shared", () => ({
   assertSubBlockInfo: jest.fn().mockReturnValue(true),
   assertSubRangeInfo: jest.fn().mockReturnValue(true),
   assertDatapackParsingPack: jest.fn().mockReturnValue(true),
+  isSubEventType: jest.fn().mockImplementation((o) => {
+    if (typeof o !== "string") return false;
+    return /^(FAD|LAD|EVENT|EVENTS)$/.test(o);
+  }),
   isSubFreehandInfo: jest.fn().mockImplementation((o) => {
     if (typeof o !== "object") return false;
     if (typeof o.baseAge !== "number") return false;
@@ -261,24 +265,33 @@ describe("process blocks line tests", () => {
 
 describe("process event line tests", () => {
   test.each([
-    ["\tlabel\t120", { label: "label", age: 120, lineStyle: "solid", popup: "" }],
-    ["\tlabel\t120\t\tpopup", { label: "label", age: 120, lineStyle: "solid", popup: "popup" }],
-    ["\tlabel\t140\tdashed\tpopup", { label: "label", age: 140, lineStyle: "dashed", popup: "popup" }],
-    ["\tlabel\t160\tdotted\tpopup", { label: "label", age: 160, lineStyle: "dotted", popup: "popup" }],
-    ["\tlabel\t180\tbadLineStyle\tpopup", { label: "label", age: 180, lineStyle: "solid", popup: "popup" }],
+    ["\tlabel\t120", { label: "label", age: 120, lineStyle: "solid", popup: "", subEventType: "FAD" }],
+    ["\tlabel\t120\t\tpopup", { label: "label", age: 120, lineStyle: "solid", popup: "popup", subEventType: "FAD" }],
+    [
+      "\tlabel\t140\tdashed\tpopup",
+      { label: "label", age: 140, lineStyle: "dashed", popup: "popup", subEventType: "FAD" }
+    ],
+    [
+      "\tlabel\t160\tdotted\tpopup",
+      { label: "label", age: 160, lineStyle: "dotted", popup: "popup", subEventType: "FAD" }
+    ],
+    [
+      "\tlabel\t180\tbadLineStyle\tpopup",
+      { label: "label", age: 180, lineStyle: "solid", popup: "popup", subEventType: "FAD" }
+    ],
     ["\tlabel", null],
     ["\tlabel\t\t\t\t", null],
     ["", null]
   ])("should process '%s'", (line, expected) => {
     if (expected === null) {
-      expect(processEvent(line)).toBeNull();
+      expect(processEvent(line, "FAD")).toBeNull();
     } else {
-      expect(processEvent(line)).toEqual(expected);
+      expect(processEvent(line, "FAD")).toEqual(expected);
     }
   });
   it("should throw error on NaN age", () => {
     const line = "\tlabel\tbadNumber";
-    expect(() => processEvent(line)).toThrow();
+    expect(() => processEvent(line, "LAD")).toThrow();
   });
 });
 

--- a/server/assets/config.json
+++ b/server/assets/config.json
@@ -1,5 +1,5 @@
 {
-  "activeJar": "assets/jars/TSCreatorBASE-8.1_22May2024.jar",
+  "activeJar": "assets/jars/TSCreatorBASE-8.1_24May2024.jar",
   "activeDatapacks": [
     "TSC2020_InternalDatapack_encrypted_13Feb2021.txt",
     "Hominids_wImages_GTS2020_Encrypted.dpk",

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -205,6 +205,7 @@ export async function parseDatapacks(
   const columnInfo = columnInfoArray;
   loneColumns.forEach((column) => {
     if (isChild.has(column.name)) return;
+    column.parent = "Chart Title";
     columnInfo.push(column);
   });
   columnInfo.unshift({

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -563,9 +563,13 @@ export async function getColumnTypes(filename: string, loneColumns: Map<string, 
       if (isSubEventType(parsedSubEventType)) {
         subEventType = parsedSubEventType;
       } else if (!subEventType) {
-        console.log(chalk.yellow.dim(`Error found while processing event block: ${event.name}, no subEventType of FAD, LAD, EVENTS, or EVENT found, skipping`));
+        console.log(
+          chalk.yellow.dim(
+            `Error found while processing event block: ${event.name}, no subEventType of FAD, LAD, EVENTS, or EVENT found, skipping`
+          )
+        );
         inEventBlock = false;
-        Object.assign(event, {...createDefaultColumnHeaderProps(), width: 150, on: false, subEventInfo: []});
+        Object.assign(event, { ...createDefaultColumnHeaderProps(), width: 150, on: false, subEventInfo: [] });
         continue;
       }
       const subEventInfo = processEvent(line, subEventType);

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -19,7 +19,8 @@ export const defaultEventSettings: EventSettings = {
   rangeSort: "first occurrence",
   frequency: null,
   stepSize: 1,
-  windowSize: 2
+  windowSize: 2,
+  isDataMiningColumn: false
 };
 
 export const allFontOptions: ValidFontOptions[] = [
@@ -231,7 +232,8 @@ export const defaultEventColumnInfoTSC: EventColumnInfoTSC = {
   rangeSort: "first occurrence",
   drawExtraColumn: null,
   windowSize: 2,
-  stepSize: 1
+  stepSize: 1,
+  isDataMiningColumn: false
 };
 
 export const defaultZoneColumnInfoTSC: ZoneColumnInfoTSC = {
@@ -265,6 +267,7 @@ export const defaultRulerColumnInfoTSC: RulerColumnInfoTSC = {
 
 export const defaultPointColumnInfoTSC: PointColumnInfoTSC = {
   ...defaultColumnBasicInfoTSC,
+  isDataMiningColumn: false,
   drawPoints: false,
   drawLine: false,
   lineColor: {
@@ -361,7 +364,8 @@ export const defaultPointSettings: PointSettings = {
   maxX: Number.MIN_SAFE_INTEGER,
   windowSize: 2,
   stepSize: 1,
-  dataMiningPointDataType: null
+  dataMiningPointDataType: null,
+  isDataMiningColumn: false
 };
 
 export const defaultPoint: Partial<Point> = {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -593,6 +593,12 @@ export function assertPoint(o: any): asserts o is Point {
   assertRGB(o.fill);
   assertColumnHeaderProps(o);
 }
+export function assertSubPointInfoArray(o: any): asserts o is SubPointInfo[] {
+  if (!Array.isArray(o)) throw new Error("SubPointInfo must be an array");
+  for (const subPoint of o) {
+    assertSubPointInfo(subPoint);
+  }
+}
 export function assertSubPointInfo(o: any): asserts o is SubPointInfo {
   if (!o || typeof o !== "object") throw new Error("SubPointInfo must be a non-null object");
   if (typeof o.age !== "number") throwError("SubPointInfo", "age", "number", o.age);
@@ -685,6 +691,13 @@ export function assertEvent(o: any): asserts o is Event {
   }
   assertColumnHeaderProps(o);
 }
+export function assertSubEventInfoArray(o: any): asserts o is SubEventInfo[] {
+  if (!Array.isArray(o)) throw new Error("SubEventInfo must be an array");
+  for (const subEvent of o) {
+    assertSubEventInfo(subEvent);
+  }
+}
+
 export function assertSubEventInfo(o: any): asserts o is SubEventInfo {
   if (!o || typeof o !== "object") throw new Error("SubEventInfo must be a non-null object");
   if (typeof o.label !== "string") throwError("SubEventInfo", "label", "string", o.label);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -692,7 +692,8 @@ export function assertSubEventInfo(o: any): asserts o is SubEventInfo {
   if (typeof o.popup !== "string") throwError("SubEventInfo", "popup", "string", o.popup);
   if (typeof o.lineStyle !== "string" || !/(^dotted|dashed|solid)$/.test(o.lineStyle))
     throwError("SubEventInfo", "lineStyle", "dotted | dashed | solid", o.lineStyle);
-  if (typeof o.subEventType !== "string" || !/(^FAD|LAD|EVENT)$/.test(o.subEventType)) throwError("SubEventInfo", "subEventType", "FAD | LAD | EVENT", o.subEventType);
+  if (typeof o.subEventType !== "string" || !/(^FAD|LAD|EVENT)$/.test(o.subEventType))
+    throwError("SubEventInfo", "subEventType", "FAD | LAD | EVENT", o.subEventType);
 }
 
 export function assertColor(o: any): asserts o is Color {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -349,11 +349,14 @@ export type SubRangeInfo = {
   popup: string;
 };
 
+export type SubEventType = "FAD" | "LAD" | "EVENT" | "EVENTS";
+
 export type SubEventInfo = {
   label: string;
   age: number;
   lineStyle: "solid" | "dashed" | "dotted";
   popup: string;
+  subEventType: SubEventType;
 };
 
 export type SubFaciesInfo = {
@@ -689,6 +692,7 @@ export function assertSubEventInfo(o: any): asserts o is SubEventInfo {
   if (typeof o.popup !== "string") throwError("SubEventInfo", "popup", "string", o.popup);
   if (typeof o.lineStyle !== "string" || !/(^dotted|dashed|solid)$/.test(o.lineStyle))
     throwError("SubEventInfo", "lineStyle", "dotted | dashed | solid", o.lineStyle);
+  if (typeof o.subEventType !== "string" || !/(^FAD|LAD|EVENT)$/.test(o.subEventType)) throwError("SubEventInfo", "subEventType", "FAD | LAD | EVENT", o.subEventType);
 }
 
 export function assertColor(o: any): asserts o is Color {
@@ -1157,6 +1161,12 @@ export function assertVertBounds(vertBounds: any): asserts vertBounds is VertBou
   if (typeof vertBounds.scale !== "number") {
     throw new Error("VertBounds must have a scale number property");
   }
+}
+
+export function isSubEventType(o: any): o is SubEventType {
+  if (typeof o !== "string") return false;
+  if (!/^(EVENT|FAD|LAD|EVENTS)$/.test(o)) return false;
+  return true;
 }
 
 export function assertRectBounds(rectBounds: any): asserts rectBounds is RectBounds {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -240,6 +240,7 @@ export type PointSettings = {
 export type DataMiningSettings = {
   windowSize: number;
   stepSize: number;
+  isDataMiningColumn: boolean;
 };
 
 export type ColumnInfo = {
@@ -267,7 +268,7 @@ export type ColumnInfo = {
 };
 
 export type RangeSort = "first occurrence" | "last occurrence" | "alphabetical";
-export type EventFrequency = "FAD" | "LAD" | "Combined";
+export type EventFrequency = "FAD" | "LAD" | "Combined Events";
 
 export type EventSettings = {
   type: EventType;
@@ -516,6 +517,8 @@ export function assertDataMiningSettings(o: any): asserts o is DataMiningSetting
   if (!o || typeof o !== "object") throw new Error("DataMiningSettings must be a non-null object");
   if (typeof o.windowSize !== "number") throwError("DataMiningSettings", "windowSize", "number", o.windowSize);
   if (typeof o.stepSize !== "number") throwError("DataMiningSettings", "stepSize", "number", o.stepSize);
+  if (typeof o.isDataMiningColumn !== "boolean")
+    throwError("DataMiningSettings", "isDataMiningColumn", "boolean", o.isDataMiningColumn);
 }
 
 export function isDataMiningPointDataType(o: any): o is DataMiningPointDataType {
@@ -539,7 +542,7 @@ export function assertEventSettings(o: any): asserts o is EventSettings {
 }
 
 export function isEventFrequency(o: any): o is EventFrequency {
-  return /^(FAD|LAD|Combined)$/.test(o);
+  return /^(FAD|LAD|Combined Events)$/.test(o);
 }
 
 export function assertMapPackInfoChunk(o: any): asserts o is MapPackInfoChunk {

--- a/shared/src/settings-types.ts
+++ b/shared/src/settings-types.ts
@@ -92,6 +92,7 @@ export type EventColumnInfoTSC = ColumnBasicInfoTSC & {
   windowSize: number;
   stepSize: number;
   drawExtraColumn: EventFrequency | null;
+  isDataMiningColumn: boolean;
 };
 
 export type ZoneColumnInfoTSC = ColumnBasicInfoTSC & {
@@ -143,6 +144,7 @@ export type PointColumnInfoTSC = ColumnBasicInfoTSC & {
   drawExtraColumn: DataMiningPointDataType | null;
   windowSize: number;
   stepSize: number;
+  isDataMiningColumn: boolean;
 };
 
 export function convertPointTypeToPointShape(type: "rect" | "round" | "tick"): PointShape {
@@ -237,6 +239,8 @@ export function assertEventColumnInfoTSC(o: any): asserts o is EventColumnInfoTS
   if (typeof o.stepSize !== "number") throwError("EventColumnInfoTSC", "stepSize", "number", o.stepSize);
   if (o.drawExtraColumn != null && (typeof o.drawExtraColumn !== "string" || !isEventFrequency(o.drawExtraColumn)))
     throwError("EventColumnInfoTSC", "drawExtraColumn", "string", o.drawExtraColumn);
+  if (typeof o.isDataMiningColumn !== "boolean")
+    throwError("EventColumnInfoTSC", "isDataMiningColumn", "boolean", o.isDataMiningColumn);
   assertColumnBasicInfoTSC(o);
 }
 export function assertSequenceColumnInfoTSC(o: any): asserts o is SequenceColumnInfoTSC {
@@ -294,6 +298,8 @@ export function assertPointColumnInfoTSC(o: any): asserts o is PointColumnInfoTS
     throwError("PointColumnInfoTSC", "drawExtraColumn", "string", o.drawExtraColumn);
   if (typeof o.windowSize !== "number") throwError("PointColumnInfoTSC", "windowSize", "number", o.windowSize);
   if (typeof o.stepSize !== "number") throwError("PointColumnInfoTSC", "stepSize", "number", o.stepSize);
+  if (typeof o.isDataMiningColumn !== "boolean")
+    throwError("PointColumnInfoTSC", "isDataMiningColumn", "boolean", o.isDataMiningColumn);
   assertColumnBasicInfoTSC(o);
 }
 export function assertColumnBasicInfoTSC(o: any): asserts o is ColumnBasicInfoTSC {


### PR DESCRIPTION
- does not include reading settings xml to create a new column yet (TSC-370)
- new xml tag in column tag `isDataMiningColumn` will let you know if this was generated from the datapack or by another column

- fix for if there are no column relationships in file and if it just contains "blocks" or "lone columns"
- created datamining that mimics that of the java file to appropriately scale the new columns
- tests for above
- added fields to parsing of events (FAD, LAD, EVENT, EVENTS)
- can clear the field to remove the added column
- selecting any data mining option will create that column and subsequent clicks on other radios will remove and add respectively
- fixed parent relationship bug that it wasn't getting set on multiple datapacks being added together

https://github.com/earthhistoryviz/tsconline/assets/89664317/fd376747-f065-47d4-b4d4-91d38219e460



