### PR TITLE
Tsc 448 sort maps so that parent maps are at the top

### DIFF
--- a/app/src/settings_tabs/map_points/MapPoints.tsx
+++ b/app/src/settings_tabs/map_points/MapPoints.tsx
@@ -80,7 +80,7 @@ const MapList: React.FC<MapRowComponentProps> = observer(({ mapInfo }) => {
       <Box>
         <List>
           {Object.entries(sortedMapInfoObj).map(([name, map]) => {
-            console.log("name: " + name, " ,parent: " + map.parent?.name)
+            console.log("name: " + name, " ,parent: " + map.parent?.name);
             return (
               <MapListItemButton
                 disableRipple

--- a/app/src/settings_tabs/map_points/MapPoints.tsx
+++ b/app/src/settings_tabs/map_points/MapPoints.tsx
@@ -80,7 +80,6 @@ const MapList: React.FC<MapRowComponentProps> = observer(({ mapInfo }) => {
       <Box>
         <List>
           {Object.entries(sortedMapInfoObj).map(([name, map]) => {
-            console.log("name: " + name, " ,parent: " + map.parent?.name);
             return (
               <MapListItemButton
                 disableRipple

--- a/app/src/settings_tabs/map_points/MapPoints.tsx
+++ b/app/src/settings_tabs/map_points/MapPoints.tsx
@@ -58,7 +58,7 @@ const MapList: React.FC<MapRowComponentProps> = observer(({ mapInfo }) => {
     if (b === "World Map") return 1;
     return a.localeCompare(b);
   });
-  const sortedMapEntries = [];
+  const sortedMapEntries: Array<[string, MapInfo[string]]> = [];
   // parent maps first
   for (const parent of sortedMapHierarchyKeys) {
     if (mapInfo[parent]) {
@@ -74,7 +74,6 @@ const MapList: React.FC<MapRowComponentProps> = observer(({ mapInfo }) => {
     }
   }
   const sortedMapInfoObj: MapInfo = Object.fromEntries(sortedMapEntries);
-  assertMapInfo(sortedMapInfoObj);
   return (
     <div className="map=list">
       <Box>

--- a/app/src/settings_tabs/map_points/MapPoints.tsx
+++ b/app/src/settings_tabs/map_points/MapPoints.tsx
@@ -2,7 +2,7 @@ import { useContext } from "react";
 import { context } from "../../state";
 import { useTheme } from "@mui/material/styles";
 import { Typography, Dialog, List, Box, ListItemButton, ListItemAvatar, ListItemText, Avatar } from "@mui/material";
-import { assertMapInfo, type MapInfo } from "@tsconline/shared";
+import { type MapInfo } from "@tsconline/shared";
 import { styled } from "@mui/material/styles";
 import { devSafeUrl } from "../../util";
 import { observer } from "mobx-react-lite";

--- a/app/src/settings_tabs/map_points/MapPoints.tsx
+++ b/app/src/settings_tabs/map_points/MapPoints.tsx
@@ -73,7 +73,7 @@ const MapList: React.FC<MapRowComponentProps> = observer(({ mapInfo }) => {
       }
     }
   }
-  const sortedMapInfoObj = Object.fromEntries(sortedMapEntries);
+  const sortedMapInfoObj: MapInfo = Object.fromEntries(sortedMapEntries);
   assertMapInfo(sortedMapInfoObj);
   return (
     <div className="map=list">


### PR DESCRIPTION
<img width="761" alt="Screenshot 2024-07-29 at 1 00 14 AM" src="https://github.com/user-attachments/assets/a3a0544a-3d37-4a5f-a890-8f33c3e41708">

world map always be the first, then all parents map shown in the alphabetic order, then their children