### PR TITLE
TSC-353 Done with cookie notifications and preventing logins if rejected

### DIFF
--- a/app/src/CookieConsent.tsx
+++ b/app/src/CookieConsent.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from "react";
+import { useTheme, Button, Typography, Box } from "@mui/material";
+import styled from "@mui/material/styles/styled";
+
+const CookieConsentContainer = styled(Box)(({ theme }) => ({
+  position: "fixed",
+  bottom: 0,
+  left: 0,
+  right: 0,
+  background: theme.palette.background.paper, // Use the background color from the theme
+  padding: theme.spacing(2),
+  boxShadow: theme.shadows[3],
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  zIndex: 1000 // Ensure it's above everything else
+}));
+
+interface CookieConsentProps {
+  persistent?: boolean;
+}
+
+const CookieConsent: React.FC<CookieConsentProps> = ({ persistent = false }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const theme = useTheme();
+
+  // uncomment the following line to see the cookie consent banner
+  // localStorage.removeItem('cookieConsent');
+
+  useEffect(() => {
+    const savedConsent = localStorage.getItem("cookieConsent");
+    if (!savedConsent) {
+      setIsVisible(true);
+    }
+  }, []);
+
+  const handleAccept = () => {
+    localStorage.setItem("cookieConsent", "accepted");
+    if (!persistent) {
+      setIsVisible(false);
+    }
+  };
+
+  const handleReject = () => {
+    localStorage.setItem("cookieConsent", "rejected");
+    if (!persistent) {
+      setIsVisible(false);
+    }
+  };
+
+  if (!isVisible && !persistent) {
+    return null;
+  }
+
+  return (
+    <CookieConsentContainer>
+      <Typography variant="body1">
+        <div>
+          This site uses cookies for the purpose of user logins and keeping track of user sessions. To see these
+          settings again, please visit the &apos;Sign in&apos; page.
+        </div>
+        <div>Note: If you reject, you will not be able to sign in, but other features will still work.</div>
+      </Typography>
+      <Box>
+        <Button
+          onClick={handleAccept}
+          variant="contained"
+          style={{ marginRight: theme.spacing(1), color: "white", backgroundColor: "green" }}>
+          Accept
+        </Button>
+        <Button onClick={handleReject} variant="outlined" style={{ color: "red", borderColor: "red" }}>
+          Reject
+        </Button>
+      </Box>
+    </CookieConsentContainer>
+  );
+};
+
+export default CookieConsent;

--- a/app/src/Home.tsx
+++ b/app/src/Home.tsx
@@ -9,8 +9,8 @@ import { Accordion, AccordionSummary, AccordionDetails, Grid, Typography } from 
 import { useTheme, styled } from "@mui/material/styles";
 import { TSCIcon, TSCButton, TSCCard, StyledScrollbar } from "./components";
 import TSCreatorLogo from "./assets/TSCreatorLogo.png";
-
 import "./Home.css";
+import CookieConsent from "./CookieConsent";
 
 const HeaderContainer = styled("div")(({ theme }) => ({
   display: "flex",
@@ -62,6 +62,7 @@ export const Home = observer(function Home() {
           Remove Cache
         </TSCButton>
       </div>
+      <CookieConsent />
     </div>
   );
 });

--- a/app/src/Login.tsx
+++ b/app/src/Login.tsx
@@ -18,6 +18,7 @@ import { ErrorCodes, ErrorMessages } from "./util/error-codes";
 import { useNavigate } from "react-router";
 import { displayServerError } from "./state/actions/util-actions";
 import "./Login.css";
+import CookieConsent from "./CookieConsent";
 
 export const Login: React.FC = observer(() => {
   const { state } = useContext(context);
@@ -46,6 +47,13 @@ export const Login: React.FC = observer(() => {
   const handleLogin = async (isGoogleLogin: boolean, body: Form | Credential) => {
     setLoading(true);
     try {
+      // Don't allow sign in if not accepting cookies
+      const cookieConsent = localStorage.getItem("cookieConsent");
+      if (cookieConsent !== "accepted") {
+        actions.pushError(ErrorCodes.COOKIE_REJECTED);
+        return;
+      }
+
       const recaptchaToken = await executeRecaptcha("login");
       if (!recaptchaToken) {
         actions.pushError(ErrorCodes.RECAPTCHA_FAILED);
@@ -66,7 +74,7 @@ export const Login: React.FC = observer(() => {
           displayServerError(null, ErrorCodes.UNABLE_TO_LOGIN_SERVER, ErrorMessages[ErrorCodes.UNABLE_TO_LOGIN_SERVER]);
         } else {
           actions.removeAllErrors();
-          actions.pushSnackbar("Succesfully signed in", "success");
+          actions.pushSnackbar("Successfully signed in", "success");
           navigate("/");
         }
       } else {
@@ -190,6 +198,7 @@ export const Login: React.FC = observer(() => {
           </Box>
         </>
       )}
+      <CookieConsent persistent={true} />
     </Box>
   );
 });

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -44,7 +44,8 @@ export enum ErrorCodes {
   USER_DATAPACK_FILE_NOT_FOUND_FOR_DOWNLOAD = "USER_DATAPACK_FILE_NOT_FOUND_FOR_DOWNLOAD",
   INCORRECT_ENCRYPTION_HEADER = "INCORRET_ENCRYPTION_HEADER",
   TOO_MANY_REQUESTS = "TOO_MANY_REQUESTS",
-  RECAPTCHA_FAILED = "RECAPTCHA_FAILED"
+  RECAPTCHA_FAILED = "RECAPTCHA_FAILED",
+  COOKIE_REJECTED = "COOKIE_REJECTED"
 }
 
 export const ErrorMessages = {
@@ -101,5 +102,6 @@ export const ErrorMessages = {
     "The datapack requested was not found on the server. Please try again later or contact our support team.",
   [ErrorCodes.INCORRECT_ENCRYPTION_HEADER]: "Unable to encrypt the file, please try again later.",
   [ErrorCodes.TOO_MANY_REQUESTS]: "You have made too many requests. Please try again later.",
-  [ErrorCodes.RECAPTCHA_FAILED]: "Recaptcha failed. Please try again."
+  [ErrorCodes.RECAPTCHA_FAILED]: "Recaptcha failed. Please try again.",
+  [ErrorCodes.COOKIE_REJECTED]: "You must accept cookies to sign in."
 };


### PR DESCRIPTION
![image](https://github.com/earthhistoryviz/tsconline/assets/55515290/352c86e8-0a52-40de-ad09-fb191a504daf)
Once accepted or rejected, will disappear from the bottom of Home.

![image](https://github.com/earthhistoryviz/tsconline/assets/55515290/2e6165a9-096e-4bd4-9de8-59978c52278e)
Will always be there regardless of accept/reject on the sign in page.


![image](https://github.com/earthhistoryviz/tsconline/assets/55515290/fabbd7e2-2937-4862-8a95-0ad2011a85b1)
Can't sign in if rejected or unset.

![image](https://github.com/earthhistoryviz/tsconline/assets/55515290/26ea00e3-03c1-402d-b7d3-e39efefeb4b4)
Can sign in when accepted, but this account does not exist. Maybe should change this error?


