### PR TITLE
range margin, age pad, and range sort

### DIFF
--- a/app/__tests__/__data__/parse-settings-keys.json
+++ b/app/__tests__/__data__/parse-settings-keys.json
@@ -28,6 +28,36 @@
         "children": [],
         "width": 100
       },
+      "translate-range-column-key": {
+        "_id": "class datastore.RangeColumn:Range",
+        "title": "Range Title",
+        "useNamedColor": false,
+        "placeHolder": false,
+        "drawTitle": true,
+        "drawAgeLabel": false,
+        "drawUncertaintyLabel": false,
+        "isSelected": true,
+        "width": 100,
+        "pad": 200,
+        "age pad": 22,
+        "backgroundColor": {
+          "text": {
+            "r": 224,
+            "g": 232,
+            "b": 239
+          }
+        },
+        "customColor": {
+          "text": {
+            "r": 224,
+            "g": 232,
+            "b": 239
+          }
+        },
+        "fonts": {},
+        "children": [],
+        "rangeSort": "alphabetical"
+      },
       "translate-event-column-key": {
         "_id": "class datastore.EventColumn:Events (Venusian)",
         "title": "Events (Venusian)",
@@ -60,8 +90,7 @@
         "rangeSort": "first occurrence",
         "drawExtraColumn": null,
         "windowSize": 2,
-        "stepSize": 1,
-        "isDataMiningColumn": false
+        "stepSize": 1
       },
       "translate-point-column-key": {
         "_id": "class datastore.PointColumn:Long-Term Phanerozoic",

--- a/app/__tests__/__data__/parse-settings-keys.json
+++ b/app/__tests__/__data__/parse-settings-keys.json
@@ -28,6 +28,38 @@
         "children": [],
         "width": 100
       },
+      "translate-chron-column-key": {
+        "_id": "class datastore.ChronColumn:Chron",
+        "title": "Chron Title",
+        "useNamedColor": false,
+        "placeHolder": false,
+        "drawTitle": true,
+        "drawAgeLabel": false,
+        "drawUncertaintyLabel": false,
+        "isSelected": true,
+        "width": 1000,
+        "pad": 0.2,
+        "age pad": 2,
+        "backgroundColor": {
+          "text": {
+            "r": 1,
+            "g": 2,
+            "b": 3
+          }
+        },
+        "customColor": {
+          "text": {
+            "r": 1,
+            "g": 2,
+            "b": 3
+          }
+        },
+        "fonts": {},
+        "children": [],
+        "drawExtraColumn": "Frequency",
+        "windowSize": 9,
+        "stepSize": 5
+      },
       "translate-range-column-key": {
         "_id": "class datastore.RangeColumn:Range",
         "title": "Range Title",

--- a/app/__tests__/__data__/parse-settings-tests.json
+++ b/app/__tests__/__data__/parse-settings-tests.json
@@ -22,6 +22,34 @@
         "show": true,
         "expanded": true
       },
+      "translate-range-column-test": {
+        "name": "Range",
+        "editName": "Range Title",
+        "fontsInfo": {},
+        "fontOptions": ["Column Header"],
+        "popup": "",
+        "on": true,
+        "width": 100,
+        "enableTitle": true,
+        "rgb": {
+          "r": 224,
+          "g": 232,
+          "b": 239
+        },
+        "minAge": 1,
+        "maxAge": 5,
+        "children": [],
+        "parent": null,
+        "units": "Ma",
+        "columnDisplayType": "Range",
+        "columnSpecificSettings": {
+          "margin": 200,
+          "agePad": 22,
+          "rangeSort": "alphabetical"
+        },
+        "show": true,
+        "expanded": false
+      },
       "translate-event-column-test": {
         "name": "Events (Venusian)",
         "editName": "Events (Venusian)",

--- a/app/__tests__/__data__/parse-settings-tests.json
+++ b/app/__tests__/__data__/parse-settings-tests.json
@@ -22,6 +22,34 @@
         "show": true,
         "expanded": true
       },
+      "translate-chron-column-test": {
+        "name": "Chron",
+        "editName": "Chron Title",
+        "fontsInfo": {},
+        "fontOptions": ["Column Header"],
+        "popup": "",
+        "on": true,
+        "width": 1000,
+        "enableTitle": true,
+        "rgb": {
+          "r": 1,
+          "g": 2,
+          "b": 3
+        },
+        "minAge": 100,
+        "maxAge": 101,
+        "children": [],
+        "parent": null,
+        "units": "Ma",
+        "columnDisplayType": "Chron",
+        "columnSpecificSettings": {
+          "dataMiningChronDataType": "Frequency",
+          "windowSize": 9,
+          "stepSize": 5
+        },
+        "show": true,
+        "expanded": false
+      },
       "translate-range-column-test": {
         "name": "Range",
         "editName": "Range Title",

--- a/app/__tests__/parse-settings.test.ts
+++ b/app/__tests__/parse-settings.test.ts
@@ -66,6 +66,11 @@ describe("translate columnInfo to columnInfoTSC", () => {
       keys["translate-point-column-key"]
     );
   });
+  it("should translate range column", async () => {
+    expect(parseSettings.translateColumnInfoToColumnInfoTSC(tests["translate-range-column-test"])).toEqual(
+      keys["translate-range-column-key"]
+    );
+  });
   const basicColumn = tests["translate-basic-column-test"];
   test.each([
     [basicColumn.name, "Root", "class datastore.RootColumn:Chart Root", basicColumn],

--- a/app/__tests__/parse-settings.test.ts
+++ b/app/__tests__/parse-settings.test.ts
@@ -71,6 +71,11 @@ describe("translate columnInfo to columnInfoTSC", () => {
       keys["translate-range-column-key"]
     );
   });
+  it("should translate chron column", async () => {
+    expect(parseSettings.translateColumnInfoToColumnInfoTSC(tests["translate-chron-column-test"])).toEqual(
+      keys["translate-chron-column-key"]
+    );
+  });
   const basicColumn = tests["translate-basic-column-test"];
   test.each([
     [basicColumn.name, "Root", "class datastore.RootColumn:Chart Root", basicColumn],

--- a/app/__tests__/parse-settings.test.ts
+++ b/app/__tests__/parse-settings.test.ts
@@ -5,7 +5,8 @@ import {
   FontsInfo,
   defaultChronSettings,
   defaultEventSettings,
-  defaultPointSettings
+  defaultPointSettings,
+  defaultRangeSettings
 } from "@tsconline/shared";
 import * as parseSettings from "../src/state/parse-settings";
 import { ChartSettings } from "../src/types";
@@ -90,7 +91,7 @@ describe("translate columnInfo to columnInfoTSC", () => {
       basicColumn.name,
       "Range",
       "class datastore.RangeColumn:Chart Root",
-      { ...basicColumn, columnDisplayType: "Range" }
+      { ...basicColumn, columnDisplayType: "Range", columnSpecificSettings: { ...defaultRangeSettings } }
     ],
     [
       basicColumn.name,

--- a/app/src/components/TSCGenericSettings.tsx
+++ b/app/src/components/TSCGenericSettings.tsx
@@ -72,7 +72,7 @@ export const GenericTextField: React.FC<GenericTextFieldProps> = ({
               label={input.label}
               InputProps={{ style: InputStyle }}
               inputProps={{ style: inputStyle }}
-              placeholder="Enter Size"
+              placeholder={`${input.helperText || "Enter value"}`}
               onValueChange={(values) => {
                 const floatValue = values.floatValue;
                 if (floatValue === undefined || floatValue === null || isNaN(floatValue)) {

--- a/app/src/settings_tabs/advanced_settings/RangeSpecificSettings.tsx
+++ b/app/src/settings_tabs/advanced_settings/RangeSpecificSettings.tsx
@@ -1,0 +1,35 @@
+import { ColumnInfo, assertRangeSettings, isRangeSort } from "@tsconline/shared";
+import { observer } from "mobx-react-lite";
+import { useContext } from "react";
+import { context } from "../../state";
+import { TSCRadioGroup } from "../../components/TSCRadioGroup";
+
+type RangeSpecificSettingsProps = {
+  column: ColumnInfo;
+};
+export const RangeSpecificSettings: React.FC<RangeSpecificSettingsProps> = observer(({ column }) => {
+  const { actions } = useContext(context);
+  if (column.columnDisplayType !== "Range" || !column.columnSpecificSettings) return null;
+  assertRangeSettings(column.columnSpecificSettings);
+  const handleRangeSortChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    assertRangeSettings(column.columnSpecificSettings);
+    const value = event.target.value;
+    if (!isRangeSort(value) || !column.columnSpecificSettings) {
+      actions.pushSnackbar("This feature is not yet implemented for value " + value + ".", "warning");
+      return;
+    }
+    actions.setRangeColumnSettings(column.columnSpecificSettings, { rangeSort: value });
+  };
+  return (
+    <TSCRadioGroup
+      onChange={handleRangeSortChange}
+      value={column.columnSpecificSettings.rangeSort}
+      name={""}
+      radioArray={[
+        { value: "first occurrence", label: "First Occurrence" },
+        { value: "last occurrence", label: "Last Occurrence" },
+        { value: "alphabetical", label: "Alphabetical" }
+      ]}
+    />
+  );
+});

--- a/app/src/settings_tabs/column_menu/ColumnMenu.tsx
+++ b/app/src/settings_tabs/column_menu/ColumnMenu.tsx
@@ -5,7 +5,7 @@ import { Box, Typography } from "@mui/material";
 import "./ColumnMenu.css";
 import { FontMenu } from "../FontMenu";
 import { ChangeBackgroundColor } from "./BackgroundColor";
-import { ColumnInfo } from "@tsconline/shared";
+import { ColumnInfo, assertRangeSettings } from "@tsconline/shared";
 import {
   CustomDivider,
   CustomFormControlLabel,
@@ -20,6 +20,7 @@ import { EditNameField } from "./EditNameField";
 import { DataMiningSettings } from "../advanced_settings/DataMiningSettings";
 import AccordionPositionControls from "./AccordionPositionControls";
 import { CustomTabs } from "../../components/TSCCustomTabs";
+import { RangeSpecificSettings } from "../advanced_settings/RangeSpecificSettings";
 
 export const ColumnMenu = observer(() => {
   const { state } = useContext(context);
@@ -109,10 +110,11 @@ const ColumnContent: React.FC<ColumnContentProps> = observer(({ tab, column }) =
                     helperText: "Edit Width",
                     id: "width",
                     value: column.width,
-                    onValueChange: (value) => {
+                    onValueChange: (value: number) => {
                       actions.setWidth(value, column);
                     }
-                  }
+                  },
+                  ...addRangeFields(column)
                 ]}
               />
             )}
@@ -121,6 +123,7 @@ const ColumnContent: React.FC<ColumnContentProps> = observer(({ tab, column }) =
             </div>
             <ShowTitles column={column} />
             <EventSpecificSettings column={column} />
+            <RangeSpecificSettings column={column} />
             {!!column.popup && <InfoBox info={column.popup} />}
           </Box>
         </StyledScrollbar>
@@ -135,6 +138,39 @@ const ColumnContent: React.FC<ColumnContentProps> = observer(({ tab, column }) =
       return null;
   }
 });
+
+/**
+ * For generic text field, add range fields if the column is a range column
+ * This is done so that the range fields can be displayed in the column menu
+ * next to the width field and for flex box to work properly
+ * @param column
+ * @returns
+ */
+function addRangeFields(column: ColumnInfo) {
+  const { actions } = useContext(context);
+  if (!column.columnSpecificSettings || column.columnDisplayType !== "Range") return [];
+  assertRangeSettings(column.columnSpecificSettings);
+  return [
+    {
+      helperText: "Margin",
+      id: "margin",
+      value: column.columnSpecificSettings.margin,
+      onValueChange: (value: number) => {
+        assertRangeSettings(column.columnSpecificSettings);
+        actions.setRangeColumnSettings(column.columnSpecificSettings, { margin: value });
+      }
+    },
+    {
+      helperText: "Age Pad",
+      id: "agePad",
+      value: column.columnSpecificSettings.agePad,
+      onValueChange: (value: number) => {
+        assertRangeSettings(column.columnSpecificSettings);
+        actions.setRangeColumnSettings(column.columnSpecificSettings, { agePad: value });
+      }
+    }
+  ];
+}
 
 const ShowTitles = observer(({ column }: { column: ColumnInfo }) => {
   const { actions } = useContext(context);

--- a/app/src/settings_tabs/column_menu/ColumnMenu.tsx
+++ b/app/src/settings_tabs/column_menu/ColumnMenu.tsx
@@ -107,7 +107,7 @@ const ColumnContent: React.FC<ColumnContentProps> = observer(({ tab, column }) =
                 helperOrientation="start"
                 inputs={[
                   {
-                    helperText: "Edit Width",
+                    helperText: "Width",
                     id: "width",
                     value: column.width,
                     onValueChange: (value: number) => {

--- a/app/src/state/actions/column-actions.ts
+++ b/app/src/state/actions/column-actions.ts
@@ -11,6 +11,7 @@ import {
   EventSettings,
   PointSettings,
   RGB,
+  RangeSettings,
   ValidFontOptions,
   assertChronSettings,
   assertEventColumnInfoTSC,
@@ -203,6 +204,9 @@ export const setDataMiningSettings = action(
 
 export const setPointColumnSettings = action((pointSettings: PointSettings, newSettings: Partial<PointSettings>) => {
   Object.assign(pointSettings, newSettings);
+});
+export const setRangeColumnSettings = action((rangeSettings: RangeSettings, newSettings: Partial<RangeSettings>) => {
+  Object.assign(rangeSettings, newSettings);
 });
 export const setColumnOn = action((isOn: boolean, column: ColumnInfo) => {
   column.on = isOn;

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -14,6 +14,7 @@ import {
   assertEventSettings,
   assertPointColumnInfoTSC,
   assertPointSettings,
+  assertRangeSettings,
   assertRulerColumnInfoTSC,
   assertSequenceColumnInfoTSC,
   assertZoneColumnInfoTSC,
@@ -32,7 +33,7 @@ import {
 } from "@tsconline/shared";
 import { ChartSettings } from "../types";
 import { convertRgbToString, convertTSCColorToRGB } from "../util/util";
-import { cloneDeep } from "lodash";
+import { cloneDeep, range } from "lodash";
 //for testing purposes
 //https://stackoverflow.com/questions/51269431/jest-mock-inner-function
 import * as parseSettings from "./parse-settings";
@@ -398,7 +399,13 @@ export function translateColumnInfoToColumnInfoTSC(state: ColumnInfo): ColumnInf
       column = cloneDeep(defaultSequenceColumnInfoTSC);
       break;
     case "Range":
-      column = cloneDeep(defaultRangeColumnInfoTSC);
+      assertRangeSettings(state.columnSpecificSettings);
+      column = {
+        ...cloneDeep(defaultRangeColumnInfoTSC),
+        pad: state.columnSpecificSettings.margin,
+        "age pad": state.columnSpecificSettings.agePad,
+        rangeSort: state.columnSpecificSettings.rangeSort
+      };
       break;
     case "Ruler":
       column = cloneDeep(defaultRulerColumnInfoTSC);

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -20,6 +20,7 @@ import {
   assertZoneColumnInfoTSC,
   convertPointShapeToPointType,
   defaultChartSettingsInfoTSC,
+  defaultChronColumnInfoTSC,
   defaultColumnBasicInfoTSC,
   defaultEventColumnInfoTSC,
   defaultFontsInfo,
@@ -442,7 +443,7 @@ export function translateColumnInfoToColumnInfoTSC(state: ColumnInfo): ColumnInf
     case "Chron":
       assertChronSettings(state.columnSpecificSettings);
       column = {
-        ...column,
+        ...cloneDeep(defaultChronColumnInfoTSC),
         drawExtraColumn: state.columnSpecificSettings.dataMiningChronDataType,
         windowSize: state.columnSpecificSettings.windowSize,
         stepSize: state.columnSpecificSettings.stepSize

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -831,6 +831,11 @@
                 ],
                 "units": "Ma",
                 "columnDisplayType": "Range",
+                "columnSpecificSettings": {
+                  "agePad": 2,
+                  "margin": 0.2,
+                  "rangeSort":"first occurrence"
+                },
                 "subInfo": [
                   {
                     "label": "SubRangeInfo 1",
@@ -1941,6 +1946,11 @@
                 "popup": "\"popup\""
               }
             ],
+            "columnSpecificSettings": {
+              "agePad": 2,
+              "margin": 0.2,
+              "rangeSort":"first occurrence"
+            },
             "enableTitle": true,
             "children": [],
             "width": 100,
@@ -1969,6 +1979,11 @@
               "Column Header",
               "Popup Body"
             ],
+            "columnSpecificSettings": {
+              "agePad": 2,
+              "margin": 0.2,
+              "rangeSort":"first occurrence"
+            },
             "units": "Ma",
             "subInfo": [
               {

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -56,7 +56,8 @@ import {
   SubEventType,
   isSubEventType,
   defaultChronSettings,
-  assertSubChronInfoArray
+  assertSubChronInfoArray,
+  defaultRangeSettings
 } from "@tsconline/shared";
 import { grabFilepaths, hasVisibleCharacters, capitalizeFirstLetter, formatColumnName } from "./util.js";
 import { createInterface } from "readline";
@@ -1441,13 +1442,16 @@ function createLoneColumn(
 function addColumnSettings(column: ColumnInfo, columnSpecificSettings?: ColumnSpecificSettings) {
   switch (column.columnDisplayType) {
     case "Event":
-      column.columnSpecificSettings = JSON.parse(JSON.stringify(defaultEventSettings));
+      column.columnSpecificSettings = _.cloneDeep(defaultEventSettings);
       break;
     case "Point":
       if (!columnSpecificSettings) {
         throw new Error("Error adding point column, no column specific settings found");
       }
       column.columnSpecificSettings = columnSpecificSettings;
+      break;
+    case "Range":
+      column.columnSpecificSettings = _.cloneDeep(defaultRangeSettings);
       break;
     default:
       break;
@@ -1508,6 +1512,7 @@ function processColumn<T extends ColumnInfoType>(
   switch (type) {
     case "Point":
       assertPoint(column);
+      // requires extra setup to handle point settings
       handlePointFields(column, loneColumns, units);
       break;
     default:
@@ -1518,6 +1523,7 @@ function processColumn<T extends ColumnInfoType>(
       break;
   }
   let partialColumn = {};
+  // reset the column to default values
   switch (type) {
     case "Event":
       partialColumn = {

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -1,5 +1,6 @@
 import {
   ChartSettingsInfoTSC,
+  ChronColumnInfoTSC,
   ChronSettings,
   ColumnBasicInfoTSC,
   DataMiningSettings,
@@ -243,6 +244,13 @@ export const defaultEventColumnInfoTSC: EventColumnInfoTSC = {
   drawExtraColumn: null,
   windowSize: 2,
   stepSize: 1
+};
+
+export const defaultChronColumnInfoTSC: ChronColumnInfoTSC = {
+  ...defaultColumnBasicInfoTSC,
+  windowSize: 2,
+  stepSize: 1,
+  drawExtraColumn: null
 };
 
 export const defaultZoneColumnInfoTSC: ZoneColumnInfoTSC = {

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -242,8 +242,7 @@ export const defaultEventColumnInfoTSC: EventColumnInfoTSC = {
   rangeSort: "first occurrence",
   drawExtraColumn: null,
   windowSize: 2,
-  stepSize: 1,
-  isDataMiningColumn: false
+  stepSize: 1
 };
 
 export const defaultZoneColumnInfoTSC: ZoneColumnInfoTSC = {

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -10,6 +10,7 @@ import {
   PointColumnInfoTSC,
   PointSettings,
   RangeColumnInfoTSC,
+  RangeSettings,
   RulerColumnInfoTSC,
   SequenceColumnInfoTSC,
   ValidFontOptions,
@@ -392,4 +393,10 @@ export const defaultPoint: Partial<Point> = {
   minX: Number.MAX_SAFE_INTEGER,
   maxX: Number.MIN_SAFE_INTEGER,
   scaleStep: 1
+};
+
+export const defaultRangeSettings: RangeSettings = {
+  margin: 0.2,
+  rangeSort: "first occurrence",
+  agePad: 2
 };

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -216,7 +216,13 @@ export type SubInfo =
   | SubSequenceInfo
   | SubTransectInfo;
 
-export type ColumnSpecificSettings = EventSettings | PointSettings | ChronSettings;
+export type ColumnSpecificSettings = EventSettings | PointSettings | ChronSettings | RangeSettings;
+
+export type RangeSettings = {
+  rangeSort: RangeSort;
+  margin: number;
+  agePad: number;
+};
 
 export type DataMiningChronDataType = "Frequency";
 
@@ -558,6 +564,19 @@ export function isDataMiningPointDataType(o: any): o is DataMiningPointDataType 
 }
 export function isDataMiningChronDataType(o: any): o is DataMiningChronDataType {
   return /^(Frequency)$/.test(o);
+}
+
+export function assertRangeSettings(o: any): asserts o is RangeSettings {
+  if (!o || typeof o !== "object") throw new Error("RangeSettings must be a non-null object");
+  if (typeof o.rangeSort !== "string" || !isRangeSort(o.rangeSort))
+    throwError(
+      "RangeSettings",
+      "rangeSort",
+      "string and first occurrence | last occurrence | alphabetical",
+      o.rangeSort
+    );
+  if (typeof o.margin !== "number") throwError("RangeSettings", "margin", "number", o.margin);
+  if (typeof o.agePad !== "number") throwError("RangeSettings", "agePad", "number", o.agePad);
 }
 
 export function assertEventSettings(o: any): asserts o is EventSettings {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1097,6 +1097,9 @@ export function assertColumnSpecificSettings(o: any, type: DisplayedColumnTypes)
     case "Chron":
       assertChronSettings(o);
       break;
+    case "Range":
+      assertRangeSettings(o);
+      break;
     default:
       throw new Error(
         "ColumnSpecificSettings must be an object of a valid column type. Found value of " +

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1324,7 +1324,7 @@ export function assertSVGStatus(o: any): asserts o is SVGStatus {
 }
 
 export function assertChronSettings(o: any): asserts o is ChronSettings {
-  if (o.dataMiningChronDataType != null && !isDataMiningChronDataType(o.dataMiningChronDataType))
+  if (o.dataMiningChronDataType !== null && !isDataMiningChronDataType(o.dataMiningChronDataType))
     throwError("ChronSettings", "dataMiningChronType", "DataMiningChronDataType", o.dataMiningChronDataType);
   assertDataMiningSettings(o);
 }

--- a/shared/src/settings-types.ts
+++ b/shared/src/settings-types.ts
@@ -92,7 +92,6 @@ export type EventColumnInfoTSC = ColumnBasicInfoTSC & {
   windowSize: number;
   stepSize: number;
   drawExtraColumn: EventFrequency | null;
-  isDataMiningColumn: boolean;
 };
 
 export type ZoneColumnInfoTSC = ColumnBasicInfoTSC & {
@@ -243,8 +242,6 @@ export function assertEventColumnInfoTSC(o: any): asserts o is EventColumnInfoTS
   if (typeof o.stepSize !== "number") throwError("EventColumnInfoTSC", "stepSize", "number", o.stepSize);
   if (o.drawExtraColumn != null && (typeof o.drawExtraColumn !== "string" || !isEventFrequency(o.drawExtraColumn)))
     throwError("EventColumnInfoTSC", "drawExtraColumn", "string", o.drawExtraColumn);
-  if (typeof o.isDataMiningColumn !== "boolean")
-    throwError("EventColumnInfoTSC", "isDataMiningColumn", "boolean", o.isDataMiningColumn);
   assertColumnBasicInfoTSC(o);
 }
 export function assertSequenceColumnInfoTSC(o: any): asserts o is SequenceColumnInfoTSC {

--- a/shared/src/settings-types.ts
+++ b/shared/src/settings-types.ts
@@ -1,4 +1,5 @@
 import {
+  DataMiningChronDataType,
   DataMiningPointDataType,
   EventFrequency,
   EventType,
@@ -8,6 +9,7 @@ import {
   RangeSort,
   assertFontsInfo,
   assertRGB,
+  isDataMiningChronDataType,
   isDataMiningPointDataType,
   isEventFrequency,
   isEventType,
@@ -58,7 +60,14 @@ export type ColumnInfoTSC =
   | SequenceColumnInfoTSC
   | RangeColumnInfoTSC
   | PointColumnInfoTSC
-  | RulerColumnInfoTSC;
+  | RulerColumnInfoTSC
+  | ChronColumnInfoTSC;
+
+export type ChronColumnInfoTSC = {
+  drawExtraColumn: DataMiningChronDataType | null;
+  windowSize: number;
+  stepSize: number;
+} & ColumnBasicInfoTSC;
 
 export type ColumnBasicInfoTSC = {
   _id: string;
@@ -172,6 +181,17 @@ export function assertChartInfoTSC(o: any): asserts o is ChartInfoTSC {
   if (!o || typeof o !== "object") throw new Error("ChartInfoTSC must be a non-null object");
   if (!o["class datastore.RootColumn:Chart Root"]) throw new Error("ChartInfoTSC must have a Chart Root");
   assertColumnInfoTSC(o["class datastore.RootColumn:Chart Root"]);
+}
+
+export function assertChronColumnInfoTSC(o: any): asserts o is ChronColumnInfoTSC {
+  if (
+    o.drawExtraColumn != null &&
+    (typeof o.drawExtraColumn !== "string" || !isDataMiningChronDataType(o.drawExtraColumn))
+  )
+    throwError("ChronColumnInfoTSC", "drawExtraColumn", "string", o.drawExtraColumn);
+  if (typeof o.windowSize !== "number") throwError("ChronColumnInfoTSC", "windowSize", "number", o.windowSize);
+  if (typeof o.stepSize !== "number") throwError("ChronColumnInfoTSC", "stepSize", "number", o.step);
+  assertColumnBasicInfoTSC(o);
 }
 
 export function assertChartSettingsInfoTSC(o: any): asserts o is ChartSettingsInfoTSC {


### PR DESCRIPTION
added tests and fixed type misunderstandings for `chron` as well

fixed placeholder text from displaying `Enter size` generically

![image](https://github.com/earthhistoryviz/tsconline/assets/89664317/65981ab1-9130-41fe-9035-34d2789b1793)

![image](https://github.com/earthhistoryviz/tsconline/assets/89664317/68539360-8f4f-4b10-a5eb-9d105b2bc596)
