### PR TITLE
Tsc 447 admin datapack config frontend

### DIFF
--- a/app/src/admin/Admin.tsx
+++ b/app/src/admin/Admin.tsx
@@ -1,7 +1,7 @@
 import { Box, Divider, Tab, Tabs, Typography, styled } from "@mui/material";
 import { observer } from "mobx-react-lite";
 import { AdminUserConfig } from "./AdminUserConfig";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { context } from "../state";
 import { PersonOutline, DataObject } from "@mui/icons-material";
 import { useState } from "react";
@@ -9,6 +9,7 @@ import Color from "color";
 import "./Admin.css";
 import { UnauthorizedAccess } from "./UnauthorizedAccess";
 import { AdminDatapackConfig } from "./AdminDatapackConfig";
+import { loadRecaptcha, removeRecaptcha } from "../util";
 
 const AdminTab = styled(Tab)(({ theme }) => ({
   textTransform: "none",
@@ -34,7 +35,20 @@ const AdminTabs = styled(Tabs)(() => ({
 
 export const Admin = observer(function Admin() {
   const [tabIndex, setTabIndex] = useState(0);
-  const { state } = useContext(context);
+  const { actions, state } = useContext(context);
+  /**
+   * Make sure the user is an admin before loading the recaptcha and fetching users
+   */
+  useEffect(() => {
+    if (!state.user.isAdmin) return;
+    loadRecaptcha().then(async () => {
+      await actions.adminFetchUsers();
+    });
+    return () => {
+      removeRecaptcha();
+    };
+  }, [state.user.isAdmin]);
+
   const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
     setTabIndex(newValue);
   };

--- a/app/src/admin/Admin.tsx
+++ b/app/src/admin/Admin.tsx
@@ -41,11 +41,11 @@ export const Admin = observer(function Admin() {
   if (!state.user.isAdmin) return <UnauthorizedAccess />;
   const tabs = [
     {
-      tabName: "User Config",
+      tabName: "Users",
       component: <AdminUserConfig />
     },
     {
-      tabName: "Datapack Config",
+      tabName: "Server Datapacks",
       component: <AdminDatapackConfig />
     }
   ];

--- a/app/src/admin/AdminDatapackConfig.tsx
+++ b/app/src/admin/AdminDatapackConfig.tsx
@@ -5,6 +5,7 @@ import { useContext, useEffect } from "react";
 import { context } from "../state";
 import { loadRecaptcha, removeRecaptcha } from "../util";
 import { ColDef } from "ag-grid-community";
+import { TSCButton } from "../components";
 
 const datapackColDefs: ColDef[] = [
   {
@@ -35,6 +36,9 @@ export const AdminDatapackConfig = observer(function AdminDatapackConfig() {
   }, [state.user.isAdmin]);
   return (
     <Box className={theme.palette.mode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz"} height={500}>
+      <Box m="10px">
+        <TSCButton>Delete Selected Datapacks</TSCButton>
+      </Box>
       <AgGridReact
         columnDefs={datapackColDefs}
         rowSelection="multiple"

--- a/app/src/admin/AdminDatapackConfig.tsx
+++ b/app/src/admin/AdminDatapackConfig.tsx
@@ -44,14 +44,14 @@ export const AdminDatapackConfig = observer(function AdminDatapackConfig() {
   };
   return (
     <Box className={theme.palette.mode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz"} height={500}>
-      <Box m="10px" gap="10px">
-        <TSCButton onClick={deleteDatapacks}>Delete Selected Datapacks</TSCButton>
+      <Box display="flex" m="10px" gap="20px">
         <TSCButton
           onClick={() => {
             setFormOpen(!formOpen);
           }}>
           Upload Datapack
         </TSCButton>
+        <TSCButton onClick={deleteDatapacks}>Delete Selected Datapacks</TSCButton>
         <Dialog open={formOpen} onClose={() => setFormOpen(false)}>
           <TSCDatapackUploadForm close={() => setFormOpen(false)} upload={actions.adminUploadServerDatapack} />
         </Dialog>

--- a/app/src/admin/AdminDatapackConfig.tsx
+++ b/app/src/admin/AdminDatapackConfig.tsx
@@ -22,14 +22,13 @@ const datapackColDefs: ColDef[] = [
   { headerName: "Size", field: "size", flex: 0.5 },
   { headerName: "Format Version", field: "formatVersion", flex: 0.8 }
 ];
-  
 
 export const AdminDatapackConfig = observer(function AdminDatapackConfig() {
   const theme = useTheme();
   const { state, actions } = useContext(context);
   useEffect(() => {
     if (!state.user.isAdmin) return;
-    loadRecaptcha()
+    loadRecaptcha();
     return () => {
       removeRecaptcha();
     };
@@ -37,10 +36,11 @@ export const AdminDatapackConfig = observer(function AdminDatapackConfig() {
   return (
     <Box className={theme.palette.mode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz"} height={500}>
       <AgGridReact
-      columnDefs={datapackColDefs}
-      rowSelection="multiple"
-      rowDragManaged
-      rowData={Object.values(state.datapackIndex).filter((datapack) => datapack.uuid === undefined)}
+        columnDefs={datapackColDefs}
+        rowSelection="multiple"
+        rowDragManaged
+        rowMultiSelectWithClick
+        rowData={Object.values(state.datapackIndex).filter((datapack) => datapack.uuid === undefined)}
       />
     </Box>
   );

--- a/app/src/admin/AdminDatapackConfig.tsx
+++ b/app/src/admin/AdminDatapackConfig.tsx
@@ -1,11 +1,47 @@
-import { Box } from "@mui/material";
+import { Box, useTheme } from "@mui/material";
 import { observer } from "mobx-react-lite";
-import { NotImplemented } from "../components";
+import { AgGridReact } from "ag-grid-react";
+import { useContext, useEffect } from "react";
+import { context } from "../state";
+import { loadRecaptcha, removeRecaptcha } from "../util";
+import { ColDef } from "ag-grid-community";
+
+const datapackColDefs: ColDef[] = [
+  {
+    headerName: "Datapack Title",
+    field: "title",
+    sortable: true,
+    filter: true,
+    rowDrag: true,
+    flex: 1,
+    checkboxSelection: true
+  },
+  { headerName: "File Name", field: "file", flex: 1, sortable: true, filter: true },
+  { headerName: "Age Units", field: "ageUnits", flex: 0.5 },
+  { headerName: "Description", field: "description", flex: 1 },
+  { headerName: "Size", field: "size", flex: 0.5 },
+  { headerName: "Format Version", field: "formatVersion", flex: 0.8 }
+];
+  
 
 export const AdminDatapackConfig = observer(function AdminDatapackConfig() {
+  const theme = useTheme();
+  const { state, actions } = useContext(context);
+  useEffect(() => {
+    if (!state.user.isAdmin) return;
+    loadRecaptcha()
+    return () => {
+      removeRecaptcha();
+    };
+  }, [state.user.isAdmin]);
   return (
-    <Box>
-      <NotImplemented />
+    <Box className={theme.palette.mode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz"} height={500}>
+      <AgGridReact
+      columnDefs={datapackColDefs}
+      rowSelection="multiple"
+      rowDragManaged
+      rowData={Object.values(state.datapackIndex).filter((datapack) => datapack.uuid === undefined)}
+      />
     </Box>
   );
 });

--- a/app/src/admin/AdminUserConfig.tsx
+++ b/app/src/admin/AdminUserConfig.tsx
@@ -193,6 +193,7 @@ const AdminDatapackDetails: React.FC<AdminDatapackDetailsProps> = observer(({ da
       <AgGridReact
         ref={gridRef}
         rowSelection="multiple"
+        rowMultiSelectWithClick
         rowDragManaged
         columnDefs={datapackColDefs}
         rowData={Object.values(datapackIndex)}

--- a/app/src/admin/AdminUserConfig.tsx
+++ b/app/src/admin/AdminUserConfig.tsx
@@ -109,6 +109,9 @@ export const AdminUserConfig = observer(function AdminUserConfig() {
         rowDragManaged
         columnDefs={userColDefs}
         rowData={state.admin.displayedUsers}
+        onGridReady={() => {
+          setUserDatapackIndex({});
+        }}
         onRowSelected={async (event) => {
           if (event.node.isSelected()) {
             if (!event.data.uuid || typeof event.data.uuid !== "string") return;

--- a/app/src/admin/AdminUserConfig.tsx
+++ b/app/src/admin/AdminUserConfig.tsx
@@ -5,10 +5,10 @@ import { loadRecaptcha, removeRecaptcha } from "../util";
 import { AgGridReact } from "ag-grid-react";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-quartz.css";
-import { ColDef } from "ag-grid-community";
+import { ColDef, IDetailCellRendererParams } from "ag-grid-community";
 import { Box, useTheme } from "@mui/material";
 import { AdminAddUserForm } from "./AdminAddUserForm";
-import { AdminSharedUser, assertAdminSharedUser } from "@tsconline/shared";
+import { AdminSharedUser, DatapackIndex, assertAdminSharedUser } from "@tsconline/shared";
 import { TSCButton } from "../components";
 
 const checkboxRenderer = (params: { value: boolean }) => {
@@ -19,7 +19,7 @@ const checkboxRenderer = (params: { value: boolean }) => {
   }
 };
 
-const colDefs: ColDef[] = [
+const userColDefs: ColDef[] = [
   {
     headerName: "Username",
     field: "username",
@@ -63,7 +63,7 @@ const colDefs: ColDef[] = [
   },
   { headerName: "Picture URL", field: "pictureUrl", width: 80, autoHeaderHeight: true, wrapHeaderText: true, flex: 1 }
 ];
-const defaultCol = {
+const userDefaultColDefs = {
   flex: 2,
   minWidth: 80
 };
@@ -97,14 +97,14 @@ export const AdminUserConfig = observer(function AdminUserConfig() {
   return (
     <Box className={theme.palette.mode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz"} height={500}>
       <AgGridReact
-        defaultColDef={defaultCol}
+        defaultColDef={userDefaultColDefs}
         ref={gridRef}
         isRowSelectable={(node) => node.data.email !== state.user.email}
         rowMultiSelectWithClick
         rowSelection="multiple"
-        columnDefs={colDefs}
+        rowDragManaged
+        columnDefs={userColDefs}
         rowData={state.admin.displayedUsers}
-        rowDragManaged={true}
       />
       <Box className="admin-user-config-buttons">
         <AdminAddUserForm />
@@ -112,4 +112,25 @@ export const AdminUserConfig = observer(function AdminUserConfig() {
       </Box>
     </Box>
   );
+});
+
+const datapackColDefs: ColDef[] = [
+  { headerName: "Datapack Title", field: "title", sortable: true, filter: true, rowDrag: true, flex: 1 },
+  { headerName: "Age Units", field: "ageUnits", flex: 1 },
+  { headerName: "Description", field: "description", flex: 1 },
+  { headerName: "File Name", field: "file", flex: 1 },
+  { headerName: "Size", field: "size", flex: 1 },
+  { headerName: "Format Version", field: "formatVersion", flex: 1 },
+];
+type AdminDatapackDetailsProps = {
+  datapackIndex: DatapackIndex;
+}
+const AdminDatapackDetails: React.FC<AdminDatapackDetailsProps> = observer(({ datapackIndex }) => {
+  const theme = useTheme();
+  return <Box className={theme.palette.mode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz"} height={500}>
+    <AgGridReact
+      columnDefs={datapackColDefs}
+      rowData={Object.values(datapackIndex)}
+    />
+  </Box>;
 });

--- a/app/src/admin/AdminUserConfig.tsx
+++ b/app/src/admin/AdminUserConfig.tsx
@@ -1,11 +1,11 @@
 import { observer } from "mobx-react-lite";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { context } from "../state";
 import { loadRecaptcha, removeRecaptcha } from "../util";
 import { AgGridReact } from "ag-grid-react";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-quartz.css";
-import { ColDef } from "ag-grid-community";
+import { ColDef, GridReadyEvent } from "ag-grid-community";
 import { Box, useTheme } from "@mui/material";
 import { AdminAddUserForm } from "./AdminAddUserForm";
 import { AdminSharedUser, DatapackIndex, assertAdminSharedUser } from "@tsconline/shared";
@@ -109,9 +109,7 @@ export const AdminUserConfig = observer(function AdminUserConfig() {
         rowDragManaged
         columnDefs={userColDefs}
         rowData={state.admin.displayedUsers}
-        onGridReady={() => {
-          setUserDatapackIndex({});
-        }}
+        onModelUpdated={() => setUserDatapackIndex({})}
         onRowSelected={async (event) => {
           if (event.node.isSelected()) {
             if (!event.data.uuid || typeof event.data.uuid !== "string") return;
@@ -132,9 +130,9 @@ export const AdminUserConfig = observer(function AdminUserConfig() {
 
 const datapackColDefs: ColDef[] = [
   { headerName: "Datapack Title", field: "title", sortable: true, filter: true, rowDrag: true, flex: 1 },
+  { headerName: "File Name", field: "file", flex: 1, sortable: true, filter: true},
   { headerName: "Age Units", field: "ageUnits", flex: 1 },
   { headerName: "Description", field: "description", flex: 1 },
-  { headerName: "File Name", field: "file", flex: 1 },
   { headerName: "Size", field: "size", flex: 1 },
   { headerName: "Format Version", field: "formatVersion", flex: 1 }
 ];
@@ -145,7 +143,7 @@ const AdminDatapackDetails: React.FC<AdminDatapackDetailsProps> = observer(({ da
   const theme = useTheme();
   return (
     <Box className={theme.palette.mode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz"} height={500}>
-      <AgGridReact columnDefs={datapackColDefs} rowData={Object.values(datapackIndex)} />
+      <AgGridReact rowDragManaged columnDefs={datapackColDefs} rowData={Object.values(datapackIndex)} />
     </Box>
   );
 });

--- a/app/src/admin/AdminUserConfig.tsx
+++ b/app/src/admin/AdminUserConfig.tsx
@@ -6,7 +6,7 @@ import { AgGridReact } from "ag-grid-react";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-quartz.css";
 import { ColDef, GridReadyEvent } from "ag-grid-community";
-import { Box, useTheme } from "@mui/material";
+import { Box, Divider, Typography, useTheme } from "@mui/material";
 import { AdminAddUserForm } from "./AdminAddUserForm";
 import { AdminSharedUser, DatapackIndex, assertAdminSharedUser } from "@tsconline/shared";
 import { TSCButton } from "../components";
@@ -65,7 +65,7 @@ const userColDefs: ColDef[] = [
 ];
 const userDefaultColDefs = {
   flex: 2,
-  minWidth: 80
+  minWidth: 80,
 };
 
 export const AdminUserConfig = observer(function AdminUserConfig() {
@@ -121,6 +121,12 @@ export const AdminUserConfig = observer(function AdminUserConfig() {
           }
         }}
       />
+      <Box mt="20px">
+        <Typography variant="h5">Selected Users' Datapcks</Typography>
+        <Box m="20px">
+          <Divider />
+        </Box>
+      </Box>
       <AdminDatapackDetails
         datapackIndex={Object.values(userDatapackIndex).reduce((acc, val) => ({ ...acc, ...val }), {})}
       />

--- a/app/src/admin/AdminUserConfig.tsx
+++ b/app/src/admin/AdminUserConfig.tsx
@@ -97,10 +97,13 @@ export const AdminUserConfig = observer(function AdminUserConfig() {
   };
   return (
     <Box className={theme.palette.mode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz"} height={500}>
+      <Box className="admin-user-config-buttons">
+        <AdminAddUserForm />
+        <TSCButton onClick={deleteUsers}>Delete Selected Users</TSCButton>
+      </Box>
       <AgGridReact
         defaultColDef={userDefaultColDefs}
         ref={gridRef}
-        isRowSelectable={(node) => node.data.email !== state.user.email}
         rowMultiSelectWithClick
         rowSelection="multiple"
         rowDragManaged
@@ -117,10 +120,6 @@ export const AdminUserConfig = observer(function AdminUserConfig() {
           }
         }}
       />
-      <Box className="admin-user-config-buttons">
-        <AdminAddUserForm />
-        <TSCButton onClick={deleteUsers}>Delete Selected Users</TSCButton>
-      </Box>
       <AdminDatapackDetails
         datapackIndex={Object.values(userDatapackIndex).reduce((acc, val) => ({ ...acc, ...val }), {})}
       />

--- a/app/src/admin/AdminUserConfig.tsx
+++ b/app/src/admin/AdminUserConfig.tsx
@@ -1,7 +1,6 @@
 import { observer } from "mobx-react-lite";
-import { useContext, useEffect, useRef } from "react";
+import { useContext, useRef } from "react";
 import { context } from "../state";
-import { loadRecaptcha, removeRecaptcha } from "../util";
 import { AgGridReact } from "ag-grid-react";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-quartz.css";
@@ -71,19 +70,6 @@ export const AdminUserConfig = observer(function AdminUserConfig() {
   const { state, actions } = useContext(context);
   const theme = useTheme();
   const gridRef = useRef<AgGridReact<AdminSharedUser>>(null);
-
-  /**
-   * Make sure the user is an admin before loading the recaptcha and fetching users
-   */
-  useEffect(() => {
-    if (!state.user.isAdmin) return;
-    loadRecaptcha().then(async () => {
-      await actions.adminFetchUsers();
-    });
-    return () => {
-      removeRecaptcha();
-    };
-  }, [state.user.isAdmin]);
 
   /**
    * delete selected users

--- a/app/src/admin/AdminUserConfig.tsx
+++ b/app/src/admin/AdminUserConfig.tsx
@@ -27,7 +27,6 @@ const userColDefs: ColDef[] = [
     filter: true,
     rowDrag: true,
     checkboxSelection: true,
-    headerCheckboxSelection: true,
     minWidth: 120
   },
   { headerName: "Email", field: "email", sortable: true, filter: true },
@@ -188,6 +187,9 @@ const AdminDatapackDetails: React.FC<AdminDatapackDetailsProps> = observer(({ da
   };
   return (
     <Box className={theme.palette.mode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz"} height={500}>
+      <Box m="10px">
+        <TSCButton onClick={deleteDatapacks}>Delete Selected Datapacks</TSCButton>
+      </Box>
       <AgGridReact
         ref={gridRef}
         rowSelection="multiple"
@@ -195,7 +197,6 @@ const AdminDatapackDetails: React.FC<AdminDatapackDetailsProps> = observer(({ da
         columnDefs={datapackColDefs}
         rowData={Object.values(datapackIndex)}
       />
-      <TSCButton onClick={deleteDatapacks}>Delete Selected Datapacks</TSCButton>
     </Box>
   );
 });

--- a/app/src/components/datapack_display/TSCDatapackUploadForm.tsx
+++ b/app/src/components/datapack_display/TSCDatapackUploadForm.tsx
@@ -12,8 +12,9 @@ import { CustomDivider } from "../TSCComponents";
 
 type TSCDatapackUploadFormProps = {
   close: () => void;
+  upload: (file: File, name: string, description: string) => Promise<void>;
 };
-export const TSCDatapackUploadForm: React.FC<TSCDatapackUploadFormProps> = ({ close }) => {
+export const TSCDatapackUploadForm: React.FC<TSCDatapackUploadFormProps> = ({ close, upload }) => {
   const { state, actions } = useContext(context);
   const [datapackName, setDatapackName] = useState("");
   const [datapackDescription, setDatapackDescription] = useState("");
@@ -111,10 +112,10 @@ export const TSCDatapackUploadForm: React.FC<TSCDatapackUploadFormProps> = ({ cl
               }
               actions.removeError(ErrorCodes.NO_DATAPACK_FILE_FOUND);
               actions.removeError(ErrorCodes.UNFINISHED_DATAPACK_UPLOAD_FORM);
-              actions.uploadDatapack(datapackFile!, datapackName, datapackDescription);
-              setDatapackFile(null);
-              setDatapackName("");
-              setDatapackDescription("");
+              upload(datapackFile, datapackName, datapackDescription);
+              // setDatapackFile(null);
+              // setDatapackName("");
+              // setDatapackDescription("");
             }}>
             Finish & Upload
           </TSCButton>

--- a/app/src/components/datapack_display/TSCDatapackUploadForm.tsx
+++ b/app/src/components/datapack_display/TSCDatapackUploadForm.tsx
@@ -113,9 +113,9 @@ export const TSCDatapackUploadForm: React.FC<TSCDatapackUploadFormProps> = ({ cl
               actions.removeError(ErrorCodes.NO_DATAPACK_FILE_FOUND);
               actions.removeError(ErrorCodes.UNFINISHED_DATAPACK_UPLOAD_FORM);
               upload(datapackFile, datapackName, datapackDescription);
-              // setDatapackFile(null);
-              // setDatapackName("");
-              // setDatapackDescription("");
+              setDatapackFile(null);
+              setDatapackName("");
+              setDatapackDescription("");
             }}>
             Finish & Upload
           </TSCButton>

--- a/app/src/settings_tabs/Datapack.tsx
+++ b/app/src/settings_tabs/Datapack.tsx
@@ -101,7 +101,7 @@ export const Datapacks = observer(function Datapacks() {
         Upload Datapack
       </TSCButton>
       <Dialog classes={{ paper: styles.dd }} open={formOpen} onClose={() => setFormOpen(false)}>
-        <TSCDatapackUploadForm close={() => setFormOpen(false)} />
+        <TSCDatapackUploadForm close={() => setFormOpen(false)} upload={actions.uploadDatapack} />
       </Dialog>
     </div>
   );

--- a/app/src/settings_tabs/Datapack.tsx
+++ b/app/src/settings_tabs/Datapack.tsx
@@ -113,7 +113,7 @@ type DatapackMenuProps = {
 export const DatapackMenu: React.FC<DatapackMenuProps> = ({ name, button }) => {
   const { actions } = useContext(context);
   return (
-    state.datapackIndex[name].isUserDatapack && (
+    state.datapackIndex[name].uuid && (
       <Menu
         direction="bottom"
         align="start"

--- a/app/src/state/actions/admin-actions.ts
+++ b/app/src/state/actions/admin-actions.ts
@@ -2,22 +2,18 @@ import { action } from "mobx";
 import { state } from "..";
 import { executeRecaptcha, fetcher } from "../../util";
 import { ErrorCodes, ErrorMessages } from "../../util/error-codes";
-import { AdminSharedUser, assertAdminSharedUserArray, assertDatapackIndex, isServerResponseError } from "@tsconline/shared";
+import {
+  AdminSharedUser,
+  assertAdminSharedUserArray,
+  assertDatapackIndex,
+  isServerResponseError
+} from "@tsconline/shared";
 import { displayServerError } from "./util-actions";
 import { pushError, pushSnackbar } from "./general-actions";
 
-export const fetchUsers = action(async () => {
-  let recaptchaToken: string;
-  try {
-    recaptchaToken = await executeRecaptcha("displayUsers");
-    if (!recaptchaToken) {
-      pushError(ErrorCodes.RECAPTCHA_FAILED);
-      return;
-    }
-  } catch (error) {
-    pushError(ErrorCodes.RECAPTCHA_FAILED);
-    return;
-  }
+export const adminFetchUsers = action(async () => {
+  const recaptchaToken = await getRecaptchaToken("adminFetchUsers");
+  if (!recaptchaToken) return;
   try {
     const response = await fetcher("/admin/users", {
       method: "POST",
@@ -49,17 +45,8 @@ export const fetchUsers = action(async () => {
 });
 
 export const adminFetchUserDatapacks = action("adminFetchUserDatapacks", async (uuid: string) => {
-  let recaptchaToken: string;
-  try {
-    recaptchaToken = await executeRecaptcha("displayUsers");
-    if (!recaptchaToken) {
-      pushError(ErrorCodes.RECAPTCHA_FAILED);
-      return;
-    }
-  } catch (error) {
-    pushError(ErrorCodes.RECAPTCHA_FAILED);
-    return;
-  }
+  const recaptchaToken = await getRecaptchaToken("adminFetchUserDatapacks");
+  if (!recaptchaToken) return null;
   try {
     const response = await fetcher("/admin/user/datapacks", {
       method: "POST",
@@ -96,17 +83,8 @@ export const setUsers = action((users: AdminSharedUser[]) => {
 });
 
 export const adminAddUser = action(async (email: string, password: string, isAdmin: boolean, username?: string) => {
-  let recaptchaToken: string;
-  try {
-    recaptchaToken = await executeRecaptcha("displayUsers");
-    if (!recaptchaToken) {
-      pushError(ErrorCodes.RECAPTCHA_FAILED);
-      return;
-    }
-  } catch (error) {
-    pushError(ErrorCodes.RECAPTCHA_FAILED);
-    return;
-  }
+  const recaptchaToken = await getRecaptchaToken("adminAddUser");
+  if (!recaptchaToken) return;
   const body = JSON.stringify({
     email,
     password,
@@ -124,7 +102,7 @@ export const adminAddUser = action(async (email: string, password: string, isAdm
       credentials: "include"
     });
     if (response.ok) {
-      fetchUsers();
+      adminFetchUsers();
       pushSnackbar("User added successfully", "success");
     } else {
       displayServerError(
@@ -140,17 +118,8 @@ export const adminAddUser = action(async (email: string, password: string, isAdm
 });
 
 export const adminDeleteUsers = action(async (users: AdminSharedUser[]) => {
-  let recaptchaToken: string;
-  try {
-    recaptchaToken = await executeRecaptcha("displayUsers");
-    if (!recaptchaToken) {
-      pushError(ErrorCodes.RECAPTCHA_FAILED);
-      return;
-    }
-  } catch (error) {
-    pushError(ErrorCodes.RECAPTCHA_FAILED);
-    return;
-  }
+  const recaptchaToken = await getRecaptchaToken("adminDeleteUsers");
+  if (!recaptchaToken) return;
   let deletedAllUsers = true;
   for (const user of users) {
     if (user.email === state.user.email) {
@@ -172,7 +141,7 @@ export const adminDeleteUsers = action(async (users: AdminSharedUser[]) => {
         credentials: "include"
       });
       if (response.ok) {
-        fetchUsers();
+        adminFetchUsers();
       } else {
         deletedAllUsers = false;
         const serverResponse = await response.json();
@@ -181,7 +150,9 @@ export const adminDeleteUsers = action(async (users: AdminSharedUser[]) => {
             pushError(ErrorCodes.CANNOT_DELETE_ROOT_USER);
             continue;
           }
-          console.error(`${ErrorMessages[ErrorCodes.ADMIN_DELETE_USER_FAILED]}\nUser: "${user.username}"\n with server response: ${serverResponse.error}`);
+          console.error(
+            `${ErrorMessages[ErrorCodes.ADMIN_DELETE_USER_FAILED]}\nUser: "${user.username}"\n with server response: ${serverResponse.error}`
+          );
         }
         continue;
       }
@@ -197,3 +168,57 @@ export const adminDeleteUsers = action(async (users: AdminSharedUser[]) => {
     pushSnackbar("Some users were not deleted", "warning");
   }
 });
+
+/**
+ * Deletes a user's datapack (datapack's "id" is the filename)
+ */
+export const adminDeleteUserDatapacks = action(async (datapacks: { uuid: string; datapack: string }[]) => {
+  const recaptchaToken = await getRecaptchaToken("adminDeleteUserDatapacks");
+  if (!recaptchaToken) return;
+  let deletedAllDatapacks = true;
+  for (const { uuid, datapack } of datapacks) {
+    try {
+      const response = await fetcher("/admin/user/datapack", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "recaptcha-token": recaptchaToken
+        },
+        body: JSON.stringify({ uuid, datapack }),
+        credentials: "include"
+      });
+      if (response.ok) {
+        pushSnackbar("Datapack deleted successfully", "success");
+      } else {
+        deletedAllDatapacks = false;
+        displayServerError(
+          await response.json(),
+          ErrorCodes.ADMIN_DELETE_USER_DATAPACK_FAILED,
+          ErrorMessages[ErrorCodes.ADMIN_DELETE_USER_DATAPACK_FAILED]
+        );
+      }
+    } catch (error) {
+      console.error(error);
+      pushError(ErrorCodes.SERVER_RESPONSE_ERROR);
+    }
+  }
+  if (deletedAllDatapacks) {
+    pushSnackbar("Datapacks deleted successfully", "success");
+  } else if (datapacks.length > 1) {
+    pushSnackbar("Some datapacks were not deleted", "warning");
+  }
+});
+
+async function getRecaptchaToken(token: string) {
+  try {
+    const recaptchaToken = await executeRecaptcha(token);
+    if (!recaptchaToken) {
+      pushError(ErrorCodes.RECAPTCHA_FAILED);
+      return null;
+    }
+    return recaptchaToken;
+  } catch (error) {
+    pushError(ErrorCodes.RECAPTCHA_FAILED);
+    return null;
+  }
+}

--- a/app/src/state/actions/admin-actions.ts
+++ b/app/src/state/actions/admin-actions.ts
@@ -73,7 +73,11 @@ export const adminFetchUserDatapacks = action("adminFetchUserDatapacks", async (
     if (response.ok) {
       const index = await response.json();
       assertDatapackIndex(index);
+      return index;
     } else {
+      if (response.status === 404) {
+        return null;
+      }
       displayServerError(
         await response.json(),
         ErrorCodes.UNABLE_TO_FETCH_USER_DATAPACKS,
@@ -84,8 +88,8 @@ export const adminFetchUserDatapacks = action("adminFetchUserDatapacks", async (
     console.error(error);
     pushError(ErrorCodes.SERVER_RESPONSE_ERROR);
   }
-}
-);
+  return null;
+});
 
 export const setUsers = action((users: AdminSharedUser[]) => {
   state.admin.displayedUsers = users;

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -10,7 +10,9 @@ import {
   assertSharedUser,
   assertChartInfoTSC,
   assertDatapackInfoChunk,
-  assertMapPackInfoChunk
+  assertMapPackInfoChunk,
+  DatapackParsingPack,
+  assertDatapackParsingPack
 } from "@tsconline/shared";
 
 import {
@@ -41,6 +43,29 @@ import { settings, defaultTimeSettings } from "../../constants";
 import { cloneDeep } from "lodash";
 
 const increment = 1;
+
+export const fetchServerDatapack = action("fetchServerDatapack", async (datapack: string) => {
+  try {
+    const response = await fetcher(`/server/datapack/${encodeURIComponent(datapack)}`, {
+      method: "GET"
+    });
+    const data = await response.json();
+    if (response.ok) {
+      assertDatapackParsingPack(data);
+      return data;
+    } else {
+      displayServerError(
+        data,
+        ErrorCodes.INVALID_SERVER_DATAPACK_REQUEST,
+        ErrorMessages[ErrorCodes.INVALID_SERVER_DATAPACK_REQUEST]
+      );
+    }
+  } catch (e) {
+    displayServerError(null, ErrorCodes.SERVER_RESPONSE_ERROR, ErrorMessages[ErrorCodes.SERVER_RESPONSE_ERROR]);
+    console.error(e);
+  }
+  return null;
+});
 
 export const fetchFaciesPatterns = action("fetchFaciesPatterns", async () => {
   try {
@@ -239,6 +264,9 @@ export const setMapPackIndex = action("setMapPackIndex", async (mapPackIndex: Ma
   }
 });
 
+export const addDatapackToIndex = action("addDatapackToIndex", (datapack: string, info: DatapackParsingPack) => {
+  state.datapackIndex[datapack] = info;
+});
 export const setDatapackIndex = action("setDatapackIndex", async (datapackIndex: DatapackIndex) => {
   // This is to prevent the UI from lagging
   state.datapackIndex = {};

--- a/app/src/state/state.ts
+++ b/app/src/state/state.ts
@@ -64,6 +64,7 @@ export type State = {
   };
   admin: {
     displayedUsers: AdminSharedUser[];
+    displayedUserDatapacks: { [uuid: string]: DatapackIndex };
   };
   mapState: {
     mapInfo: MapInfo;
@@ -133,7 +134,8 @@ export const state = observable<State>({
     }
   },
   admin: {
-    displayedUsers: []
+    displayedUsers: [],
+    displayedUserDatapacks: {}
   },
   chartLoading: false,
   madeChart: false,

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -61,6 +61,7 @@ export enum ErrorCodes {
   ADMIN_DELETE_USER_DATAPACK_FAILED = "ADMIN_DELETE_USER_DATAPACK_FAILED",
   ADMIN_DELETE_SERVER_DATAPACK_FAILED = "ADMIN_DELETE_SERVER_DATAPACK_FAILED",
   ADMIN_CANNOT_DELETE_ROOT_DATAPACK = "ADMIN_CANNOT_DELETE_ROOT_DATAPACK",
+  INVALID_SERVER_DATAPACK_REQUEST = "INVALID_SERVER_DATAPACK_REQUEST"
 }
 
 export const ErrorMessages = {
@@ -134,4 +135,5 @@ export const ErrorMessages = {
   [ErrorCodes.ADMIN_DELETE_USER_DATAPACK_FAILED]: "Unable to delete user datapack. Please try again later.",
   [ErrorCodes.ADMIN_DELETE_SERVER_DATAPACK_FAILED]: "Unable to delete server datapack. Please try again later.",
   [ErrorCodes.ADMIN_CANNOT_DELETE_ROOT_DATAPACK]: "Cannot delete root datapack. Ask server admin for assistance.",
+  [ErrorCodes.INVALID_SERVER_DATAPACK_REQUEST]: "Invalid server datapack request. Please try again later."
 };

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -55,7 +55,8 @@ export enum ErrorCodes {
   ADMIN_ADD_USER_FAILED = "ADMIN_ADD_USER_FAILED",
   ADMIN_DELETE_USER_FAILED = "ADMIN_DELETE_USER_FAILED",
   SERVER_TIMEOUT = "SERVER_TIMEOUT",
-  SERVER_BUSY = "SERVER_BUSY"
+  SERVER_BUSY = "SERVER_BUSY",
+  UNABLE_TO_FETCH_USER_DATAPACKS = "UNABLE_TO_FETCH_USER_DATAPACKS",
 }
 
 export const ErrorMessages = {
@@ -121,7 +122,8 @@ export const ErrorMessages = {
   [ErrorCodes.UNABLE_TO_READ_FILE_OR_EMPTY_FILE]: "Unable to read file or file is empty. Please try again.",
   [ErrorCodes.FETCH_USERS_FAILED]: "Unable to fetch users for admin display. Please try again later.",
   [ErrorCodes.ADMIN_ADD_USER_FAILED]: "Unable to add user. Please try again later.",
-  [ErrorCodes.ADMIN_DELETE_USER_FAILED]: "Unable to delete user. Please try again later.",
   [ErrorCodes.SERVER_TIMEOUT]: "Server timed out. Please try again later.",
   [ErrorCodes.SERVER_BUSY]: "Server is too busy. Please try again later."
+  [ErrorCodes.ADMIN_DELETE_USER_FAILED]: "Unable to delete user. Please try again later.",
+  [ErrorCodes.UNABLE_TO_FETCH_USER_DATAPACKS]: "Unable to fetch user datapacks. Please try again later.",
 };

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -57,7 +57,8 @@ export enum ErrorCodes {
   SERVER_TIMEOUT = "SERVER_TIMEOUT",
   SERVER_BUSY = "SERVER_BUSY",
   UNABLE_TO_FETCH_USER_DATAPACKS = "UNABLE_TO_FETCH_USER_DATAPACKS",
-  CANNOT_DELETE_ROOT_USER = "CANNOT_DELETE_ROOT_USER"
+  CANNOT_DELETE_ROOT_USER = "CANNOT_DELETE_ROOT_USER",
+  ADMIN_DELETE_USER_DATAPACK_FAILED = "ADMIN_DELETE_USER_DATAPACK_FAILED"
 }
 
 export const ErrorMessages = {
@@ -127,5 +128,6 @@ export const ErrorMessages = {
   [ErrorCodes.SERVER_BUSY]: "Server is too busy. Please try again later."
   [ErrorCodes.ADMIN_DELETE_USER_FAILED]: "Unable to delete user. Please try again later.",
   [ErrorCodes.UNABLE_TO_FETCH_USER_DATAPACKS]: "Unable to fetch user datapacks. Please try again later.",
-  [ErrorCodes.CANNOT_DELETE_ROOT_USER]: "Cannot delete root user."
+  [ErrorCodes.CANNOT_DELETE_ROOT_USER]: "Cannot delete root user.",
+  [ErrorCodes.ADMIN_DELETE_USER_DATAPACK_FAILED]: "Unable to delete user datapack. Please try again later."
 };

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -56,7 +56,8 @@ export enum ErrorCodes {
   ADMIN_DELETE_USER_FAILED = "ADMIN_DELETE_USER_FAILED",
   SERVER_TIMEOUT = "SERVER_TIMEOUT",
   SERVER_BUSY = "SERVER_BUSY",
-  UNABLE_TO_FETCH_USER_DATAPACKS = "UNABLE_TO_FETCH_USER_DATAPACKS"
+  UNABLE_TO_FETCH_USER_DATAPACKS = "UNABLE_TO_FETCH_USER_DATAPACKS",
+  CANNOT_DELETE_ROOT_USER = "CANNOT_DELETE_ROOT_USER"
 }
 
 export const ErrorMessages = {
@@ -125,5 +126,6 @@ export const ErrorMessages = {
   [ErrorCodes.SERVER_TIMEOUT]: "Server timed out. Please try again later.",
   [ErrorCodes.SERVER_BUSY]: "Server is too busy. Please try again later."
   [ErrorCodes.ADMIN_DELETE_USER_FAILED]: "Unable to delete user. Please try again later.",
-  [ErrorCodes.UNABLE_TO_FETCH_USER_DATAPACKS]: "Unable to fetch user datapacks. Please try again later."
+  [ErrorCodes.UNABLE_TO_FETCH_USER_DATAPACKS]: "Unable to fetch user datapacks. Please try again later.",
+  [ErrorCodes.CANNOT_DELETE_ROOT_USER]: "Cannot delete root user."
 };

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -128,7 +128,7 @@ export const ErrorMessages = {
   [ErrorCodes.FETCH_USERS_FAILED]: "Unable to fetch users for admin display. Please try again later.",
   [ErrorCodes.ADMIN_ADD_USER_FAILED]: "Unable to add user. Please try again later.",
   [ErrorCodes.SERVER_TIMEOUT]: "Server timed out. Please try again later.",
-  [ErrorCodes.SERVER_BUSY]: "Server is too busy. Please try again later."
+  [ErrorCodes.SERVER_BUSY]: "Server is too busy. Please try again later.",
   [ErrorCodes.ADMIN_DELETE_USER_FAILED]: "Unable to delete user. Please try again later.",
   [ErrorCodes.UNABLE_TO_FETCH_USER_DATAPACKS]: "Unable to fetch user datapacks. Please try again later.",
   [ErrorCodes.CANNOT_DELETE_ROOT_USER]: "Cannot delete root user.",

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -58,7 +58,9 @@ export enum ErrorCodes {
   SERVER_BUSY = "SERVER_BUSY",
   UNABLE_TO_FETCH_USER_DATAPACKS = "UNABLE_TO_FETCH_USER_DATAPACKS",
   CANNOT_DELETE_ROOT_USER = "CANNOT_DELETE_ROOT_USER",
-  ADMIN_DELETE_USER_DATAPACK_FAILED = "ADMIN_DELETE_USER_DATAPACK_FAILED"
+  ADMIN_DELETE_USER_DATAPACK_FAILED = "ADMIN_DELETE_USER_DATAPACK_FAILED",
+  ADMIN_DELETE_SERVER_DATAPACK_FAILED = "ADMIN_DELETE_SERVER_DATAPACK_FAILED",
+  ADMIN_CANNOT_DELETE_ROOT_DATAPACK = "ADMIN_CANNOT_DELETE_ROOT_DATAPACK",
 }
 
 export const ErrorMessages = {
@@ -129,5 +131,7 @@ export const ErrorMessages = {
   [ErrorCodes.ADMIN_DELETE_USER_FAILED]: "Unable to delete user. Please try again later.",
   [ErrorCodes.UNABLE_TO_FETCH_USER_DATAPACKS]: "Unable to fetch user datapacks. Please try again later.",
   [ErrorCodes.CANNOT_DELETE_ROOT_USER]: "Cannot delete root user.",
-  [ErrorCodes.ADMIN_DELETE_USER_DATAPACK_FAILED]: "Unable to delete user datapack. Please try again later."
+  [ErrorCodes.ADMIN_DELETE_USER_DATAPACK_FAILED]: "Unable to delete user datapack. Please try again later.",
+  [ErrorCodes.ADMIN_DELETE_SERVER_DATAPACK_FAILED]: "Unable to delete server datapack. Please try again later.",
+  [ErrorCodes.ADMIN_CANNOT_DELETE_ROOT_DATAPACK]: "Cannot delete root datapack. Ask server admin for assistance.",
 };

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -56,7 +56,7 @@ export enum ErrorCodes {
   ADMIN_DELETE_USER_FAILED = "ADMIN_DELETE_USER_FAILED",
   SERVER_TIMEOUT = "SERVER_TIMEOUT",
   SERVER_BUSY = "SERVER_BUSY",
-  UNABLE_TO_FETCH_USER_DATAPACKS = "UNABLE_TO_FETCH_USER_DATAPACKS",
+  UNABLE_TO_FETCH_USER_DATAPACKS = "UNABLE_TO_FETCH_USER_DATAPACKS"
 }
 
 export const ErrorMessages = {
@@ -125,5 +125,5 @@ export const ErrorMessages = {
   [ErrorCodes.SERVER_TIMEOUT]: "Server timed out. Please try again later.",
   [ErrorCodes.SERVER_BUSY]: "Server is too busy. Please try again later."
   [ErrorCodes.ADMIN_DELETE_USER_FAILED]: "Unable to delete user. Please try again later.",
-  [ErrorCodes.UNABLE_TO_FETCH_USER_DATAPACKS]: "Unable to fetch user datapacks. Please try again later.",
+  [ErrorCodes.UNABLE_TO_FETCH_USER_DATAPACKS]: "Unable to fetch user datapacks. Please try again later."
 };

--- a/server/__tests__/__data__/column-keys.json
+++ b/server/__tests__/__data__/column-keys.json
@@ -1,2059 +1,2057 @@
 {
-    "general-parse-datapacks-test-1-key": {
-      "columnInfo": {
-        "name": "Chart Title",
-        "editName": "Chart Title",
-        "fontsInfo": {
-          "font": "Arial"
-        },
-        "fontOptions": [
-          "Column Header",
-          "Age Label",
-          "Uncertainty Label",
-          "Zone Column Label"
-        ],
-        "on": true,
-        "width": 100,
-        "enableTitle": true,
-        "show": true,
-        "expanded": true,
-        "rgb": {
-          "r": 255,
-          "g": 255,
-          "b": 255
-        },
-        "popup": "",
-        "children": [
-          {
-            "name": "Ma",
-            "editName": "Ma",
-            "fontsInfo": {
-              "font": "Arial"
-            },
-            "fontOptions": [
-              "Column Header",
-              "Ruler Label"
-            ],
-            "show": true,
-            "expanded": false,
-            "on": true,
-            "width": 100,
-            "enableTitle": true,
-            "rgb": {
-              "r": 255,
-              "g": 255,
-              "b": 255
-            },
-            "popup": "",
-            "children": [],
-            "parent": "Chart Title",
-            "minAge": 5e-324,
-            "maxAge": 1.7976931348623157e+308,
-            "units": "Ma",
-            "columnDisplayType": "Ruler"
-          },
-          {
-            "name": "Central Africa Cenozoic",
-            "editName": "Central Africa Cenozoic",
-            "on": true,
-            "enableTitle": true,
-            "show": true,
-            "expanded": false,
-            "fontsInfo": {
-              "font": "Arial"
-            },
-            "popup": "",
-            "children": [
-              {
-                "name": "Nigeria Coast",
-                "editName": "Nigeria Coast",
-                "on": true,
-                "enableTitle": true,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "",
-                "show": true,
-                "expanded": false,
-                "children": [
-                  {
-                    "name": "Nigeria Coast Facies",
-                    "editName": "Nigeria Coast",
-                    "on": true,
-                    "enableTitle": false,
-                    "showAgeLabels": false,
-                    "expanded": false,
-                    "showUncertaintyLabels": false,
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Uncertainty Label"
-                    ],
-                    "popup": "",
-                    "children": [],
-                    "parent": "Nigeria Coast",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "show": true,
-                    "width": 84,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Facies", 
-                    "subInfo": [
-                      {
-                        "age": 0,
-                        "info": "",
-                        "rockType": "TOP"
-                      },
-                      {
-                        "age": 5,
-                        "info": "",
-                        "label": "Delta",
-                        "rockType": "Sandstone"
-                      },
-                      {
-                        "age": 10,
-                        "info": "",
-                        "label": "ProDelta",
-                        "rockType": "Claystone"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "Nigeria Coast Members",
-                    "editName": "Members",
-                    "on": false,
-                    "enableTitle": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "showAgeLabels": false,
-                    "popup": "",
-                    "children": [],
-                    "parent": "Nigeria Coast",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "width": 210,
-                    "show": true,
-                    "expanded": false,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  },
-                  {
-                    "name": "Nigeria Coast Facies Label",
-                    "editName": "Facies Label",
-                    "on": true,
-                    "enableTitle": false,
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "showAgeLabels": false,
-                    "popup": "",
-                    "children": [],
-                    "parent": "Nigeria Coast",
-                    "show": true,
-                    "expanded": false,
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "width": 84,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  },
-                  {
-                    "name": "Nigeria Coast Series Label",
-                    "editName": "Series Label",
-                    "show": true,
-                    "expanded": false,
-                    "on": true,
-                    "enableTitle": false,
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "showAgeLabels": false,
-                    "popup": "",
-                    "children": [],
-                    "parent": "Nigeria Coast",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "width": 42,
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  }
-                ],
-                "parent": "Central Africa Cenozoic",
-                "columnDisplayType": "BlockSeriesMetaColumn",
-                "minAge": 0,
-                "maxAge": 10,
-                "rgb": {
-                  "r": 255,
-                  "g": 255,
-                  "b": 255
-                },
-                "fontOptions": [
-                  "Column Header",
-                  "Age Label",
-                  "Uncertainty Label",
-                  "Zone Column Label"
-                ],
-                "units": "Ma",
-                "subInfo": [
-                  {
-                    "rockType": "TOP",
-                    "age": 0,
-                    "info": ""
-                  },
-                  {
-                    "rockType": "Sandstone",
-                    "label": "Delta",
-                    "age": 5,
-                    "info": ""
-                  },
-                  {
-                    "rockType": "Claystone",
-                    "label": "ProDelta",
-                    "age": 10,
-                    "info": ""
-                  }
-                ]
-              },
-              {
-                "name": "South Atlantic",
-                "editName": "South Atlantic",
-                "on": true,
-                "enableTitle": true,
-                "show": true,
-                "expanded": false,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "",
-                "children": [
-                  {
-                    "name": "South Atlantic Facies",
-                    "editName": "South Atlantic",
-                    "on": true,
-                    "enableTitle": false,
-                    "show": true,
-                    "expanded": false,
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Uncertainty Label"
-                    ],
-                    "showAgeLabels": false,
-                    "showUncertaintyLabels": false,
-                    "popup": "",
-                    "children": [],
-                    "parent": "South Atlantic",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "width": 84,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Facies",
-                    "subInfo": [
-                      {
-                        "age": 0,
-                        "info": "",
-                        "rockType": "TOP"
-                      },
-                      {
-                        "age": 5,
-                        "info": "",
-                        "label": "Deep marine",
-                        "rockType": "Shallow-marine marl"
-                      },
-                      {
-                        "age": 10,
-                        "info": "",
-                        "label": "Ocean crust",
-                        "rockType": "Lava"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "South Atlantic Members",
-                    "editName": "Members",
-                    "show": true,
-                    "expanded": false,
-                    "on": false,
-                    "enableTitle": false,
-                    "showAgeLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "popup": "",
-                    "children": [],
-                    "parent": "South Atlantic",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "width": 210,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  },
-                  {
-                    "name": "South Atlantic Facies Label",
-                    "editName": "Facies Label",
-                    "show": true,
-                    "expanded": false,
-                    "on": true,
-                    "enableTitle": false,
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "showAgeLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "popup": "",
-                    "children": [],
-                    "parent": "South Atlantic",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "width": 84,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  },
-                  {
-                    "name": "South Atlantic Series Label",
-                    "editName": "Series Label",
-                    "show": true,
-                    "expanded": false,
-                    "on": true,
-                    "enableTitle": false,
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "showAgeLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "popup": "",
-                    "children": [],
-                    "parent": "South Atlantic",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "width": 42,
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  }
-                ],
-                "parent": "Central Africa Cenozoic",
-                "columnDisplayType": "BlockSeriesMetaColumn",
-                "minAge": 0,
-                "maxAge": 10,
-                "rgb": {
-                  "r": 255,
-                  "g": 255,
-                  "b": 255
-                },
-                "fontOptions": [
-                  "Column Header",
-                  "Age Label",
-                  "Uncertainty Label",
-                  "Zone Column Label"
-                ],
-                "units": "Ma",
-                "subInfo": [
-                  {
-                    "rockType": "TOP",
-                    "age": 0,
-                    "info": ""
-                  },
-                  {
-                    "rockType": "Shallow-marine marl",
-                    "label": "Deep marine",
-                    "age": 5,
-                    "info": ""
-                  },
-                  {
-                    "rockType": "Lava",
-                    "label": "Ocean crust",
-                    "age": 10,
-                    "info": ""
-                  }
-                ]
-              }
-            ],
-            "parent": "Chart Title",
-            "columnDisplayType": "MetaColumn",
-            "minAge": 0,
-            "maxAge": 10,
-            "rgb": {
-              "r": 255,
-              "g": 255,
-              "b": 255
-            },
-            "fontOptions": [
-              "Column Header",
-              "Age Label",
-              "Uncertainty Label",
-              "Zone Column Label"
-            ],
-            "units": "Ma",
-            "subInfo": [
-              {
-                "rockType": "TOP",
-                "age": 0,
-                "info": ""
-              },
-              {
-                "rockType": "Sandstone",
-                "label": "Delta",
-                "age": 5,
-                "info": ""
-              },
-              {
-                "rockType": "Claystone",
-                "label": "ProDelta",
-                "age": 10,
-                "info": ""
-              }
-            ]
-          }
-        ],
-        "parent": "Chart Root",
-        "minAge": 0,
-        "maxAge": 10,
-        "units": "Ma",
-        "columnDisplayType": "RootColumn"
+  "general-parse-datapacks-test-1-key": {
+    "columnInfo": {
+      "name": "Chart Title",
+      "editName": "Chart Title",
+      "fontsInfo": {
+        "font": "Arial"
       },
-      "ageUnits": "Ma",
-      "defaultChronostrat": "UNESCO",
-      "formatVersion": 1.5,
-      "image": "",
-      "isUserDatapack": false,
-      "file": "AfricaBight.map",
-      "description": "Africa Bight Map",
-      "title": "Africa Bight",
-      "size": "200.98 KB"
-    },
-    "general-parse-datapacks-test-2-key": {
-      "columnInfo": {
-        "name": "Chart Title",
-        "editName": "Chart Title",
-        "fontsInfo": {
-          "font": "Arial"
-        },
-        "fontOptions": [
-          "Column Header",
-          "Age Label",
-          "Zone Column Label",
-          "Uncertainty Label",
-          "Event Column Label",
-          "Range Label",
-          "Popup Body",
-          "Point Column Scale Label",
-          "Sequence Column Label"
-        ],
-        "on": true,
-        "show": true,
-        "expanded": true,
-        "width": 100,
-        "enableTitle": true,
-        "rgb": {
-          "r": 255,
-          "g": 255,
-          "b": 255
-        },
-        "popup": "",
-        "children": [
-          {
-            "name": "Ma",
-            "editName": "Ma",
-            "fontsInfo": {
-              "font": "Arial"
-            },
-            "fontOptions": [
-              "Column Header",
-              "Ruler Label"
-            ],
-            "on": true,
-            "show": true,
-            "expanded": false,
-            "width": 100,
-            "enableTitle": true,
-            "rgb": {
-              "r": 255,
-              "g": 255,
-              "b": 255
-            },
-            "popup": "",
-            "children": [],
-            "parent": "Chart Title",
-            "minAge": 5e-324,
-            "maxAge": 1.7976931348623157e+308,
-            "units": "Ma",
-            "columnDisplayType": "Ruler"
+      "fontOptions": [
+        "Column Header",
+        "Age Label",
+        "Uncertainty Label",
+        "Zone Column Label"
+      ],
+      "on": true,
+      "width": 100,
+      "enableTitle": true,
+      "show": true,
+      "expanded": true,
+      "rgb": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      },
+      "popup": "",
+      "children": [
+        {
+          "name": "Ma",
+          "editName": "Ma",
+          "fontsInfo": {
+            "font": "Arial"
           },
-          {
-            "name": "Parent 1",
-            "editName": "Parent 1",
-            "on": true,
-            "show": true,
-            "expanded": false,
-            "enableTitle": true,
-            "fontsInfo": {
-              "font": "Arial"
-            },
-            "popup": "",
-            "children": [
-              {
-                "name": "Block",
-                "editName": "Block",
-                "on": false,
-                "show": true,
-                "expanded": false,
-                "enableTitle": false,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "Block Popup",
-                "children": [],
-                "parent": "Parent 1",
-                "minAge": 419.2,
-                "maxAge": 433.35,
-                "width": 120,
-                "rgb": {
-                  "r": 197,
-                  "g": 217,
-                  "b": 234
-                },
-                "showAgeLabels": false,
-                "fontOptions": [
-                  "Column Header",
-                  "Age Label",
-                  "Zone Column Label"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "Zone",
-                "subInfo": [
-                  {
-                    "label": "TOP",
-                    "age": 419.2,
-                    "popup": "",
-                    "lineStyle": "solid",
-                    "rgb": {
-                      "r": 197,
-                      "g": 217,
-                      "b": 234
-                    }
-                  },
-                  {
-                    "label": "Block SubBlock",
-                    "age": 433.35,
-                    "popup": "Block SubBlock Info",
-                    "lineStyle": "solid",
-                    "rgb": {
-                      "r": 197,
-                      "g": 217,
-                      "b": 234
-                    }
-                  }
-                ]
+          "fontOptions": [
+            "Column Header",
+            "Ruler Label"
+          ],
+          "show": true,
+          "expanded": false,
+          "on": true,
+          "width": 100,
+          "enableTitle": true,
+          "rgb": {
+            "r": 255,
+            "g": 255,
+            "b": 255
+          },
+          "popup": "",
+          "children": [],
+          "parent": "Chart Title",
+          "minAge": 5e-324,
+          "maxAge": 1.7976931348623157e+308,
+          "units": "Ma",
+          "columnDisplayType": "Ruler"
+        },
+        {
+          "name": "Central Africa Cenozoic",
+          "editName": "Central Africa Cenozoic",
+          "on": true,
+          "enableTitle": true,
+          "show": true,
+          "expanded": false,
+          "fontsInfo": {
+            "font": "Arial"
+          },
+          "popup": "",
+          "children": [
+            {
+              "name": "Nigeria Coast",
+              "editName": "Nigeria Coast",
+              "on": true,
+              "enableTitle": true,
+              "fontsInfo": {
+                "font": "Arial"
               },
-              {
-                "name": "Facies",
-                "editName": "Facies",
-                "on": false,
-                "enableTitle": false,
-                "show": true,
-                "expanded": false,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "Facies Popup",
-                "children": [
-                  {
-                    "name": "Facies Facies",
-                    "editName": "Facies",
-                    "show": true,
-                    "expanded": false,
-                    "on": true,
-                    "enableTitle": false,
-                    "fontsInfo": {
-                      "font": "Arial"
+              "popup": "",
+              "show": true,
+              "expanded": false,
+              "children": [
+                {
+                  "name": "Nigeria Coast Facies",
+                  "editName": "Nigeria Coast",
+                  "on": true,
+                  "enableTitle": false,
+                  "showAgeLabels": false,
+                  "expanded": false,
+                  "showUncertaintyLabels": false,
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Uncertainty Label"
+                  ],
+                  "popup": "",
+                  "children": [],
+                  "parent": "Nigeria Coast",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "show": true,
+                  "width": 84,
+                  "rgb": {
+                    "r": 255,
+                    "g": 255,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Facies",
+                  "subInfo": [
+                    {
+                      "age": 0,
+                      "info": "",
+                      "rockType": "TOP"
                     },
-                    "showAgeLabels": false,
-                    "showUncertaintyLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Uncertainty Label"
-                    ],
-                    "popup": "",
-                    "children": [],
-                    "parent": "Facies",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "width": 84,
-                    "rgb": {
-                      "r": 100,
-                      "g": 200,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Facies",
-                    "subInfo": [
-                      {
-                        "age": 0,
-                        "info": "",
-                        "rockType": "TOP"
-                      },
-                      {
+                    {
                       "age": 5,
                       "info": "",
-                      "label": "Facies SubFaciesInfo 1 Label",
-                        "rockType": "Facies SubFaciesInfo 1"
-                      },
-                      {
-                        "age": 10,
-                        "info": "",
-                        "label": "Facies SubFaciesInfo 2 Label",
-                        "rockType": "Facies SubFaciesInfo 2"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "Facies Members",
-                    "editName": "Members",
-                    "on": false,
-                    "show": true,
-                    "expanded": false,
-                    "enableTitle": false,
-                    "showAgeLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "fontsInfo": {
-                      "font": "Arial"
+                      "label": "Delta",
+                      "rockType": "Sandstone"
                     },
-                    "popup": "",
-                    "children": [],
-                    "parent": "Facies",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "width": 210,
-                    "rgb": {
-                      "r": 100,
-                      "g": 200,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  },
-                  {
-                    "name": "Facies Facies Label",
-                    "editName": "Facies Label",
-                    "on": true,
-                    "show": true,
-                    "expanded": false,
-                    "enableTitle": false,
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "showAgeLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "popup": "",
-                    "children": [],
-                    "parent": "Facies",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "width": 84,
-                    "rgb": {
-                      "r": 100,
-                      "g": 200,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  },
-                  {
-                    "name": "Facies Series Label",
-                    "editName": "Series Label",
-                    "on": true,
-                    "enableTitle": false,
-                    "show": true,
-                    "expanded": false,
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "showAgeLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "popup": "",
-                    "children": [],
-                    "parent": "Facies",
-                    "minAge": 0,
-                    "maxAge": 10,
-                    "rgb": {
-                      "r": 100,
-                      "g": 200,
-                      "b": 255
-                    },
-                    "width": 42,
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  }
-                ],
-                "parent": "Parent 1",
-                "minAge": 0,
-                "maxAge": 10,
-                "rgb": {
-                  "r": 100,
-                  "g": 200,
-                  "b": 255
+                    {
+                      "age": 10,
+                      "info": "",
+                      "label": "ProDelta",
+                      "rockType": "Claystone"
+                    }
+                  ]
                 },
-                "fontOptions": [
-                  "Column Header",
-                  "Age Label",
-                  "Uncertainty Label",
-                  "Zone Column Label"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "BlockSeriesMetaColumn",
-                "subInfo": [
-                  {
-                    "rockType": "TOP",
-                    "age": 0,
-                    "info": ""
+                {
+                  "name": "Nigeria Coast Members",
+                  "editName": "Members",
+                  "on": false,
+                  "enableTitle": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "fontsInfo": {
+                    "font": "Arial"
                   },
-                  {
-                    "rockType": "Facies SubFaciesInfo 1",
-                    "label": "Facies SubFaciesInfo 1 Label",
-                    "age": 5,
-                    "info": ""
-                  },
-                  {
-                    "rockType": "Facies SubFaciesInfo 2",
-                    "label": "Facies SubFaciesInfo 2 Label",
-                    "age": 10,
-                    "info": ""
-                  }
-                ]
-              },
-              {
-                "name": "Event",
-                "editName": "Event",
-                "on": true,
-                "show": true,
-                "expanded": false,
-                "enableTitle": true,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "Event Popup",
-                "children": [],
-                "parent": "Parent 1",
-                "minAge": 0.02,
-                "maxAge": 0.4,
-                "width": 250,
-                "rgb": {
-                  "r": 100,
-                  "g": 200,
-                  "b": 255
-                },
-                "showAgeLabels": false,
-                "showUncertaintyLabels": false,
-                "columnSpecificSettings": {
-                  "type": "events",
-                  "rangeSort": "first occurrence",
-                  "frequency": null,
-                  "stepSize": 1,
-                  "windowSize": 2
-                },
-                "fontOptions": [
-                  "Column Header",
-                  "Age Label",
-                  "Event Column Label",
-                  "Uncertainty Label",
-                  "Range Label"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "Event",
-                "subInfo": [
-                  {
-                    "label": "SubEventInfo 1",
-                    "age": 0.02,
-                    "popup": "Event SubEventInfo Popup 1",
-                    "lineStyle": "solid",
-                    "subEventType": "EVENT"
-                  },
-                  {
-                    "label": "SubEventInfo 2",
-                    "age": 0.4,
-                    "popup": "Event SubEventInfo Popup 2",
-                    "lineStyle": "solid",
-                    "subEventType": "EVENT"
-                  }
-                ]
-              },
-              {
-                "name": "Range",
-                "editName": "Range",
-                "on": true,
-                "show": true,
-                "expanded": false,
-                "enableTitle": true,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "Range Popup",
-                "children": [],
-                "parent": "Parent 1",
-                "minAge": 10,
-                "maxAge": 100,
-                "width": 100,
-                "rgb": {
-                  "r": 198,
-                  "g": 207,
-                  "b": 174
-                },
-                "fontOptions": [
-                  "Column Header",
-                  "Popup Body"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "Range",
-                "columnSpecificSettings": {
-                  "agePad": 2,
-                  "margin": 0.2,
-                  "rangeSort":"first occurrence"
-                },
-                "subInfo": [
-                  {
-                    "label": "SubRangeInfo 1",
-                    "age": 10,
-                    "abundance": "TOP",
-                    "popup": ""
-                  },
-                  {
-                    "label": "SubRangeInfo 2",
-                    "age": 100,
-                    "abundance": "rare",
-                    "popup": "Range SubRangeInfo Popup 2"
-                  }
-                ]
-              },
-              {
-                "name": "Chron",
-                "editName": "Chron",
-                "on": true,
-                "show": true,
-                "expanded": false,
-                "enableTitle": false,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "Chron Popup",
-                "children": [
-                  {
-                    "name": "Chron Chron",
-                    "editName": "Chron",
-                    "columnSpecificSettings": {
-                      "dataMiningChronDataType": null,
-                      "stepSize": 1,
-                      "windowSize": 2
-                    },
-                    "on": true,
-                    "show": true,
-                    "expanded": false,
-                    "enableTitle": false,
-                    "showAgeLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label"
-                    ],
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "subInfo": [
-                      {
-                        "polarity": "TOP",
-                        "age": 0,
-                        "popup": ""
-                      },
-                      {
-                        "polarity": "N",
-                        "age": 0.123,
-                        "label": "SubChronInfo 1 Label",
-                        "popup": "SubChronInfo 1 Popup"
-                      },
-                      {
-                        "polarity": "R",
-                        "age": 0.234,
-                        "label": "SubChronInfo 2 Label",
-                        "popup": "SubChronInfo 2 Popup"
-                      }
-                    ],
-                    "popup": "",
-                    "children": [],
-                    "parent": "Chron",
-                    "minAge": 0,
-                    "maxAge": 0.234,
-                    "width": 60,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Chron"
-                  },
-                  {
-                    "name": "Chron Chron Label",
-                    "editName": "Chron Label",
-                    "show": true,
-                    "expanded": false,
-                    "on": false,
-                    "enableTitle": false,
-                    "showAgeLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "popup": "",
-                    "children": [],
-                    "parent": "Chron",
-                    "minAge": 0,
-                    "maxAge": 0.234,
-                    "width": 40,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  },
-                  {
-                    "name": "Chron Series Label",
-                    "editName": "Series Label",
-                    "show": true,
-                    "expanded": false,
-                    "on": true,
-                    "enableTitle": false,
-                    "showAgeLabels": false,
-                    "fontOptions": [
-                      "Column Header",
-                      "Age Label",
-                      "Zone Column Label"
-                    ],
-                    "fontsInfo": {
-                      "font": "Arial"
-                    },
-                    "popup": "",
-                    "children": [],
-                    "parent": "Chron",
-                    "minAge": 0,
-                    "maxAge": 0.234,
-                    "width": 40,
-                    "rgb": {
-                      "r": 255,
-                      "g": 255,
-                      "b": 255
-                    },
-                    "units": "Ma",
-                    "columnDisplayType": "Zone"
-                  }
-                ],
-                "parent": "Parent 1",
-                "minAge": 0,
-                "maxAge": 0.234,
-                "rgb": {
-                  "r": 255,
-                  "g": 255,
-                  "b": 255
-                },
-                "fontOptions": [
-                  "Column Header",
-                  "Age Label",
-                  "Zone Column Label"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "BlockSeriesMetaColumn",
-                "subInfo": [
-                  {
-                    "polarity": "TOP",
-                    "age": 0,
-                    "popup": ""
-                  },
-                  {
-                    "polarity": "N",
-                    "age": 0.123,
-                    "label": "SubChronInfo 1 Label",
-                    "popup": "SubChronInfo 1 Popup"
-                  },
-                  {
-                    "polarity": "R",
-                    "age": 0.234,
-                    "label": "SubChronInfo 2 Label",
-                    "popup": "SubChronInfo 2 Popup"
-                  }
-                ]
-              },
-              {
-                "name": "Point",
-                "editName": "Point",
-                "show": true,
-                "expanded": false,
-                "on": false,
-                "enableTitle": true,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "Point Popup",
-                "children": [],
-                "parent": "Parent 1",
-                "minAge": 4,
-                "maxAge": 5,
-                "width": 100,
-                "rgb": {
-                  "r": 255,
-                  "g": 255,
-                  "b": 255
-                },
-                "fontOptions": [
-                  "Column Header",
-                  "Point Column Scale Label"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "Point",
-                "subInfo": [
-                  {
-                    "age": 4,
-                    "xVal": 0,
-                    "popup": "SubPointInfo Popup 1"
-                  },
-                  {
-                    "age": 5,
-                    "xVal": 9,
-                    "popup": "SubPointInfo Popup 2"
-                  }
-                ],
-                "columnSpecificSettings": {
-                  "drawFill": true,
-                  "drawLine": true,
-                  "lowerRange": 0,
-                  "upperRange": 10,
-                  "smoothed": true,
-                  "minX": 0,
-                  "maxX": 9,
-                  "pointShape": "nopoints",
-                  "backgroundGradientStart": {
-                    "r": 0,
-                    "g": 0,
-                    "b": 0
-                  },
-                  "backgroundGradientEnd": {
+                  "showAgeLabels": false,
+                  "popup": "",
+                  "children": [],
+                  "parent": "Nigeria Coast",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "width": 210,
+                  "show": true,
+                  "expanded": false,
+                  "rgb": {
                     "r": 255,
                     "g": 255,
                     "b": 255
                   },
-                  "curveGradientStart": {
-                    "r": 0,
-                    "g": 0,
-                    "b": 0
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                },
+                {
+                  "name": "Nigeria Coast Facies Label",
+                  "editName": "Facies Label",
+                  "on": true,
+                  "enableTitle": false,
+                  "fontsInfo": {
+                    "font": "Arial"
                   },
-                  "curveGradientEnd": {
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "showAgeLabels": false,
+                  "popup": "",
+                  "children": [],
+                  "parent": "Nigeria Coast",
+                  "show": true,
+                  "expanded": false,
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "width": 84,
+                  "rgb": {
                     "r": 255,
                     "g": 255,
                     "b": 255
                   },
-                  "drawBackgroundGradient": false,
-                  "drawCurveGradient": false,
-                  "drawScale": true,
-                  "fill": {
-                    "r": 64,
-                    "g": 233,
-                    "b": 191
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                },
+                {
+                  "name": "Nigeria Coast Series Label",
+                  "editName": "Series Label",
+                  "show": true,
+                  "expanded": false,
+                  "on": true,
+                  "enableTitle": false,
+                  "fontsInfo": {
+                    "font": "Arial"
                   },
-                  "flipScale": false,
-                  "lineColor": {
-                    "r": 0,
-                    "g": 0,
-                    "b": 0
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "showAgeLabels": false,
+                  "popup": "",
+                  "children": [],
+                  "parent": "Nigeria Coast",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "rgb": {
+                    "r": 255,
+                    "g": 255,
+                    "b": 255
                   },
-                  "scaleStart": 0,
-                  "scaleStep": 1,
-                  "dataMiningPointDataType": null,
-                  "windowSize": 2,
-                  "stepSize": 1,
-                  "isDataMiningColumn": false
+                  "width": 42,
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
                 }
+              ],
+              "parent": "Central Africa Cenozoic",
+              "columnDisplayType": "BlockSeriesMetaColumn",
+              "minAge": 0,
+              "maxAge": 10,
+              "rgb": {
+                "r": 255,
+                "g": 255,
+                "b": 255
               },
-              {
-                "name": "Sequence",
-                "editName": "Sequence",
-                "show": true,
-                "expanded": false,
-                "on": true,
-                "enableTitle": false,
-                "fontsInfo": {
-                  "font": "Arial"
+              "fontOptions": [
+                "Column Header",
+                "Age Label",
+                "Uncertainty Label",
+                "Zone Column Label"
+              ],
+              "units": "Ma",
+              "subInfo": [
+                {
+                  "rockType": "TOP",
+                  "age": 0,
+                  "info": ""
                 },
-                "popup": "Sequence Popup",
-                "children": [],
-                "parent": "Parent 1",
-                "minAge": 0,
-                "maxAge": 2,
-                "width": 900,
-                "rgb": {
-                  "r": 255,
-                  "g": 255,
-                  "b": 255
+                {
+                  "rockType": "Sandstone",
+                  "label": "Delta",
+                  "age": 5,
+                  "info": ""
                 },
-                "showAgeLabels": false,
-                "fontOptions": [
-                  "Column Header",
-                  "Age Label",
-                  "Sequence Column Label"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "Sequence",
-                "subInfo": [
-                  {
-                    "direction": "MFS",
-                    "age": 0,
-                    "severity": "Major",
-                    "popup": "No Label Popup"
-                  },
-                  {
-                    "label": "Label 1",
-                    "direction": "SB",
-                    "age": 2,
-                    "severity": "Medium",
-                    "popup": "Label 1 Popup"
-                  }
-                ],
-                "columnSpecificSettings": {
-                                 "drawNameLabel": true,
-                                 "graphStyle": "stroke-width: 0; fill: rgb(64, 191, 233);",
-                                 "labelMarginLeft": 5,
-                                 "labelMarginRight": 5,
-                                 "type": "sequence"
-                               }
-              },
-              {
-                "name": "Freehand",
-                "editName": "Freehand",
-                "show": true,
-                "expanded": false,
-                "on": true,
-                "enableTitle": false,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "",
-                "children": [],
-                "parent": "Parent 1",
-                "minAge": 0,
-                "maxAge": 1.3,
-                "width": 70,
-                "rgb": {
-                  "r": 227,
-                  "g": 123,
-                  "b": 104
-                },
-                "fontOptions": [
-                  "Column Header"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "Freehand",
-                "subInfo": [
-                  {
-                    "topAge": 0,
-                    "baseAge": 1
-                  },
-                  {
-                    "topAge": 0.3,
-                    "baseAge": 1.3
-                  }
-                ]
-              },
-              {
-                "name": "Blank",
-                "editName": "Blank",
-                "show": true,
-                "expanded": false,
-                "on": false,
-                "enableTitle": false,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "Blank Popup",
-                "children": [],
-                "parent": "Parent 1",
-                "minAge": 1.7976931348623157e+308,
-                "maxAge": 5e-324,
-                "width": 800,
-                "rgb": {
-                  "r": 7,
-                  "g": 3,
-                  "b": 4
-                },
-                "fontOptions": [
-                  "Column Header"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "Blank"
-              },
-              {
-                "name": "Transect",
-                "editName": "Transect",
-                "show": true,
-                "expanded": false,
-                "on": true,
-                "enableTitle": true,
-                "fontsInfo": {
-                  "font": "Arial"
-                },
-                "popup": "Transect Popup",
-                "children": [],
-                "parent": "Parent 1",
-                "minAge": 0,
-                "maxAge": 9.22,
-                "width": 500,
-                "rgb": {
-                  "r": 240,
-                  "g": 255,
-                  "b": 255
-                },
-                "fontOptions": [
-                  "Column Header"
-                ],
-                "units": "Ma",
-                "columnDisplayType": "Transect",
-                "subInfo": [
-                  {
-                    "age": 0
-                  },
-                  {
-                    "age": 2.58
-                  },
-                  {
-                    "age": 9.22
-                  }
-                ]
-              }
-            ],
-            "parent": "Chart Title",
-            "minAge": 0,
-            "maxAge": 433.35,
-            "rgb": {
-              "r": 255,
-              "g": 255,
-              "b": 255
+                {
+                  "rockType": "Claystone",
+                  "label": "ProDelta",
+                  "age": 10,
+                  "info": ""
+                }
+              ]
             },
-            "fontOptions": [
-              "Column Header",
-              "Age Label",
-              "Zone Column Label",
-              "Uncertainty Label",
-              "Event Column Label",
-              "Range Label",
-              "Popup Body",
-              "Point Column Scale Label",
-              "Sequence Column Label"
-            ],
-            "units": "Ma",
-            "columnDisplayType": "MetaColumn",
-            "subInfo": [
-              {
-                "rockType": "TOP",
-                "age": 0,
-                "info": ""
+            {
+              "name": "South Atlantic",
+              "editName": "South Atlantic",
+              "on": true,
+              "enableTitle": true,
+              "show": true,
+              "expanded": false,
+              "fontsInfo": {
+                "font": "Arial"
               },
-              {
-                "rockType": "Facies SubFaciesInfo 1",
-                "label": "Facies SubFaciesInfo 1 Label",
-                "age": 5,
-                "info": ""
+              "popup": "",
+              "children": [
+                {
+                  "name": "South Atlantic Facies",
+                  "editName": "South Atlantic",
+                  "on": true,
+                  "enableTitle": false,
+                  "show": true,
+                  "expanded": false,
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Uncertainty Label"
+                  ],
+                  "showAgeLabels": false,
+                  "showUncertaintyLabels": false,
+                  "popup": "",
+                  "children": [],
+                  "parent": "South Atlantic",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "width": 84,
+                  "rgb": {
+                    "r": 255,
+                    "g": 255,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Facies",
+                  "subInfo": [
+                    {
+                      "age": 0,
+                      "info": "",
+                      "rockType": "TOP"
+                    },
+                    {
+                      "age": 5,
+                      "info": "",
+                      "label": "Deep marine",
+                      "rockType": "Shallow-marine marl"
+                    },
+                    {
+                      "age": 10,
+                      "info": "",
+                      "label": "Ocean crust",
+                      "rockType": "Lava"
+                    }
+                  ]
+                },
+                {
+                  "name": "South Atlantic Members",
+                  "editName": "Members",
+                  "show": true,
+                  "expanded": false,
+                  "on": false,
+                  "enableTitle": false,
+                  "showAgeLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "popup": "",
+                  "children": [],
+                  "parent": "South Atlantic",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "width": 210,
+                  "rgb": {
+                    "r": 255,
+                    "g": 255,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                },
+                {
+                  "name": "South Atlantic Facies Label",
+                  "editName": "Facies Label",
+                  "show": true,
+                  "expanded": false,
+                  "on": true,
+                  "enableTitle": false,
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "showAgeLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "popup": "",
+                  "children": [],
+                  "parent": "South Atlantic",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "width": 84,
+                  "rgb": {
+                    "r": 255,
+                    "g": 255,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                },
+                {
+                  "name": "South Atlantic Series Label",
+                  "editName": "Series Label",
+                  "show": true,
+                  "expanded": false,
+                  "on": true,
+                  "enableTitle": false,
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "showAgeLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "popup": "",
+                  "children": [],
+                  "parent": "South Atlantic",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "rgb": {
+                    "r": 255,
+                    "g": 255,
+                    "b": 255
+                  },
+                  "width": 42,
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                }
+              ],
+              "parent": "Central Africa Cenozoic",
+              "columnDisplayType": "BlockSeriesMetaColumn",
+              "minAge": 0,
+              "maxAge": 10,
+              "rgb": {
+                "r": 255,
+                "g": 255,
+                "b": 255
               },
-              {
-                "rockType": "Facies SubFaciesInfo 2",
-                "label": "Facies SubFaciesInfo 2 Label",
-                "age": 10,
-                "info": ""
-              }
-            ]
-          }
-        ],
-        "parent": "Chart Root",
-        "minAge": 0,
-        "maxAge": 433.35,
-        "units": "Ma",
-        "columnDisplayType": "RootColumn"
+              "fontOptions": [
+                "Column Header",
+                "Age Label",
+                "Uncertainty Label",
+                "Zone Column Label"
+              ],
+              "units": "Ma",
+              "subInfo": [
+                {
+                  "rockType": "TOP",
+                  "age": 0,
+                  "info": ""
+                },
+                {
+                  "rockType": "Shallow-marine marl",
+                  "label": "Deep marine",
+                  "age": 5,
+                  "info": ""
+                },
+                {
+                  "rockType": "Lava",
+                  "label": "Ocean crust",
+                  "age": 10,
+                  "info": ""
+                }
+              ]
+            }
+          ],
+          "parent": "Chart Title",
+          "columnDisplayType": "MetaColumn",
+          "minAge": 0,
+          "maxAge": 10,
+          "rgb": {
+            "r": 255,
+            "g": 255,
+            "b": 255
+          },
+          "fontOptions": [
+            "Column Header",
+            "Age Label",
+            "Uncertainty Label",
+            "Zone Column Label"
+          ],
+          "units": "Ma",
+          "subInfo": [
+            {
+              "rockType": "TOP",
+              "age": 0,
+              "info": ""
+            },
+            {
+              "rockType": "Sandstone",
+              "label": "Delta",
+              "age": 5,
+              "info": ""
+            },
+            {
+              "rockType": "Claystone",
+              "label": "ProDelta",
+              "age": 10,
+              "info": ""
+            }
+          ]
+        }
+      ],
+      "parent": "Chart Root",
+      "minAge": 0,
+      "maxAge": 10,
+      "units": "Ma",
+      "columnDisplayType": "RootColumn"
+    },
+    "ageUnits": "Ma",
+    "defaultChronostrat": "UNESCO",
+    "formatVersion": 1.5,
+    "image": "",
+    "file": "AfricaBight.map",
+    "description": "Africa Bight Map",
+    "title": "Africa Bight",
+    "size": "200.98 KB"
+  },
+  "general-parse-datapacks-test-2-key": {
+    "columnInfo": {
+      "name": "Chart Title",
+      "editName": "Chart Title",
+      "fontsInfo": {
+        "font": "Arial"
       },
-      "topAge": 0,
-      "baseAge": 5,
-      "ageUnits": "Ma",
-      "defaultChronostrat": "USGS",
-      "formatVersion": 1,
-      "image": "",
-      "verticalScale": 6,
-      "date": "2015-03-15",
-      "isUserDatapack": false,
-      "file": "file.dpk",
-      "description": "description",
-      "title": "Title",
-      "size": "size"
-    },
-    "column-types-facies-key": {
-        "FaciesOne": {
-            "name": "FaciesOne",
-            "editName": "FaciesOne",
-            "show": true,
-            "expanded": false,
-            "units": "Ma",
-            "fontsInfo": {
-                "font": "Arial"
-            },
-            "columnDisplayType": "Facies",
-            "children": [],
-            "parent": null,
-            "fontOptions": [
-                "Column Header",
-                "Age Label",
-                "Uncertainty Label"
-            ],
-            "width": 500,
-            "rgb": {
-                "r": 255,
-                "g": 255,
-                "b": 255
-            },
-            "subInfo": [
-                {
-                    "rockType": "TOP",
-                    "age": 374.64,
-                    "info": "\"info\""
-                },
-                {
-                    "rockType": "RockTypeOne",
-                    "label": "RockTypeOneLabel",
-                    "age": 376.11,
-                    "info": "\"info for RockTypeOne\""
-                }
-            ],
-            "minAge": 374.64,
-            "maxAge": 376.11,
-            "enableTitle": true,
-            "popup": "\"FaciesOne info\"",
-            "on": false
+      "fontOptions": [
+        "Column Header",
+        "Age Label",
+        "Zone Column Label",
+        "Uncertainty Label",
+        "Event Column Label",
+        "Range Label",
+        "Popup Body",
+        "Point Column Scale Label",
+        "Sequence Column Label"
+      ],
+      "on": true,
+      "show": true,
+      "expanded": true,
+      "width": 100,
+      "enableTitle": true,
+      "rgb": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      },
+      "popup": "",
+      "children": [
+        {
+          "name": "Ma",
+          "editName": "Ma",
+          "fontsInfo": {
+            "font": "Arial"
+          },
+          "fontOptions": [
+            "Column Header",
+            "Ruler Label"
+          ],
+          "on": true,
+          "show": true,
+          "expanded": false,
+          "width": 100,
+          "enableTitle": true,
+          "rgb": {
+            "r": 255,
+            "g": 255,
+            "b": 255
+          },
+          "popup": "",
+          "children": [],
+          "parent": "Chart Title",
+          "minAge": 5e-324,
+          "maxAge": 1.7976931348623157e+308,
+          "units": "Ma",
+          "columnDisplayType": "Ruler"
         },
-        "FaciesTwo": {
-            "name": "FaciesTwo",
-            "editName": "FaciesTwo",
-            "units": "Ma",
-            "show": true,
-            "expanded": false,
-            "fontsInfo": {
+        {
+          "name": "Parent 1",
+          "editName": "Parent 1",
+          "on": true,
+          "show": true,
+          "expanded": false,
+          "enableTitle": true,
+          "fontsInfo": {
+            "font": "Arial"
+          },
+          "popup": "",
+          "children": [
+            {
+              "name": "Block",
+              "editName": "Block",
+              "on": false,
+              "show": true,
+              "expanded": false,
+              "enableTitle": false,
+              "fontsInfo": {
                 "font": "Arial"
-            },
-            "columnDisplayType": "Facies",
-            "children": [],
-            "parent": null,
-            "fontOptions": [
-                "Column Header",
-                "Age Label",
-                "Uncertainty Label"
-            ],
-            "subInfo": [
-                {
-                    "rockType": "TOP",
-                    "age": 311.59,
-                    "info": "\"info\""
-                },
-                {
-                    "rockType": "RockTypeTwo",
-                    "label": "RockTypeTwoLabel",
-                    "age": 315,
-                    "info": "\"info for RockTypeTwo\""
-                }
-            ],
-            "minAge": 311.59,
-            "width": 500,
-            "maxAge": 315,
-            "enableTitle": true,
-            "rgb": {
-                "r": 234,
-                "g": 221,
-                "b": 221 
-            },
-            "popup": "\"FaciesTwo info\"",
-            "on": false
-        }
-    },
-    "column-types-block-key": {
-        "Block Child 1": {
-            "name": "Block Child 1",
-            "editName": "Block Child 1",
-            "columnDisplayType": "Zone",
-            "fontOptions": [
-                "Column Header",
-                "Age Label",
-                "Zone Column Label"
-            ],
-            "fontsInfo": {
-                "font": "Arial"
-            },
-            "show": true,
-            "expanded": false,
-            "children": [],
-            "parent": null,
-            "subInfo": [
-                {
-                    "label": "Sub Block Top",
-                    "age": 0,
-                    "popup": "",
-                    "lineStyle": "solid",
-                    "rgb": {
-                        "r": 255,
-                        "g": 255,
-                        "b": 255
-                    }
-                },
-                {
-                    "label": "Sub Block 1",
-                    "age": 201.36,
-                    "popup": "",
-                    "lineStyle": "solid",
-                    "rgb": {
-                        "r": 255,
-                        "g": 255,
-                        "b": 255
-                    }
-                }
-            ],
-            "width": 100,
-            "units": "Ma",
-            "minAge": 0,
-            "maxAge": 201.36,
-            "popup": "",
-            "on": true,
-            "enableTitle": true,
-            "rgb": {
-                "r": 255,
-                "g": 255,
-                "b": 255
-            }
-        },
-        "Block Child 2": {
-            "name": "Block Child 2",
-            "editName": "Block Child 2",
-            "columnDisplayType": "Zone",
-            "fontOptions": [
-                "Column Header",
-                "Age Label",
-                "Zone Column Label"
-            ],
-            "fontsInfo": {
-                "font": "Arial"
-            },
-            "show": true,
-            "expanded": false,
-            "children": [],
-            "parent": null,
-            "units": "Ma",
-            "subInfo": [
-                {
-                    "label": "Sub Block Top",
-                    "age": 0,
-                    "popup": "info",
-                    "lineStyle": "solid",
-                    "rgb": {
-                        "r": 255,
-                        "g": 225,
-                        "b": 210
-                    }
-                },
-                {
-                    "label": "Sub Block 2",
-                    "age": 23.03,
-                    "popup": "info",
-                    "lineStyle": "solid",
-                    "rgb": {
-                        "r": 222,
-                        "g": 255,
-                        "b": 0
-                    }
-                },
-                {
-                    "label": "Sub Block 3",
-                    "age": 32.02,
-                    "popup": "info",
-                    "lineStyle": "solid",
-                    "rgb": {
-                        "r": 255,
-                        "g": 225,
-                        "b": 210
-                    }
-                }
-            ],
-            "width": 70,
-            "minAge": 0,
-            "maxAge": 32.02,
-            "popup": "\"popup\"",
-            "on": false,
-            "enableTitle": false,
-            "rgb": {
-                "r": 255,
-                "g": 225,
-                "b": 210
-            }
-        }
-    },
-    "column-types-all-column-types-key": {
-        "Facies": {
-            "name": "Facies",
-            "subFaciesInfo": [
-                {
-                    "rockType": "TOP",
-                    "age": 0,
-                    "info": ""
-                },
-                {
-                    "rockType": "Facies SubFaciesInfo 1",
-                    "label": "Facies SubFaciesInfo 1 Label",
-                    "age": 5,
-                    "info": ""
-                },
-                {
-                    "rockType": "Facies SubFaciesInfo 2",
-                    "label": "Facies SubFaciesInfo 2 Label",
-                    "age": 10,
-                    "info": ""
-                }
-            ],
-            "minAge": 0,
-            "maxAge": 10,
-            "enableTitle": false,
-            "width": 210,
-            "rgb": {
-                "r": 100,
-                "g": 200,
-                "b": 255
-            },
-            "popup": "Facies Popup",
-            "on": false
-        },
-        "Block": {
-            "name": "Block",
-            "subBlockInfo": [
-                {
-                    "label": "TOP",
-                    "age": 419.2,
-                    "lineStyle": "solid",
-                    "popup": "",
-                    "rgb": {
-                        "r": 197,
-                        "g": 217,
-                        "b": 234
-                    }
-                },
-                {
-                    "label": "Block SubBlock",
-                    "age": 433.35,
-                    "lineStyle": "solid",
-                    "popup": "Block SubBlock Info",
-                    "rgb": {
-                        "r": 197,
-                        "g": 217,
-                        "b": 234
-                    }
-                }
-            ],
-            "popup": "Block Popup",
-            "on": false,
-            "enableTitle": false,
-            "rgb": {
+              },
+              "popup": "Block Popup",
+              "children": [],
+              "parent": "Parent 1",
+              "minAge": 419.2,
+              "maxAge": 433.35,
+              "width": 120,
+              "rgb": {
                 "r": 197,
                 "g": 217,
                 "b": 234
-            },
-            "width": 120,
-            "minAge": 419.2,
-            "maxAge": 433.35
-        },
-        "Event": {
-            "name": "Event",
-            "on": true,
-            "subEventInfo": [
+              },
+              "showAgeLabels": false,
+              "fontOptions": [
+                "Column Header",
+                "Age Label",
+                "Zone Column Label"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "Zone",
+              "subInfo": [
                 {
-                "label": "SubEventInfo 1",
-                "age": 0.02,
-                "popup": "Event SubEventInfo Popup 1",
-                "lineStyle": "solid"
+                  "label": "TOP",
+                  "age": 419.2,
+                  "popup": "",
+                  "lineStyle": "solid",
+                  "rgb": {
+                    "r": 197,
+                    "g": 217,
+                    "b": 234
+                  }
                 },
                 {
-                "label": "SubEventInfo 2",
-                "age": 0.4,
-                "popup": "Event SubEventInfo Popup 2",
-                "lineStyle": "solid"
+                  "label": "Block SubBlock",
+                  "age": 433.35,
+                  "popup": "Block SubBlock Info",
+                  "lineStyle": "solid",
+                  "rgb": {
+                    "r": 197,
+                    "g": 217,
+                    "b": 234
+                  }
                 }
-            ],
-            "enableTitle": true,
-            "width": 250,
-            "rgb": {
+              ]
+            },
+            {
+              "name": "Facies",
+              "editName": "Facies",
+              "on": false,
+              "enableTitle": false,
+              "show": true,
+              "expanded": false,
+              "fontsInfo": {
+                "font": "Arial"
+              },
+              "popup": "Facies Popup",
+              "children": [
+                {
+                  "name": "Facies Facies",
+                  "editName": "Facies",
+                  "show": true,
+                  "expanded": false,
+                  "on": true,
+                  "enableTitle": false,
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "showAgeLabels": false,
+                  "showUncertaintyLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Uncertainty Label"
+                  ],
+                  "popup": "",
+                  "children": [],
+                  "parent": "Facies",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "width": 84,
+                  "rgb": {
+                    "r": 100,
+                    "g": 200,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Facies",
+                  "subInfo": [
+                    {
+                      "age": 0,
+                      "info": "",
+                      "rockType": "TOP"
+                    },
+                    {
+                      "age": 5,
+                      "info": "",
+                      "label": "Facies SubFaciesInfo 1 Label",
+                      "rockType": "Facies SubFaciesInfo 1"
+                    },
+                    {
+                      "age": 10,
+                      "info": "",
+                      "label": "Facies SubFaciesInfo 2 Label",
+                      "rockType": "Facies SubFaciesInfo 2"
+                    }
+                  ]
+                },
+                {
+                  "name": "Facies Members",
+                  "editName": "Members",
+                  "on": false,
+                  "show": true,
+                  "expanded": false,
+                  "enableTitle": false,
+                  "showAgeLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "popup": "",
+                  "children": [],
+                  "parent": "Facies",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "width": 210,
+                  "rgb": {
+                    "r": 100,
+                    "g": 200,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                },
+                {
+                  "name": "Facies Facies Label",
+                  "editName": "Facies Label",
+                  "on": true,
+                  "show": true,
+                  "expanded": false,
+                  "enableTitle": false,
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "showAgeLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "popup": "",
+                  "children": [],
+                  "parent": "Facies",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "width": 84,
+                  "rgb": {
+                    "r": 100,
+                    "g": 200,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                },
+                {
+                  "name": "Facies Series Label",
+                  "editName": "Series Label",
+                  "on": true,
+                  "enableTitle": false,
+                  "show": true,
+                  "expanded": false,
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "showAgeLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "popup": "",
+                  "children": [],
+                  "parent": "Facies",
+                  "minAge": 0,
+                  "maxAge": 10,
+                  "rgb": {
+                    "r": 100,
+                    "g": 200,
+                    "b": 255
+                  },
+                  "width": 42,
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                }
+              ],
+              "parent": "Parent 1",
+              "minAge": 0,
+              "maxAge": 10,
+              "rgb": {
                 "r": 100,
                 "g": 200,
                 "b": 255
-            },
-            "minAge": 0.02,
-            "maxAge": 0.4,
-            "popup": "Event Popup"
-        },
-        "Range": {
-            "name": "Range",
-            "subRangeInfo": [
-              {
-                "label": "SubRangeInfo 1",
-                "age": 10,
-                "abundance": "TOP",
-                "popup": ""
               },
-              {
-                "label": "SubRangeInfo 2",
-                "age": 100,
-                "abundance": "rare",
-                "popup": "Range SubRangeInfo Popup 2"
-              }
-            ],
-            "enableTitle": true,
-            "width": 100,
-            "rgb": {
-              "r": 198,
-              "g": 207,
-              "b": 174
-            },
-            "minAge": 10,
-            "maxAge": 100,
-            "popup": "Range Popup",
-            "on": true 
-        }, 
-        "Chron": {
-            "name": "Chron",
-            "subChronInfo": [
-                {
-                    "polarity": "TOP",
-                    "age": 0,
-                    "popup": ""
-                },
-                {
-                    "polarity": "N",
-                    "age": 0.123,
-                    "label": "SubChronInfo 1 Label",
-                    "popup": "SubChronInfo 1 Popup"
-                },
-                {
-                    "polarity": "R",
-                    "age": 0.234,
-                    "label": "SubChronInfo 2 Label",
-                    "popup": "SubChronInfo 2 Popup"
-                }
-            ],
-            "minAge": 0,
-            "maxAge": 0.234,
-            "on": true,
-            "enableTitle": false,
-            "width": 100,
-            "rgb": {
-                "r": 255,
-                "g": 255,
-                "b": 255
-            },
-            "popup": "Chron Popup"
-        },
-        "Point": {
-            "name": "Point",
-            "minAge": 4,
-            "maxAge": 5,
-            "enableTitle": true,
-            "on": false,
-            "width": 100,
-            "popup": "Point Popup",
-            "rgb": {
-              "r": 255,
-              "g": 255,
-              "b": 255
-            },
-            "subPointInfo": [
-              {
-                "age": 4,
-                "xVal": 0,
-                "popup": "SubPointInfo Popup 1"
-              },
-              {
-                "age": 5,
-                "xVal": 9,
-                "popup": "SubPointInfo Popup 2"
-              }
-            ],
-            "drawFill": true,
-            "drawLine": true,
-            "lowerRange": 0,
-            "upperRange": 10,
-            "smoothed": true,
-            "minX": 0,
-            "maxX": 9,
-            "pointShape": "nopoints",
-            "fill": {
-              "r": 64,
-              "g": 233,
-              "b": 191
-            }
-        },
-        "Sequence": {
-            "name": "Sequence",
-            "minAge": 0,
-            "maxAge": 2,
-            "enableTitle": false,
-            "on": true,
-            "width": 900,
-            "popup": "Sequence Popup",
-            "rgb": {
-                "r": 255,
-                "g": 255,
-                "b": 255
-            },
-            "subSequenceInfo": [
-                {
-                    "direction": "MFS",
-                    "age": 0,
-                    "severity": "Major",
-                    "popup": "No Label Popup"
-                },
-                {
-                    "label": "Label 1",
-                    "direction": "SB",
-                    "age": 2,
-                    "severity": "Medium",
-                    "popup": "Label 1 Popup"
-                }
-            ]
-        },
-        "Transect": {
-            "name": "Transect",
-            "minAge": 0,
-            "maxAge": 9.22,
-            "enableTitle": true,
-            "on": true,
-            "width": 500,
-            "popup": "Transect Popup",
-            "rgb": {
-              "r": 240,
-              "g": 255,
-              "b": 255
-            },
-            "subTransectInfo": [
-              {
-                "age": 0
-              },
-              {
-                "age": 2.58
-              },
-              {
-                "age": 9.22
-              }
-            ]
-        },
-        "Freehand": {
-            "name": "Freehand",
-            "minAge": 0,
-            "maxAge": 1.3,
-            "enableTitle": false,
-            "on": true,
-            "width": 70,
-            "popup": "",
-            "rgb": {
-                "r": 227,
-                "g": 123,
-                "b": 104
-            },
-            "subFreehandInfo": [
-                {
-                "topAge": 0,
-                "baseAge": 1
-                },
-                {
-                "topAge": 0.3,
-                "baseAge": 1.3
-                }
-            ]
-        },
-        "Blank": {
-            "name": "Blank",
-            "minAge": 1.7976931348623157e+308,
-            "maxAge": 5e-324,
-            "enableTitle": false,
-            "on": false,
-            "width": 800,
-            "popup": "Blank Popup",
-            "rgb": {
-              "r": 7,
-              "g": 3,
-              "b": 4
-            }
-        }
-    },
-    "column-types-event-key": {
-        "Event 1": {
-            "name": "Event 1",
-            "editName": "Event 1",
-            "show": true,
-            "expanded": false,
-            "fontsInfo": {
-                "font": "Arial"
-            },
-            "fontOptions": [
+              "fontOptions": [
                 "Column Header",
                 "Age Label",
-                "Event Column Label",
                 "Uncertainty Label",
-                "Range Label"
-            ],
-            "children": [],
-            "columnDisplayType": "Event",
-            "parent": null,
-            "columnSpecificSettings": {
+                "Zone Column Label"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "BlockSeriesMetaColumn",
+              "subInfo": [
+                {
+                  "rockType": "TOP",
+                  "age": 0,
+                  "info": ""
+                },
+                {
+                  "rockType": "Facies SubFaciesInfo 1",
+                  "label": "Facies SubFaciesInfo 1 Label",
+                  "age": 5,
+                  "info": ""
+                },
+                {
+                  "rockType": "Facies SubFaciesInfo 2",
+                  "label": "Facies SubFaciesInfo 2 Label",
+                  "age": 10,
+                  "info": ""
+                }
+              ]
+            },
+            {
+              "name": "Event",
+              "editName": "Event",
+              "on": true,
+              "show": true,
+              "expanded": false,
+              "enableTitle": true,
+              "fontsInfo": {
+                "font": "Arial"
+              },
+              "popup": "Event Popup",
+              "children": [],
+              "parent": "Parent 1",
+              "minAge": 0.02,
+              "maxAge": 0.4,
+              "width": 250,
+              "rgb": {
+                "r": 100,
+                "g": 200,
+                "b": 255
+              },
+              "showAgeLabels": false,
+              "showUncertaintyLabels": false,
+              "columnSpecificSettings": {
                 "type": "events",
                 "rangeSort": "first occurrence",
                 "frequency": null,
                 "stepSize": 1,
                 "windowSize": 2
-            },
-            "units": "Ma",
-            "subInfo": [
+              },
+              "fontOptions": [
+                "Column Header",
+                "Age Label",
+                "Event Column Label",
+                "Uncertainty Label",
+                "Range Label"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "Event",
+              "subInfo": [
                 {
-                "label": "Event 1 SubEvent 1",
-                "age": 2,
-                "popup": "Event 1 SubEvent 1 Popup",
-                "lineStyle": "dashed",
-                "subEventType": "EVENT"
+                  "label": "SubEventInfo 1",
+                  "age": 0.02,
+                  "popup": "Event SubEventInfo Popup 1",
+                  "lineStyle": "solid",
+                  "subEventType": "EVENT"
                 },
                 {
-                "label": "Event 1 SubEvent 2",
-                "age": 4,
-                "popup": "Event 1 SubEvent 2 Popup",
-                "lineStyle": "solid",
-                "subEventType": "EVENT"
+                  "label": "SubEventInfo 2",
+                  "age": 0.4,
+                  "popup": "Event SubEventInfo Popup 2",
+                  "lineStyle": "solid",
+                  "subEventType": "EVENT"
                 }
-            ],
-            "enableTitle": true,
-            "width": 250,
-            "rgb": {
+              ]
+            },
+            {
+              "name": "Range",
+              "editName": "Range",
+              "on": true,
+              "show": true,
+              "expanded": false,
+              "enableTitle": true,
+              "fontsInfo": {
+                "font": "Arial"
+              },
+              "popup": "Range Popup",
+              "children": [],
+              "parent": "Parent 1",
+              "minAge": 10,
+              "maxAge": 100,
+              "width": 100,
+              "rgb": {
                 "r": 198,
                 "g": 207,
                 "b": 174
-            },
-            "minAge": 2,
-            "maxAge": 4,
-            "popup": "\"Event 1 Popup\"",
-            "on": true
-        },
-        "Event 2": {
-            "name": "Event 2",
-            "editName": "Event 2",
-            "show": true,
-            "expanded": false,
-            "parent": null,
-            "fontsInfo": {
-                "font": "Arial"
-            },
-            "children": [],
-            "columnDisplayType": "Event",
-            "columnSpecificSettings": {
-                "type": "events",
-                "rangeSort": "first occurrence",
-                "frequency": null,
-                "stepSize": 1,
-                "windowSize": 2
-            },
-            "fontOptions": [
+              },
+              "fontOptions": [
                 "Column Header",
-                "Age Label",
-                "Event Column Label",
-                "Uncertainty Label",
-                "Range Label"
-            ],
-            "units": "Ma",
-            "subInfo": [
+                "Popup Body"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "Range",
+              "columnSpecificSettings": {
+                "agePad": 2,
+                "margin": 0.2,
+                "rangeSort": "first occurrence"
+              },
+              "subInfo": [
                 {
-                "label": "Event 2 SubEvent 1",
-                "age": 5,
-                "popup": "",
-                "lineStyle": "solid",
-                "subEventType": "FAD"
+                  "label": "SubRangeInfo 1",
+                  "age": 10,
+                  "abundance": "TOP",
+                  "popup": ""
                 },
                 {
-                "label": "Event 2 SubEvent 2",
-                "age": 6,
-                "popup": "",
-                "lineStyle": "solid",
-                "subEventType": "FAD"
+                  "label": "SubRangeInfo 2",
+                  "age": 100,
+                  "abundance": "rare",
+                  "popup": "Range SubRangeInfo Popup 2"
                 }
-            ],
-            "enableTitle": false,
-            "width": 150,
-            "rgb": {
+              ]
+            },
+            {
+              "name": "Chron",
+              "editName": "Chron",
+              "on": true,
+              "show": true,
+              "expanded": false,
+              "enableTitle": false,
+              "fontsInfo": {
+                "font": "Arial"
+              },
+              "popup": "Chron Popup",
+              "children": [
+                {
+                  "name": "Chron Chron",
+                  "editName": "Chron",
+                  "columnSpecificSettings": {
+                    "dataMiningChronDataType": null,
+                    "stepSize": 1,
+                    "windowSize": 2
+                  },
+                  "on": true,
+                  "show": true,
+                  "expanded": false,
+                  "enableTitle": false,
+                  "showAgeLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label"
+                  ],
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "subInfo": [
+                    {
+                      "polarity": "TOP",
+                      "age": 0,
+                      "popup": ""
+                    },
+                    {
+                      "polarity": "N",
+                      "age": 0.123,
+                      "label": "SubChronInfo 1 Label",
+                      "popup": "SubChronInfo 1 Popup"
+                    },
+                    {
+                      "polarity": "R",
+                      "age": 0.234,
+                      "label": "SubChronInfo 2 Label",
+                      "popup": "SubChronInfo 2 Popup"
+                    }
+                  ],
+                  "popup": "",
+                  "children": [],
+                  "parent": "Chron",
+                  "minAge": 0,
+                  "maxAge": 0.234,
+                  "width": 60,
+                  "rgb": {
+                    "r": 255,
+                    "g": 255,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Chron"
+                },
+                {
+                  "name": "Chron Chron Label",
+                  "editName": "Chron Label",
+                  "show": true,
+                  "expanded": false,
+                  "on": false,
+                  "enableTitle": false,
+                  "showAgeLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "popup": "",
+                  "children": [],
+                  "parent": "Chron",
+                  "minAge": 0,
+                  "maxAge": 0.234,
+                  "width": 40,
+                  "rgb": {
+                    "r": 255,
+                    "g": 255,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                },
+                {
+                  "name": "Chron Series Label",
+                  "editName": "Series Label",
+                  "show": true,
+                  "expanded": false,
+                  "on": true,
+                  "enableTitle": false,
+                  "showAgeLabels": false,
+                  "fontOptions": [
+                    "Column Header",
+                    "Age Label",
+                    "Zone Column Label"
+                  ],
+                  "fontsInfo": {
+                    "font": "Arial"
+                  },
+                  "popup": "",
+                  "children": [],
+                  "parent": "Chron",
+                  "minAge": 0,
+                  "maxAge": 0.234,
+                  "width": 40,
+                  "rgb": {
+                    "r": 255,
+                    "g": 255,
+                    "b": 255
+                  },
+                  "units": "Ma",
+                  "columnDisplayType": "Zone"
+                }
+              ],
+              "parent": "Parent 1",
+              "minAge": 0,
+              "maxAge": 0.234,
+              "rgb": {
                 "r": 255,
                 "g": 255,
                 "b": 255
-            },
-            "minAge": 5,
-            "maxAge": 6,
-            "popup": "Event 2 Popup",
-            "on": false
-        }
-    },
-    "column-types-range-key": {
-        "Range 1": {
-            "name": "Range 1",
-            "editName": "Range 1",
-            "show": true,
-            "expanded": false,
-            "parent": null,
-            "fontsInfo": {
-                "font": "Arial"
-            },
-            "columnDisplayType": "Range",
-            "fontOptions": [
-              "Column Header",
-              "Popup Body"
-            ],
-            "units": "Ma",
-            "subInfo": [
-              {
-                "label": "Range 1 SubRangeInfo 1",
-                "age": 28.4,
-                "abundance": "TOP",
-                "popup": ""
               },
-              {
-                "label": "Range 1 SubRangeInfo 2",
-                "age": 33.9,
-                "abundance": "rare",
-                "popup": "\"popup\""
-              }
-            ],
-            "columnSpecificSettings": {
-              "agePad": 2,
-              "margin": 0.2,
-              "rangeSort":"first occurrence"
+              "fontOptions": [
+                "Column Header",
+                "Age Label",
+                "Zone Column Label"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "BlockSeriesMetaColumn",
+              "subInfo": [
+                {
+                  "polarity": "TOP",
+                  "age": 0,
+                  "popup": ""
+                },
+                {
+                  "polarity": "N",
+                  "age": 0.123,
+                  "label": "SubChronInfo 1 Label",
+                  "popup": "SubChronInfo 1 Popup"
+                },
+                {
+                  "polarity": "R",
+                  "age": 0.234,
+                  "label": "SubChronInfo 2 Label",
+                  "popup": "SubChronInfo 2 Popup"
+                }
+              ]
             },
-            "enableTitle": true,
-            "children": [],
-            "width": 100,
-            "rgb": {
-              "r": 198,
-              "g": 207,
-              "b": 174
-            },
-            "minAge": 28.4,
-            "maxAge": 33.9,
-            "popup": "Range 1 info",
-            "on": false
-        },
-        "Range 2": {
-            "name": "Range 2",
-            "editName": "Range 2",
-            "show": true,
-            "expanded": false,
-            "parent": null,
-            "fontsInfo": {
+            {
+              "name": "Point",
+              "editName": "Point",
+              "show": true,
+              "expanded": false,
+              "on": false,
+              "enableTitle": true,
+              "fontsInfo": {
                 "font": "Arial"
+              },
+              "popup": "Point Popup",
+              "children": [],
+              "parent": "Parent 1",
+              "minAge": 4,
+              "maxAge": 5,
+              "width": 100,
+              "rgb": {
+                "r": 255,
+                "g": 255,
+                "b": 255
+              },
+              "fontOptions": [
+                "Column Header",
+                "Point Column Scale Label"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "Point",
+              "subInfo": [
+                {
+                  "age": 4,
+                  "xVal": 0,
+                  "popup": "SubPointInfo Popup 1"
+                },
+                {
+                  "age": 5,
+                  "xVal": 9,
+                  "popup": "SubPointInfo Popup 2"
+                }
+              ],
+              "columnSpecificSettings": {
+                "drawFill": true,
+                "drawLine": true,
+                "lowerRange": 0,
+                "upperRange": 10,
+                "smoothed": true,
+                "minX": 0,
+                "maxX": 9,
+                "pointShape": "nopoints",
+                "backgroundGradientStart": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0
+                },
+                "backgroundGradientEnd": {
+                  "r": 255,
+                  "g": 255,
+                  "b": 255
+                },
+                "curveGradientStart": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0
+                },
+                "curveGradientEnd": {
+                  "r": 255,
+                  "g": 255,
+                  "b": 255
+                },
+                "drawBackgroundGradient": false,
+                "drawCurveGradient": false,
+                "drawScale": true,
+                "fill": {
+                  "r": 64,
+                  "g": 233,
+                  "b": 191
+                },
+                "flipScale": false,
+                "lineColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0
+                },
+                "scaleStart": 0,
+                "scaleStep": 1,
+                "dataMiningPointDataType": null,
+                "windowSize": 2,
+                "stepSize": 1,
+                "isDataMiningColumn": false
+              }
             },
-            "children": [],
-            "columnDisplayType": "Range",
-            "fontOptions": [
-              "Column Header",
-              "Popup Body"
-            ],
-            "columnSpecificSettings": {
-              "agePad": 2,
-              "margin": 0.2,
+            {
+              "name": "Sequence",
+              "editName": "Sequence",
+              "show": true,
+              "expanded": false,
+              "on": true,
+              "enableTitle": false,
+              "fontsInfo": {
+                "font": "Arial"
+              },
+              "popup": "Sequence Popup",
+              "children": [],
+              "parent": "Parent 1",
+              "minAge": 0,
+              "maxAge": 2,
+              "width": 900,
+              "rgb": {
+                "r": 255,
+                "g": 255,
+                "b": 255
+              },
+              "showAgeLabels": false,
+              "fontOptions": [
+                "Column Header",
+                "Age Label",
+                "Sequence Column Label"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "Sequence",
+              "subInfo": [
+                {
+                  "direction": "MFS",
+                  "age": 0,
+                  "severity": "Major",
+                  "popup": "No Label Popup"
+                },
+                {
+                  "label": "Label 1",
+                  "direction": "SB",
+                  "age": 2,
+                  "severity": "Medium",
+                  "popup": "Label 1 Popup"
+                }
+              ],
+              "columnSpecificSettings": {
+                "drawNameLabel": true,
+                "graphStyle": "stroke-width: 0; fill: rgb(64, 191, 233);",
+                "labelMarginLeft": 5,
+                "labelMarginRight": 5,
+                "type": "sequence"
+              }
+            },
+            {
+              "name": "Freehand",
+              "editName": "Freehand",
+              "show": true,
+              "expanded": false,
+              "on": true,
+              "enableTitle": false,
+              "fontsInfo": {
+                "font": "Arial"
+              },
+              "popup": "",
+              "children": [],
+              "parent": "Parent 1",
+              "minAge": 0,
+              "maxAge": 1.3,
+              "width": 70,
+              "rgb": {
+                "r": 227,
+                "g": 123,
+                "b": 104
+              },
+              "fontOptions": [
+                "Column Header"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "Freehand",
+              "subInfo": [
+                {
+                  "topAge": 0,
+                  "baseAge": 1
+                },
+                {
+                  "topAge": 0.3,
+                  "baseAge": 1.3
+                }
+              ]
+            },
+            {
+              "name": "Blank",
+              "editName": "Blank",
+              "show": true,
+              "expanded": false,
+              "on": false,
+              "enableTitle": false,
+              "fontsInfo": {
+                "font": "Arial"
+              },
+              "popup": "Blank Popup",
+              "children": [],
+              "parent": "Parent 1",
+              "minAge": 1.7976931348623157e+308,
+              "maxAge": 5e-324,
+              "width": 800,
+              "rgb": {
+                "r": 7,
+                "g": 3,
+                "b": 4
+              },
+              "fontOptions": [
+                "Column Header"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "Blank"
+            },
+            {
+              "name": "Transect",
+              "editName": "Transect",
+              "show": true,
+              "expanded": false,
+              "on": true,
+              "enableTitle": true,
+              "fontsInfo": {
+                "font": "Arial"
+              },
+              "popup": "Transect Popup",
+              "children": [],
+              "parent": "Parent 1",
+              "minAge": 0,
+              "maxAge": 9.22,
+              "width": 500,
+              "rgb": {
+                "r": 240,
+                "g": 255,
+                "b": 255
+              },
+              "fontOptions": [
+                "Column Header"
+              ],
+              "units": "Ma",
+              "columnDisplayType": "Transect",
+              "subInfo": [
+                {
+                  "age": 0
+                },
+                {
+                  "age": 2.58
+                },
+                {
+                  "age": 9.22
+                }
+              ]
+            }
+          ],
+          "parent": "Chart Title",
+          "minAge": 0,
+          "maxAge": 433.35,
+          "rgb": {
+            "r": 255,
+            "g": 255,
+            "b": 255
+          },
+          "fontOptions": [
+            "Column Header",
+            "Age Label",
+            "Zone Column Label",
+            "Uncertainty Label",
+            "Event Column Label",
+            "Range Label",
+            "Popup Body",
+            "Point Column Scale Label",
+            "Sequence Column Label"
+          ],
+          "units": "Ma",
+          "columnDisplayType": "MetaColumn",
+          "subInfo": [
+            {
+              "rockType": "TOP",
+              "age": 0,
+              "info": ""
+            },
+            {
+              "rockType": "Facies SubFaciesInfo 1",
+              "label": "Facies SubFaciesInfo 1 Label",
+              "age": 5,
+              "info": ""
+            },
+            {
+              "rockType": "Facies SubFaciesInfo 2",
+              "label": "Facies SubFaciesInfo 2 Label",
+              "age": 10,
+              "info": ""
+            }
+          ]
+        }
+      ],
+      "parent": "Chart Root",
+      "minAge": 0,
+      "maxAge": 433.35,
+      "units": "Ma",
+      "columnDisplayType": "RootColumn"
+    },
+    "topAge": 0,
+    "baseAge": 5,
+    "ageUnits": "Ma",
+    "defaultChronostrat": "USGS",
+    "formatVersion": 1,
+    "image": "",
+    "verticalScale": 6,
+    "date": "2015-03-15",
+    "file": "file.dpk",
+    "description": "description",
+    "title": "Title",
+    "size": "size"
+  },
+  "column-types-facies-key": {
+    "FaciesOne": {
+      "name": "FaciesOne",
+      "editName": "FaciesOne",
+      "show": true,
+      "expanded": false,
+      "units": "Ma",
+      "fontsInfo": {
+        "font": "Arial"
+      },
+      "columnDisplayType": "Facies",
+      "children": [],
+      "parent": null,
+      "fontOptions": [
+        "Column Header",
+        "Age Label",
+        "Uncertainty Label"
+      ],
+      "width": 500,
+      "rgb": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      },
+      "subInfo": [
+        {
+          "rockType": "TOP",
+          "age": 374.64,
+          "info": "\"info\""
+        },
+        {
+          "rockType": "RockTypeOne",
+          "label": "RockTypeOneLabel",
+          "age": 376.11,
+          "info": "\"info for RockTypeOne\""
+        }
+      ],
+      "minAge": 374.64,
+      "maxAge": 376.11,
+      "enableTitle": true,
+      "popup": "\"FaciesOne info\"",
+      "on": false
+    },
+    "FaciesTwo": {
+      "name": "FaciesTwo",
+      "editName": "FaciesTwo",
+      "units": "Ma",
+      "show": true,
+      "expanded": false,
+      "fontsInfo": {
+        "font": "Arial"
+      },
+      "columnDisplayType": "Facies",
+      "children": [],
+      "parent": null,
+      "fontOptions": [
+        "Column Header",
+        "Age Label",
+        "Uncertainty Label"
+      ],
+      "subInfo": [
+        {
+          "rockType": "TOP",
+          "age": 311.59,
+          "info": "\"info\""
+        },
+        {
+          "rockType": "RockTypeTwo",
+          "label": "RockTypeTwoLabel",
+          "age": 315,
+          "info": "\"info for RockTypeTwo\""
+        }
+      ],
+      "minAge": 311.59,
+      "width": 500,
+      "maxAge": 315,
+      "enableTitle": true,
+      "rgb": {
+        "r": 234,
+        "g": 221,
+        "b": 221
+      },
+      "popup": "\"FaciesTwo info\"",
+      "on": false
+    }
+  },
+  "column-types-block-key": {
+    "Block Child 1": {
+      "name": "Block Child 1",
+      "editName": "Block Child 1",
+      "columnDisplayType": "Zone",
+      "fontOptions": [
+        "Column Header",
+        "Age Label",
+        "Zone Column Label"
+      ],
+      "fontsInfo": {
+        "font": "Arial"
+      },
+      "show": true,
+      "expanded": false,
+      "children": [],
+      "parent": null,
+      "subInfo": [
+        {
+          "label": "Sub Block Top",
+          "age": 0,
+          "popup": "",
+          "lineStyle": "solid",
+          "rgb": {
+            "r": 255,
+            "g": 255,
+            "b": 255
+          }
+        },
+        {
+          "label": "Sub Block 1",
+          "age": 201.36,
+          "popup": "",
+          "lineStyle": "solid",
+          "rgb": {
+            "r": 255,
+            "g": 255,
+            "b": 255
+          }
+        }
+      ],
+      "width": 100,
+      "units": "Ma",
+      "minAge": 0,
+      "maxAge": 201.36,
+      "popup": "",
+      "on": true,
+      "enableTitle": true,
+      "rgb": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      }
+    },
+    "Block Child 2": {
+      "name": "Block Child 2",
+      "editName": "Block Child 2",
+      "columnDisplayType": "Zone",
+      "fontOptions": [
+        "Column Header",
+        "Age Label",
+        "Zone Column Label"
+      ],
+      "fontsInfo": {
+        "font": "Arial"
+      },
+      "show": true,
+      "expanded": false,
+      "children": [],
+      "parent": null,
+      "units": "Ma",
+      "subInfo": [
+        {
+          "label": "Sub Block Top",
+          "age": 0,
+          "popup": "info",
+          "lineStyle": "solid",
+          "rgb": {
+            "r": 255,
+            "g": 225,
+            "b": 210
+          }
+        },
+        {
+          "label": "Sub Block 2",
+          "age": 23.03,
+          "popup": "info",
+          "lineStyle": "solid",
+          "rgb": {
+            "r": 222,
+            "g": 255,
+            "b": 0
+          }
+        },
+        {
+          "label": "Sub Block 3",
+          "age": 32.02,
+          "popup": "info",
+          "lineStyle": "solid",
+          "rgb": {
+            "r": 255,
+            "g": 225,
+            "b": 210
+          }
+        }
+      ],
+      "width": 70,
+      "minAge": 0,
+      "maxAge": 32.02,
+      "popup": "\"popup\"",
+      "on": false,
+      "enableTitle": false,
+      "rgb": {
+        "r": 255,
+        "g": 225,
+        "b": 210
+      }
+    }
+  },
+  "column-types-all-column-types-key": {
+    "Facies": {
+      "name": "Facies",
+      "subFaciesInfo": [
+        {
+          "rockType": "TOP",
+          "age": 0,
+          "info": ""
+        },
+        {
+          "rockType": "Facies SubFaciesInfo 1",
+          "label": "Facies SubFaciesInfo 1 Label",
+          "age": 5,
+          "info": ""
+        },
+        {
+          "rockType": "Facies SubFaciesInfo 2",
+          "label": "Facies SubFaciesInfo 2 Label",
+          "age": 10,
+          "info": ""
+        }
+      ],
+      "minAge": 0,
+      "maxAge": 10,
+      "enableTitle": false,
+      "width": 210,
+      "rgb": {
+        "r": 100,
+        "g": 200,
+        "b": 255
+      },
+      "popup": "Facies Popup",
+      "on": false
+    },
+    "Block": {
+      "name": "Block",
+      "subBlockInfo": [
+        {
+          "label": "TOP",
+          "age": 419.2,
+          "lineStyle": "solid",
+          "popup": "",
+          "rgb": {
+            "r": 197,
+            "g": 217,
+            "b": 234
+          }
+        },
+        {
+          "label": "Block SubBlock",
+          "age": 433.35,
+          "lineStyle": "solid",
+          "popup": "Block SubBlock Info",
+          "rgb": {
+            "r": 197,
+            "g": 217,
+            "b": 234
+          }
+        }
+      ],
+      "popup": "Block Popup",
+      "on": false,
+      "enableTitle": false,
+      "rgb": {
+        "r": 197,
+        "g": 217,
+        "b": 234
+      },
+      "width": 120,
+      "minAge": 419.2,
+      "maxAge": 433.35
+    },
+    "Event": {
+      "name": "Event",
+      "on": true,
+      "subEventInfo": [
+        {
+          "label": "SubEventInfo 1",
+          "age": 0.02,
+          "popup": "Event SubEventInfo Popup 1",
+          "lineStyle": "solid"
+        },
+        {
+          "label": "SubEventInfo 2",
+          "age": 0.4,
+          "popup": "Event SubEventInfo Popup 2",
+          "lineStyle": "solid"
+        }
+      ],
+      "enableTitle": true,
+      "width": 250,
+      "rgb": {
+        "r": 100,
+        "g": 200,
+        "b": 255
+      },
+      "minAge": 0.02,
+      "maxAge": 0.4,
+      "popup": "Event Popup"
+    },
+    "Range": {
+      "name": "Range",
+      "subRangeInfo": [
+        {
+          "label": "SubRangeInfo 1",
+          "age": 10,
+          "abundance": "TOP",
+          "popup": ""
+        },
+        {
+          "label": "SubRangeInfo 2",
+          "age": 100,
+          "abundance": "rare",
+          "popup": "Range SubRangeInfo Popup 2"
+        }
+      ],
+      "enableTitle": true,
+      "width": 100,
+      "rgb": {
+        "r": 198,
+        "g": 207,
+        "b": 174
+      },
+      "minAge": 10,
+      "maxAge": 100,
+      "popup": "Range Popup",
+      "on": true
+    },
+    "Chron": {
+      "name": "Chron",
+      "subChronInfo": [
+        {
+          "polarity": "TOP",
+          "age": 0,
+          "popup": ""
+        },
+        {
+          "polarity": "N",
+          "age": 0.123,
+          "label": "SubChronInfo 1 Label",
+          "popup": "SubChronInfo 1 Popup"
+        },
+        {
+          "polarity": "R",
+          "age": 0.234,
+          "label": "SubChronInfo 2 Label",
+          "popup": "SubChronInfo 2 Popup"
+        }
+      ],
+      "minAge": 0,
+      "maxAge": 0.234,
+      "on": true,
+      "enableTitle": false,
+      "width": 100,
+      "rgb": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      },
+      "popup": "Chron Popup"
+    },
+    "Point": {
+      "name": "Point",
+      "minAge": 4,
+      "maxAge": 5,
+      "enableTitle": true,
+      "on": false,
+      "width": 100,
+      "popup": "Point Popup",
+      "rgb": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      },
+      "subPointInfo": [
+        {
+          "age": 4,
+          "xVal": 0,
+          "popup": "SubPointInfo Popup 1"
+        },
+        {
+          "age": 5,
+          "xVal": 9,
+          "popup": "SubPointInfo Popup 2"
+        }
+      ],
+      "drawFill": true,
+      "drawLine": true,
+      "lowerRange": 0,
+      "upperRange": 10,
+      "smoothed": true,
+      "minX": 0,
+      "maxX": 9,
+      "pointShape": "nopoints",
+      "fill": {
+        "r": 64,
+        "g": 233,
+        "b": 191
+      }
+    },
+    "Sequence": {
+      "name": "Sequence",
+      "minAge": 0,
+      "maxAge": 2,
+      "enableTitle": false,
+      "on": true,
+      "width": 900,
+      "popup": "Sequence Popup",
+      "rgb": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      },
+      "subSequenceInfo": [
+        {
+          "direction": "MFS",
+          "age": 0,
+          "severity": "Major",
+          "popup": "No Label Popup"
+        },
+        {
+          "label": "Label 1",
+          "direction": "SB",
+          "age": 2,
+          "severity": "Medium",
+          "popup": "Label 1 Popup"
+        }
+      ]
+    },
+    "Transect": {
+      "name": "Transect",
+      "minAge": 0,
+      "maxAge": 9.22,
+      "enableTitle": true,
+      "on": true,
+      "width": 500,
+      "popup": "Transect Popup",
+      "rgb": {
+        "r": 240,
+        "g": 255,
+        "b": 255
+      },
+      "subTransectInfo": [
+        {
+          "age": 0
+        },
+        {
+          "age": 2.58
+        },
+        {
+          "age": 9.22
+        }
+      ]
+    },
+    "Freehand": {
+      "name": "Freehand",
+      "minAge": 0,
+      "maxAge": 1.3,
+      "enableTitle": false,
+      "on": true,
+      "width": 70,
+      "popup": "",
+      "rgb": {
+        "r": 227,
+        "g": 123,
+        "b": 104
+      },
+      "subFreehandInfo": [
+        {
+          "topAge": 0,
+          "baseAge": 1
+        },
+        {
+          "topAge": 0.3,
+          "baseAge": 1.3
+        }
+      ]
+    },
+    "Blank": {
+      "name": "Blank",
+      "minAge": 1.7976931348623157e+308,
+      "maxAge": 5e-324,
+      "enableTitle": false,
+      "on": false,
+      "width": 800,
+      "popup": "Blank Popup",
+      "rgb": {
+        "r": 7,
+        "g": 3,
+        "b": 4
+      }
+    }
+  },
+  "column-types-event-key": {
+    "Event 1": {
+      "name": "Event 1",
+      "editName": "Event 1",
+      "show": true,
+      "expanded": false,
+      "fontsInfo": {
+        "font": "Arial"
+      },
+      "fontOptions": [
+        "Column Header",
+        "Age Label",
+        "Event Column Label",
+        "Uncertainty Label",
+        "Range Label"
+      ],
+      "children": [],
+      "columnDisplayType": "Event",
+      "parent": null,
+      "columnSpecificSettings": {
+        "type": "events",
+        "rangeSort": "first occurrence",
+        "frequency": null,
+        "stepSize": 1,
+        "windowSize": 2
+      },
+      "units": "Ma",
+      "subInfo": [
+        {
+          "label": "Event 1 SubEvent 1",
+          "age": 2,
+          "popup": "Event 1 SubEvent 1 Popup",
+          "lineStyle": "dashed",
+          "subEventType": "EVENT"
+        },
+        {
+          "label": "Event 1 SubEvent 2",
+          "age": 4,
+          "popup": "Event 1 SubEvent 2 Popup",
+          "lineStyle": "solid",
+          "subEventType": "EVENT"
+        }
+      ],
+      "enableTitle": true,
+      "width": 250,
+      "rgb": {
+        "r": 198,
+        "g": 207,
+        "b": 174
+      },
+      "minAge": 2,
+      "maxAge": 4,
+      "popup": "\"Event 1 Popup\"",
+      "on": true
+    },
+    "Event 2": {
+      "name": "Event 2",
+      "editName": "Event 2",
+      "show": true,
+      "expanded": false,
+      "parent": null,
+      "fontsInfo": {
+        "font": "Arial"
+      },
+      "children": [],
+      "columnDisplayType": "Event",
+      "columnSpecificSettings": {
+        "type": "events",
+        "rangeSort": "first occurrence",
+        "frequency": null,
+        "stepSize": 1,
+        "windowSize": 2
+      },
+      "fontOptions": [
+        "Column Header",
+        "Age Label",
+        "Event Column Label",
+        "Uncertainty Label",
+        "Range Label"
+      ],
+      "units": "Ma",
+      "subInfo": [
+        {
+          "label": "Event 2 SubEvent 1",
+          "age": 5,
+          "popup": "",
+          "lineStyle": "solid",
+          "subEventType": "FAD"
+        },
+        {
+          "label": "Event 2 SubEvent 2",
+          "age": 6,
+          "popup": "",
+          "lineStyle": "solid",
+          "subEventType": "FAD"
+        }
+      ],
+      "enableTitle": false,
+      "width": 150,
+      "rgb": {
+        "r": 255,
+        "g": 255,
+        "b": 255
+      },
+      "minAge": 5,
+      "maxAge": 6,
+      "popup": "Event 2 Popup",
+      "on": false
+    }
+  },
+  "column-types-range-key": {
+    "Range 1": {
+      "name": "Range 1",
+      "editName": "Range 1",
+      "show": true,
+      "expanded": false,
+      "parent": null,
+      "fontsInfo": {
+        "font": "Arial"
+      },
+      "columnDisplayType": "Range",
+      "fontOptions": [
+        "Column Header",
+        "Popup Body"
+      ],
+      "units": "Ma",
+      "subInfo": [
+        {
+          "label": "Range 1 SubRangeInfo 1",
+          "age": 28.4,
+          "abundance": "TOP",
+          "popup": ""
+        },
+        {
+          "label": "Range 1 SubRangeInfo 2",
+          "age": 33.9,
+          "abundance": "rare",
+          "popup": "\"popup\""
+        }
+      ],
+      "columnSpecificSettings": {
+        "agePad": 2,
+        "margin": 0.2,
+        "rangeSort": "first occurrence"
+      },
+      "enableTitle": true,
+      "children": [],
+      "width": 100,
+      "rgb": {
+        "r": 198,
+        "g": 207,
+        "b": 174
+      },
+      "minAge": 28.4,
+      "maxAge": 33.9,
+      "popup": "Range 1 info",
+      "on": false
+    },
+    "Range 2": {
+      "name": "Range 2",
+      "editName": "Range 2",
+      "show": true,
+      "expanded": false,
+      "parent": null,
+      "fontsInfo": {
+        "font": "Arial"
+      },
+      "children": [],
+      "columnDisplayType": "Range",
+      "fontOptions": [
+        "Column Header",
+        "Popup Body"
+      ],
+      "columnSpecificSettings": {
+        "agePad": 2,
+        "margin": 0.2,
               "rangeSort":"first occurrence"
             },
             "units": "Ma",
@@ -2676,7 +2674,6 @@
             "defaultChronostrat": "UNESCO",
             "formatVersion": 1.5,
             "image": "",
-            "isUserDatapack": false,
             "file": "file.dpk",
             "description": "description",
             "title": "Title",

--- a/server/__tests__/admin-routes.test.ts
+++ b/server/__tests__/admin-routes.test.ts
@@ -73,7 +73,7 @@ vi.mock("../src/util", async () => {
       removeDevDatapacks: ["remove-datapack.dpk"]
     },
     checkFileExists: vi.fn().mockResolvedValue(true),
-    verifyFilepath: vi.fn().mockReturnValue(true),
+    verifyFilepath: vi.fn().mockReturnValue(true)
   };
 });
 
@@ -89,7 +89,7 @@ vi.mock("stream/promises", async () => {
   return {
     pipeline: vi.fn().mockImplementation(async (readable) => {
       return new Promise<void>((resolve, reject) => {
-        readable.on("data", () => { });
+        readable.on("data", () => {});
         readable.on("end", () => {
           resolve();
         });
@@ -200,7 +200,7 @@ beforeAll(async () => {
   });
   await app.register(adminAuth.adminRoutes, { prefix: "/admin" });
   await app.listen({ host: "localhost", port: 1239 });
-  vi.spyOn(console, "error").mockImplementation(() => { });
+  vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterAll(async () => {
@@ -1469,12 +1469,12 @@ describe("getAllUserDatapacks", () => {
   const verifyFilepath = vi.spyOn(util, "verifyFilepath");
   const payload = {
     uuid: "test-uuid"
-  }
+  };
   const testParsingPack = {
     "test-datapack.dpk": {
       mock: "test-datapack"
     }
-  }
+  };
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -1529,7 +1529,7 @@ describe("getAllUserDatapacks", () => {
     expect(await response.json()).toEqual({ error: "Error reading user datapack index, possible corruption of file" });
     expect(response.statusCode).toBe(500);
   });
-  it("should return 403 if the filepath is bad", async () => {
+  it("should return 200 if the filepath is bad/doesn't exist", async () => {
     verifyFilepath.mockResolvedValueOnce(false);
     const response = await app.inject({
       method: "POST",
@@ -1539,7 +1539,7 @@ describe("getAllUserDatapacks", () => {
     });
     expect(readFile).toHaveBeenCalledTimes(0);
     expect(assertDatapackIndex).toHaveBeenCalledTimes(0);
-    expect(await response.json()).toEqual({ error: "Directory traversal detected" });
-    expect(response.statusCode).toBe(403);
+    expect(await response.json()).toEqual({});
+    expect(response.statusCode).toBe(200);
   });
-})
+});

--- a/server/__tests__/admin-routes.test.ts
+++ b/server/__tests__/admin-routes.test.ts
@@ -13,7 +13,7 @@ import * as index from "../src/index";
 import * as shared from "@tsconline/shared";
 import { afterAll, beforeAll, describe, test, it, vi, expect, beforeEach } from "vitest";
 import fastifySecureSession from "@fastify/secure-session";
-import { join, normalize, resolve } from "path";
+import { join, normalize, parse, resolve } from "path";
 import fastifyMultipart from "@fastify/multipart";
 import formAutoContent from "form-auto-content";
 import { DatapackParsingPack, MapPack } from "@tsconline/shared";
@@ -89,7 +89,7 @@ vi.mock("stream/promises", async () => {
   return {
     pipeline: vi.fn().mockImplementation(async (readable) => {
       return new Promise<void>((resolve, reject) => {
-        readable.on("data", () => { });
+        readable.on("data", () => {});
         readable.on("end", () => {
           resolve();
         });
@@ -200,7 +200,7 @@ beforeAll(async () => {
   });
   await app.register(adminAuth.adminRoutes, { prefix: "/admin" });
   await app.listen({ host: "localhost", port: 1239 });
-  vi.spyOn(console, "error").mockImplementation(() => { });
+  vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterAll(async () => {
@@ -448,7 +448,7 @@ describe("adminCreateUser tests", () => {
     expect(deleteUser).toHaveBeenCalledWith({ email: customUser.email });
     expect(await response.json()).toEqual({ error: "Database error" });
     expect(response.statusCode).toBe(500);
-  })
+  });
   it("should return 500 if findUser throws error", async () => {
     // twice for prehandler
     findUser.mockResolvedValueOnce([testAdminUser]).mockRejectedValueOnce(new Error());
@@ -1117,7 +1117,7 @@ describe("adminUploadServerDatapack", () => {
           contentType: "application/zip"
         }
       }
-    })
+    });
     const response = await app.inject({
       method: "POST",
       url: "/admin/server/datapack",
@@ -1128,7 +1128,7 @@ describe("adminUploadServerDatapack", () => {
     expect(realpath).toHaveBeenCalledTimes(1);
     expect(loadIndexes).not.toHaveBeenCalled();
     expect(await response.json()).toEqual({ error: "Empty file cannot be uploaded" });
-  })
+  });
   it("should return 500 if loadIndexes fails", async () => {
     loadIndexes.mockResolvedValueOnce(false);
     const response = await app.inject({
@@ -1295,7 +1295,7 @@ describe("adminDeleteServerDatapack", () => {
   };
   const realpath = vi.spyOn(fsPromises, "realpath");
   const filepath = resolve(`testdir/datapacksDirectory/${body.datapack}`);
-  const decryptedFilepath = resolve(`testdir/decryptionDirectory/${body.datapack}`);
+  const decryptedFilepath = resolve(`testdir/decryptionDirectory/${parse(body.datapack).name}`);
   beforeEach(async () => {
     vi.clearAllMocks();
     const originalUtil = await import("../src/util");

--- a/server/src/admin-auth.ts
+++ b/server/src/admin-auth.ts
@@ -74,7 +74,7 @@ export const adminRoutes = async (fastify: FastifyInstance, _options: RegisterOp
     },
     required: ["email", "password"]
   };
-  const adminDeleteUserBody = {
+  const adminUUIDbody = {
     type: "object",
     properties: {
       uuid: { type: "string" }
@@ -115,7 +115,7 @@ export const adminRoutes = async (fastify: FastifyInstance, _options: RegisterOp
     "/user",
     {
       schema: {
-        body: adminDeleteUserBody
+        body: adminUUIDbody
       },
       config: {
         rateLimit: moderateRateLimit
@@ -148,5 +148,5 @@ export const adminRoutes = async (fastify: FastifyInstance, _options: RegisterOp
     },
     adminDeleteServerDatapack
   );
-  fastify.post("/user/datapacks", { config: { rateLimit: looseRateLimit } }, getAllUserDatapacks);
+  fastify.post("/user/datapacks", { schema: { body: adminUUIDbody }, config: { rateLimit: looseRateLimit } }, getAllUserDatapacks);
 };

--- a/server/src/admin-auth.ts
+++ b/server/src/admin-auth.ts
@@ -148,5 +148,9 @@ export const adminRoutes = async (fastify: FastifyInstance, _options: RegisterOp
     },
     adminDeleteServerDatapack
   );
-  fastify.post("/user/datapacks", { schema: { body: adminUUIDbody }, config: { rateLimit: looseRateLimit } }, getAllUserDatapacks);
+  fastify.post(
+    "/user/datapacks",
+    { schema: { body: adminUUIDbody }, config: { rateLimit: looseRateLimit } },
+    getAllUserDatapacks
+  );
 };

--- a/server/src/admin-auth.ts
+++ b/server/src/admin-auth.ts
@@ -148,5 +148,5 @@ export const adminRoutes = async (fastify: FastifyInstance, _options: RegisterOp
     },
     adminDeleteServerDatapack
   );
-  fastify.get("/user/datapacks", { config: { rateLimit: looseRateLimit } }, getAllUserDatapacks);
+  fastify.post("/user/datapacks", { config: { rateLimit: looseRateLimit } }, getAllUserDatapacks);
 };

--- a/server/src/admin-auth.ts
+++ b/server/src/admin-auth.ts
@@ -6,7 +6,8 @@ import {
   adminDeleteUser,
   getUsers,
   adminUploadServerDatapack,
-  adminDeleteServerDatapack
+  adminDeleteServerDatapack,
+  getAllUserDatapacks
 } from "./admin-routes.js";
 import { checkRecaptchaToken } from "./verify.js";
 import { googleRecaptchaBotThreshold } from "./login-routes.js";
@@ -147,4 +148,5 @@ export const adminRoutes = async (fastify: FastifyInstance, _options: RegisterOp
     },
     adminDeleteServerDatapack
   );
+  fastify.get("/user/datapacks", { config: { rateLimit: looseRateLimit } }, getAllUserDatapacks);
 };

--- a/server/src/admin-routes.ts
+++ b/server/src/admin-routes.ts
@@ -166,9 +166,9 @@ export const adminDeleteUserDatapack = async function adminDeleteUserDatapack(
     return;
   }
   try {
-    const uploadDirectory = await realpath(assetconfigs.uploadDirectory);
-    const userDirectory = await realpath(join(assetconfigs.uploadDirectory, uuid));
-    const datapackDirectory = await realpath(join(userDirectory, "datapacks", datapack));
+    const uploadDirectory = await realpath(resolve(assetconfigs.uploadDirectory));
+    const userDirectory = await realpath(resolve(assetconfigs.uploadDirectory, uuid));
+    const datapackDirectory = await realpath(resolve(userDirectory, "datapacks", datapack));
     if (!userDirectory.startsWith(uploadDirectory) || !datapackDirectory.startsWith(userDirectory)) {
       reply.status(403).send({ error: "Directory traversal detected" });
       return;

--- a/server/src/admin-routes.ts
+++ b/server/src/admin-routes.ts
@@ -414,9 +414,9 @@ export const getAllUserDatapacks = async function getAllUserDatapacks(
       const datapackIndexFilepath = join(path, "DatapackIndex.json");
       try {
         await realpath(datapackIndexFilepath);
-        const datapackIndex = JSON.parse(await readFile(datapackIndexFilepath));
+        const datapackIndex = JSON.parse(await readFile(datapackIndexFilepath, "utf-8"));
         assertDatapackIndex(datapackIndex);
-      } catch(e) {
+      } catch (e) {
         continue;
       }
       adminDisplayDatapacks[uuid] = {};

--- a/server/src/admin-routes.ts
+++ b/server/src/admin-routes.ts
@@ -412,18 +412,18 @@ export const getAllUserDatapacks = async function getAllUserDatapacks(
     for (const path of paths) {
       const uuid = basename(path);
       const datapackIndexFilepath = join(path, "DatapackIndex.json");
+      let userDatapackIndex;
       try {
         await realpath(datapackIndexFilepath);
-        const datapackIndex = JSON.parse(await readFile(datapackIndexFilepath, "utf-8"));
+        userDatapackIndex = JSON.parse(await readFile(datapackIndexFilepath, "utf-8"));
         assertDatapackIndex(datapackIndex);
       } catch (e) {
         continue;
       }
       adminDisplayDatapacks[uuid] = {};
-      console.log(datapackIndex)
-      for (const datapack in datapackIndex) {
-        const datapackInfo = datapackIndex[datapack];
-        if (!datapackInfo) return;
+      for (const datapack in userDatapackIndex) {
+        const datapackInfo = userDatapackIndex[datapack];
+        if (!datapackInfo) continue;
         adminDisplayDatapacks[uuid]![datapack] = datapackInfo
       }
     }

--- a/server/src/admin-routes.ts
+++ b/server/src/admin-routes.ts
@@ -414,12 +414,13 @@ export const getAllUserDatapacks = async function getAllUserDatapacks(
       const datapackIndexFilepath = join(path, "DatapackIndex.json");
       try {
         await realpath(datapackIndexFilepath);
-        const datapackIndex = JSON.parse((await readFile(datapackIndexFilepath)).toString());
+        const datapackIndex = JSON.parse(await readFile(datapackIndexFilepath));
         assertDatapackIndex(datapackIndex);
-      } catch {
+      } catch(e) {
         continue;
       }
       adminDisplayDatapacks[uuid] = {};
+      console.log(datapackIndex)
       for (const datapack in datapackIndex) {
         const datapackInfo = datapackIndex[datapack];
         if (!datapackInfo) return;

--- a/server/src/admin-routes.ts
+++ b/server/src/admin-routes.ts
@@ -17,7 +17,6 @@ import { execFile } from "node:child_process";
 import { promisify } from "util";
 import { assertAdminSharedUser, assertDatapackIndex } from "@tsconline/shared";
 import { DatapackDescriptionInfo, NewUser } from "./types.js";
-import { glob } from "glob";
 
 /**
  * Get all users for admin to configure on frontend
@@ -402,18 +401,15 @@ export const adminDeleteServerDatapack = async function adminDeleteServerDatapac
   reply.status(200).send({ message: `Datapack ${datapack} deleted` });
 };
 
-export const getAllUserDatapacks = async function getAllUserDatapacks(
-  request: FastifyRequest,
-  reply: FastifyReply
-) {
+export const getAllUserDatapacks = async function getAllUserDatapacks(request: FastifyRequest, reply: FastifyReply) {
   const { uuid } = request.body as { uuid: string };
   if (!uuid) {
     reply.status(400).send({ error: "Missing uuid in body" });
     return;
   }
-  const datapackIndexFilepath = join(assetconfigs.uploadDirectory, uuid, "datapack-index.json");
+  const datapackIndexFilepath = join(assetconfigs.uploadDirectory, uuid, "DatapackIndex.json");
   if (!(await verifyFilepath(datapackIndexFilepath))) {
-    reply.status(403).send({ error: "Directory traversal detected" });
+    reply.send({});
     return;
   }
   let userDatapackIndex;
@@ -424,4 +420,4 @@ export const getAllUserDatapacks = async function getAllUserDatapacks(
     reply.status(500).send({ error: "Error reading user datapack index, possible corruption of file" });
   }
   reply.send(userDatapackIndex);
-}
+};

--- a/server/src/admin-routes.ts
+++ b/server/src/admin-routes.ts
@@ -121,6 +121,11 @@ export const adminDeleteUser = async function adminDeleteUser(
       reply.status(404).send({ error: "User not found" });
       return;
     }
+    // add more root logic later (maybe a new table for root users or an extra column)
+    if (user[0].email === (process.env.ADMIN_EMAIL || "test@gmail.com")) {
+      reply.status(403).send({ error: "Cannot delete root user" });
+      return;
+    }
     await deleteUser({ uuid });
     try {
       let userDirectory = resolve(assetconfigs.uploadDirectory, uuid);

--- a/server/src/admin-routes.ts
+++ b/server/src/admin-routes.ts
@@ -3,7 +3,7 @@ import { checkForUsersWithUsernameOrEmail, createUser, findUser } from "./databa
 import { randomUUID } from "node:crypto";
 import { hash } from "bcrypt-ts";
 import { deleteUser } from "./database.js";
-import { resolve, basename, extname, join, relative } from "path";
+import { resolve, extname, join, relative, parse } from "path";
 import { adminconfig, assetconfigs, checkFileExists, getBytes, verifyFilepath } from "./util.js";
 import { createWriteStream } from "fs";
 import { readFile, realpath, rm, writeFile } from "fs/promises";
@@ -205,7 +205,7 @@ export const adminUploadServerDatapack = async function adminUploadServerDatapac
       file = part;
       filename = file.filename;
       filepath = resolve(assetconfigs.datapacksDirectory, filename);
-      decryptedFilepath = resolve(assetconfigs.decryptionDirectory, basename(filename));
+      decryptedFilepath = resolve(assetconfigs.decryptionDirectory, parse(filename).name);
       if (
         !filepath.startsWith(resolve(assetconfigs.datapacksDirectory)) ||
         !decryptedFilepath.startsWith(resolve(assetconfigs.decryptionDirectory))
@@ -349,7 +349,7 @@ export const adminDeleteServerDatapack = async function adminDeleteServerDatapac
   let decryptedFilepath;
   try {
     filepath = resolve(assetconfigs.datapacksDirectory, datapack);
-    decryptedFilepath = resolve(assetconfigs.decryptionDirectory, basename(datapack));
+    decryptedFilepath = resolve(assetconfigs.decryptionDirectory, parse(datapack).name);
     if (
       !filepath.startsWith(resolve(assetconfigs.datapacksDirectory)) ||
       !decryptedFilepath.startsWith(resolve(assetconfigs.decryptionDirectory))

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -169,7 +169,7 @@ server.register(cors, {
   credentials: true
 });
 
-server.register(fastifyCompress, { global: true, threshold: 2048 });
+server.register(fastifyCompress, { global: true, threshold: 1024 * 20 });
 
 // removes the cached public/cts directory
 server.post("/removecache", async (request, reply) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -169,7 +169,7 @@ server.register(cors, {
   credentials: true
 });
 
-server.register(fastifyCompress, { global: true, threshold: 1024 * 20 });
+server.register(fastifyCompress, { global: false, threshold: 1024 * 20 });
 
 // removes the cached public/cts directory
 server.post("/removecache", async (request, reply) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -190,6 +190,8 @@ server.get("/presets", async (_request, reply) => {
   reply.send(presets);
 });
 
+server.get("/server/datapack/:name", routes.fetchServerDatapack);
+
 server.get("/datapack-index", routes.fetchServerDatapackInfo);
 server.get("/map-pack-index", routes.fetchServerMapPackInfo);
 

--- a/server/src/load-packs.ts
+++ b/server/src/load-packs.ts
@@ -32,12 +32,12 @@ export async function loadIndexes(
   mapPackIndex: MapPackIndex,
   decryptionDirectory: string,
   datapacks: DatapackDescriptionInfo[],
-  userUploaded?: boolean
+  uuid?: string
 ) {
   let successful = true;
   console.log(`\nParsing datapacks \n`);
   for (const datapack of datapacks) {
-    await parseDatapacks(datapack, decryptionDirectory, userUploaded)
+    await parseDatapacks(datapack, decryptionDirectory, uuid)
       .then((datapackParsingPack) => {
         if (!datapackParsingPack) {
           return;

--- a/server/src/parse-datapacks.ts
+++ b/server/src/parse-datapacks.ts
@@ -149,7 +149,7 @@ export function spliceArrayAtFirstSpecialMatch(array: string[]): ParsedColumnEnt
 export async function parseDatapacks(
   datapackInfo: DatapackDescriptionInfo,
   decryptFilePath: string,
-  isUserDatapack: boolean = false
+  uuid?: string
 ): Promise<DatapackParsingPack | null> {
   const decryptPaths = await grabFilepaths([datapackInfo.file], decryptFilePath, "datapacks");
   if (decryptPaths.length == 0)
@@ -287,8 +287,8 @@ export async function parseDatapacks(
     file: datapackInfo.file,
     size: datapackInfo.size,
 
-    isUserDatapack,
-    image: ""
+    image: "",
+    ...(uuid ? { uuid } : {})
   };
   assertDatapackParsingPack(datapackParsingPack);
   if (date) datapackParsingPack.date = date;

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -406,7 +406,7 @@ export const uploadDatapack = async function uploadDatapack(request: FastifyRequ
       return;
     }
   }
-  await loadIndexes(datapackIndex, mapPackIndex, decryptDir.replaceAll("\\", "/"), [datapackInfo], true);
+  await loadIndexes(datapackIndex, mapPackIndex, decryptDir.replaceAll("\\", "/"), [datapackInfo], uuid);
   if (!datapackIndex[filename]) {
     await errorHandler("Failed to load decrypted datapack", 500);
     return;

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -29,6 +29,23 @@ import { MultipartFile } from "@fastify/multipart";
 import { runJavaEncrypt } from "./encryption.js";
 import { queue, maxQueueSize } from "./index.js";
 
+export const fetchServerDatapack = async function fetchServerDatapack(
+  request: FastifyRequest<{ Params: { name: string } }>,
+  reply: FastifyReply
+) {
+  const { name } = request.params;
+  if (!name) {
+    reply.status(400).send({ error: "Invalid datapack" });
+    return;
+  }
+  const datapack = serverDatapackindex[decodeURIComponent(name)];
+  if (!datapack) {
+    reply.status(404).send({ error: "Datapack not found" });
+    return;
+  }
+  reply.send(datapack);
+};
+
 export const fetchServerDatapackInfo = async function fetchServerDatapackInfo(
   request: FastifyRequest<{ Querystring: { start?: string; increment?: string } }>,
   reply: FastifyReply

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -74,7 +74,6 @@ export type AssetConfig = {
 
 export type AdminConfig = {
   datapacks: DatapackDescriptionInfo[];
-  removeDevDatapacks: string[]; // for ignoring any datapacks that dev wants to use to prevent merge conflicts
 };
 
 export type Colors = {
@@ -105,11 +104,6 @@ export function assertAdminConfig(o: any): asserts o is AdminConfig {
   if (!o.datapacks || !Array.isArray(o.datapacks)) throw 'AdminConfig must have a "datapacks" array';
   for (const datapack of o.datapacks) {
     assertDatapackDescriptionInfo(datapack);
-  }
-  if (!o.removeDevDatapacks || !Array.isArray(o.removeDevDatapacks))
-    throw 'AdminConfig must have a "removeDevDatapacks" array';
-  for (const datapack of o.removeDevDatapacks) {
-    if (typeof datapack !== "string") throw "AdminConfig removeDevDatapacks must be an array of strings";
   }
 }
 export function assertEmail(o: any): asserts o is Email {

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -1,6 +1,6 @@
 import fs, { createReadStream } from "fs";
 import path from "path";
-import { rm, readFile, access, mkdir, readdir, copyFile, writeFile } from "fs/promises";
+import { rm, readFile, access, mkdir, readdir, copyFile, writeFile, realpath } from "fs/promises";
 import { glob } from "glob";
 import { createInterface } from "readline/promises";
 import { constants } from "fs";
@@ -274,3 +274,13 @@ export function getBytes(bytes: number) {
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
 }
+
+export async function verifyFilepath(filepath: string) {
+  const root = process.cwd();
+  filepath = await realpath(path.resolve(filepath));
+  if (!filepath.startsWith(root)) {
+    return false;
+  }
+  return true;
+}
+

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -210,7 +210,7 @@ export async function checkFileExists(filePath: string): Promise<boolean> {
 }
 
 export let assetconfigs: AssetConfig;
-export let adminconfig: AdminConfig = { datapacks: [], removeDevDatapacks: [] };
+export let adminconfig: AdminConfig = { datapacks: [] };
 export async function loadAssetConfigs() {
   try {
     const contents = JSON.parse((await readFile("assets/config.json")).toString());
@@ -225,13 +225,10 @@ export async function loadAssetConfigs() {
       const content = JSON.parse((await readFile(assetconfigs.adminConfigPath)).toString());
       assertAdminConfig(content);
       adminconfig = content;
-      assetconfigs.activeDatapacks = assetconfigs.activeDatapacks.filter(
-        (datapack) => !adminconfig.removeDevDatapacks.includes(datapack.file)
-      );
     } catch (e) {
       console.log("ERROR: Failed to load admin configs from assets/admin-config.json.  Error was: ", e);
       console.error("Removing admin-config.json and writing a new config file");
-      adminconfig = { datapacks: [], removeDevDatapacks: [] };
+      adminconfig = { datapacks: [] };
       try {
         await rm(assetconfigs.adminConfigPath);
         await writeFile(assetconfigs.adminConfigPath, JSON.stringify(adminconfig, null, 2));

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -277,10 +277,13 @@ export function getBytes(bytes: number) {
 
 export async function verifyFilepath(filepath: string) {
   const root = process.cwd();
-  filepath = await realpath(path.resolve(filepath));
-  if (!filepath.startsWith(root)) {
+  try {
+    filepath = await realpath(path.resolve(filepath));
+    if (!filepath.startsWith(root)) {
+      return false;
+    }
+  } catch {
     return false;
   }
   return true;
 }
-

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -45,7 +45,7 @@ export type DatapackParsingPack = {
   baseAge?: number;
   date?: string;
   verticalScale?: number;
-  isUserDatapack: boolean;
+  uuid?: string;
   description: string;
   title: string;
   file: string;
@@ -921,8 +921,7 @@ export function assertDatapackParsingPack(o: any): asserts o is DatapackParsingP
   if ("topAge" in o && typeof o.topAge !== "number") throwError("DatapackParsingPack", "topAge", "number", o.topAge);
   if ("baseAge" in o && typeof o.baseAge !== "number")
     throwError("DatapackParsingPack", "baseAge", "number", o.baseAge);
-  if (typeof o.isUserDatapack !== "boolean")
-    throwError("DatapackParingPack", "isUserDatapack", "boolean", o.isUserDatapack);
+  if ("uuid" in o && typeof o.uuid !== "string") throwError("DatapackParsingPack", "uuid", "string", o.uuid);
   if (typeof o.description !== "string") throwError("DatapackParsingPack", "description", "string", o.description);
   if (typeof o.title !== "string") throwError("DatapackParsingPack", "title", "string", o.title);
   if (typeof o.file !== "string") throwError("DatapackParsingPack", "file", "string", o.file);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -34,6 +34,12 @@ export type MapPackInfoChunk = {
   totalChunks: number;
 };
 
+export type AdminDisplayDatapacks = {
+  [uuid: string]: {
+    [datapack: string]: DatapackParsingPack;
+  }
+}
+
 export type ServerResponse = SuccessfulServerResponse | ServerResponseError;
 
 export type DatapackParsingPack = {
@@ -1103,6 +1109,14 @@ export function assertDisplayedColumnTypes(o: any): asserts o is DisplayedColumn
     throw new Error("DisplayedColumnTypes must be a string of a valid column type. Found value + " + o);
 }
 
+export function assertAdminDisplayDatapacks(o: any): asserts o is AdminDisplayDatapacks {
+  if (!o || typeof o !== "object") throw new Error("AdminDisplayDatapacks must be an object");
+  for (const key in o) {
+    const datapack = o[key];
+    assertDatapackParsingPack(datapack);
+  }
+}
+
 export function assertColumnInfo(o: any): asserts o is ColumnInfo {
   if (typeof o !== "object" || o === null) {
     throw new Error("ColumnInfo must be a non-null object");
@@ -1180,8 +1194,8 @@ export function assertColumnSpecificSettings(o: any, type: DisplayedColumnTypes)
     default:
       throw new Error(
         "ColumnSpecificSettings must be an object of a valid column type. Found value of " +
-          type +
-          " which is not a valid column type"
+        type +
+        " which is not a valid column type"
       );
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -34,12 +34,6 @@ export type MapPackInfoChunk = {
   totalChunks: number;
 };
 
-export type AdminDisplayDatapacks = {
-  [uuid: string]: {
-    [datapack: string]: DatapackParsingPack;
-  }
-}
-
 export type ServerResponse = SuccessfulServerResponse | ServerResponseError;
 
 export type DatapackParsingPack = {
@@ -1107,14 +1101,6 @@ export function assertDisplayedColumnTypes(o: any): asserts o is DisplayedColumn
     )
   )
     throw new Error("DisplayedColumnTypes must be a string of a valid column type. Found value + " + o);
-}
-
-export function assertAdminDisplayDatapacks(o: any): asserts o is AdminDisplayDatapacks {
-  if (!o || typeof o !== "object") throw new Error("AdminDisplayDatapacks must be an object");
-  for (const key in o) {
-    const datapack = o[key];
-    assertDatapackParsingPack(datapack);
-  }
 }
 
 export function assertColumnInfo(o: any): asserts o is ColumnInfo {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1180,8 +1180,8 @@ export function assertColumnSpecificSettings(o: any, type: DisplayedColumnTypes)
     default:
       throw new Error(
         "ColumnSpecificSettings must be an object of a valid column type. Found value of " +
-        type +
-        " which is not a valid column type"
+          type +
+          " which is not a valid column type"
       );
   }
 }


### PR DESCRIPTION
## done
changed user datapacks to associate uuids instead of `isUserDatapack`
removed `removeDevDatapacks` which used to remove dev datapacks in a hidden config file
thought that was too messy if they could upload a dev datapack after removing it with new description/titles then if the server restarts, you lose that information more or less
now make `root` datapacks unremovable and `root` users unremovable
might want to make a root table for users but i don't see us using more than one
changed a lot of the tests to this new implementation
however, everytime i save `column-keys.json` it reformats the whole file, i'm not sure why 😭 large file change there but it's just changing `isUserDatapack` to nothing since `uuid` is `undefined` and we use that instead.


# delete and display all user datapacks

https://github.com/user-attachments/assets/528d3ccb-b013-4663-a9cc-ae303ba7e106

# becomes a server datapack when uploading in the server datapack tab

https://github.com/user-attachments/assets/e6f3516b-ec64-495d-a5f1-6be885673721

