### PR TITLE
Tsc 467 make deploy actions listen to docker logs to return errors properly

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -53,3 +53,27 @@ jobs:
               exit 1
             fi
             docker-compose -f docker-compose.yml restart
+
+            START_TIME=$(date +"%Y-%m-%dT%H:%M:%SZ")
+
+            sleep 5
+
+            CONTAINER_ID=$(docker ps --filter "name=tsconline" --format "{{.ID}}")
+            if [ -z "$CONTAINER_ID" ]; then
+              echo "Error: Failed to get container ID for tsconline."
+              exit 1
+            fi
+
+            MAX_WAIT=240
+            INTERVAL=5
+            ELAPSED=0
+
+            while ! docker logs --since "$START_TIME" "$CONTAINER_ID" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"
+              if [ $ELAPSED -ge $MAX_WAIT ]; then
+                echo "Max wait time exceeded. Exiting..."
+                exit 1
+              fi
+              echo "Waiting for server to start... (elapsed: ${ELAPSED}s)"
+              sleep $INTERVAL
+              ELAPSED=$((ELAPSED + INTERVAL))
+            done

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -71,6 +71,7 @@ jobs:
             while ! docker logs --since "$START_TIME" "$CONTAINER_ID" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"
               if [ $ELAPSED -ge $MAX_WAIT ]; then
                 echo "Max wait time exceeded. Exiting..."
+                docker-compose -f docker-compose.yml down
                 exit 1
               fi
               echo "Waiting for server to start... (elapsed: ${ELAPSED}s)"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -61,11 +61,11 @@ jobs:
           username: deployuser
           key: ${{ secrets.SSH_KEY }}
           script: |
-            if docker ps --filter "name=pr-preview-${{ github.event.issue.number }}" | grep -q pr-preview; then
+            if docker ps --filter "name=pr-preview-${{ github.event.issue.number }}" | grep -q pr-preview-run; then
               echo "false" > /tmp/container_status.txt
               exit 0
             fi
-            if docker ps --filter "name=pr-preview" | grep -q pr-preview; then
+            if docker ps --filter "name=pr-preview" | grep -q pr-preview-run; then
               echo "true" > /tmp/container_status.txt
               exit 0
             fi
@@ -78,10 +78,20 @@ jobs:
             fi
             docker wait $BUILD_CONTAINER_ID
             docker-compose -f docker-compose-preview.yml up -d --remove-orphans pr-preview-run
+
+            CONTAINER_ID=$(docker-compose -f docker-compose-preview.yml ps -q pr-preview-run)
+            if [ -z "$CONTAINER_ID" ]; then
+              echo "Error: Failed to get container ID for pr-preview-run."
+              exit 1
+            fi
+
             MAX_WAIT=180
             INTERVAL=5
             ELAPSED=0
-            while ! docker-compose -f docker-compose-preview.yml logs | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"; do
+
+            START_TIME=$(date +"%Y-%m-%dT%H:%M:%SZ")
+
+            while ! docker logs --since "$START_TIME" "$CONTAINER_ID" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"; do
               if [ $ELAPSED -ge $MAX_WAIT ]; then
                 echo "Max wait time exceeded. Exiting..."
                 exit 1

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -98,6 +98,7 @@ jobs:
             while ! docker logs --since "$START_TIME" "$CONTAINER_ID" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"; do
               if [ $ELAPSED -ge $MAX_WAIT ]; then
                 echo "Max wait time exceeded. Exiting..."
+                docker-compose -f docker-compose-preview.yml down
                 exit 1
               fi
               echo "Waiting for server to start... (elapsed: ${ELAPSED}s)"
@@ -196,6 +197,13 @@ jobs:
               docker stop $RUNNING_CONTAINER
               docker rm $RUNNING_CONTAINER
             fi 
+            docker-compose -f docker-compose-preview.yml up -d --remove-orphans pr-preview-build
+            BUILD_CONTAINER_ID=$(docker-compose -f docker-compose-preview.yml ps -q pr-preview-build)
+            if [ -z "$BUILD_CONTAINER_ID" ]; then
+              echo "Error: Failed to get container ID for pr-preview-build."
+              exit 1
+            fi
+            docker wait $BUILD_CONTAINER_ID
             docker-compose -f docker-compose-preview.yml up -d --remove-orphans pr-preview-run
             CONTAINER_ID=$(docker-compose -f docker-compose-preview.yml ps -q pr-preview-run)
             if [ -z "$CONTAINER_ID" ]; then
@@ -212,6 +220,7 @@ jobs:
             while ! docker logs --since "$START_TIME" "$CONTAINER_ID" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"; do
               if [ $ELAPSED -ge $MAX_WAIT ]; then
                 echo "Max wait time exceeded. Exiting..."
+                docker-compose -f docker-compose-preview.yml down
                 exit 1
               fi
               echo "Waiting for server to start... (elapsed: ${ELAPSED}s)"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -183,14 +183,25 @@ jobs:
             cd /home/aaron/tsconline/pr-preview-${{ github.event.issue.number }}
             docker ps --filter "name=pr-preview" --format "{{.Names}}" | grep -oP "pr-preview-\K[0-9]+" > /tmp/running_pr.txt
             RUNNING_CONTAINER=$(docker ps --filter "name=pr-preview" --format "{{.ID}}")
-            echo "Stopping and removing container $RUNNING_CONTAINER"
-            docker stop $RUNNING_CONTAINER
-            docker rm $RUNNING_CONTAINER
+            if [ -n "$RUNNING_CONTAINER" ]; then
+              echo "Stopping and removing container $RUNNING_CONTAINER"
+              docker stop $RUNNING_CONTAINER
+              docker rm $RUNNING_CONTAINER
+            fi 
             docker-compose -f docker-compose-preview.yml up -d --remove-orphans pr-preview-run
+            CONTAINER_ID=$(docker-compose -f docker-compose-preview.yml ps -q pr-preview-run)
+            if [ -z "$CONTAINER_ID" ]; then
+              echo "Error: Failed to get container ID for pr-preview-run."
+              exit 1
+            fi
+
+            START_TIME=$(date +"%Y-%m-%dT%H:%M:%SZ")
+
             MAX_WAIT=180
             INTERVAL=5
             ELAPSED=0
-            while ! docker-compose -f docker-compose-preview.yml logs | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"; do
+
+            while ! docker logs --since "$START_TIME" "$CONTAINER_ID" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"; do
               if [ $ELAPSED -ge $MAX_WAIT ]; then
                 echo "Max wait time exceeded. Exiting..."
                 exit 1

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -70,6 +70,10 @@ jobs:
               exit 0
             fi
             echo "false" > /tmp/container_status.txt
+            if [ ! -d /home/aaron/tsconline/pr-preview-${{ github.event.issue.number }} ]; then
+              echo "Error: Directory /home/aaron/tsconline/pr-preview-${{ github.event.issue.number }} not found."
+              exit 1
+            fi
             cd /home/aaron/tsconline/pr-preview-${{ github.event.issue.number }}
             BUILD_CONTAINER_ID=$(docker-compose -f docker-compose-preview.yml ps -q pr-preview-build)
             if [ -z "$BUILD_CONTAINER_ID" ]; then
@@ -180,6 +184,10 @@ jobs:
           username: deployuser
           key: ${{ secrets.SSH_KEY }}
           script: |
+            if [ ! -d /home/aaron/tsconline/pr-preview-${{ github.event.issue.number }} ]; then
+              echo "Error: Directory /home/aaron/tsconline/pr-preview-${{ github.event.issue.number }} not found."
+              exit 1
+            fi
             cd /home/aaron/tsconline/pr-preview-${{ github.event.issue.number }}
             docker ps --filter "name=pr-preview" --format "{{.Names}}" | grep -oP "pr-preview-\K[0-9]+" > /tmp/running_pr.txt
             RUNNING_CONTAINER=$(docker ps --filter "name=pr-preview" --format "{{.ID}}")

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -76,6 +76,7 @@ jobs:
             while ! docker logs --since "$START_TIME" "$CONTAINER_ID" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"
               if [ $ELAPSED -ge $MAX_WAIT ]; then
                 echo "Max wait time exceeded. Exiting..."
+                docker-compose -f docker-compose.yml down
                 exit 1
               fi
               echo "Waiting for server to start... (elapsed: ${ELAPSED}s)"

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -58,3 +58,28 @@ jobs:
             fi
             
             docker compose -f docker-compose.yml restart
+
+            START_TIME=$(date +"%Y-%m-%dT%H:%M:%SZ")
+
+            sleep 5
+
+            CONTAINER_ID=$(docker ps --filter "name=tsconline" --format "{{.ID}}")
+            if [ -z "$CONTAINER_ID" ]; then
+              echo "Error: Failed to get container ID for tsconline."
+              exit 1
+            fi
+
+            MAX_WAIT=240
+            INTERVAL=5
+            ELAPSED=0
+
+            while ! docker logs --since "$START_TIME" "$CONTAINER_ID" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"
+              if [ $ELAPSED -ge $MAX_WAIT ]; then
+                echo "Max wait time exceeded. Exiting..."
+                exit 1
+              fi
+              echo "Waiting for server to start... (elapsed: ${ELAPSED}s)"
+              sleep $INTERVAL
+              ELAPSED=$((ELAPSED + INTERVAL))
+            done
+            

--- a/.github/workflows/merge-pipeline.yml
+++ b/.github/workflows/merge-pipeline.yml
@@ -302,7 +302,8 @@ jobs:
               MAX_WAIT=180
               INTERVAL=5
               ELAPSED=0
-              while ! docker-compose -f docker-compose-preview.yml logs pr-preview-run | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"; do
+              START_TIME=$(date +"%Y-%m-%dT%H:%M:%SZ")
+              while ! docker logs --since "$START_TIME" "$CONTAINER_NAME" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"; do
                 if [ $ELAPSED -ge $MAX_WAIT ]; then
                   echo "Max wait time exceeded. Exiting..."
                   exit 1

--- a/.github/workflows/merge-pipeline.yml
+++ b/.github/workflows/merge-pipeline.yml
@@ -306,6 +306,7 @@ jobs:
               while ! docker logs --since "$START_TIME" "$CONTAINER_NAME" 2>&1 | grep -q "Server listening on  { address: '0.0.0.0', family: 'IPv4', port: 3000 }"; do
                 if [ $ELAPSED -ge $MAX_WAIT ]; then
                   echo "Max wait time exceeded. Exiting..."
+                  docker-compose -f docker-compose.yml down
                   exit 1
                 fi
                 echo "Waiting for server to start... (elapsed: ${ELAPSED}s)"


### PR DESCRIPTION
listen to docker logs for if the server restarts/starts properly

add some proper error checking for if `/confirm-deploy` gets called by itself and more specific docker querying for current running containers

not sure why but it doesn't use my workflow file when commenting so i can't for sure test it until it merges to main
although i tested all the commands in the console