### PR TITLE
Tsc 468 fix update file metadata on datapack usage when generating a chart

### DIFF
--- a/app/src/state/initialize.ts
+++ b/app/src/state/initialize.ts
@@ -4,6 +4,8 @@ export async function initialize() {
   // If we're running in dev mode (yarn dev), then the app is not served from the same URL
   // as the server hosts the /charts endpoint.  So, we'll hard-code that for ourselves here.
   actions.sessionCheck();
+  actions.fetchDatapackIndex();
+  actions.fetchMapPackIndex();
   actions.fetchPresets();
   actions.setDatapackConfig([], "");
   actions.fetchFaciesPatterns();

--- a/app/src/util/error-codes.ts
+++ b/app/src/util/error-codes.ts
@@ -62,7 +62,8 @@ export enum ErrorCodes {
   ADMIN_DELETE_USER_DATAPACK_FAILED = "ADMIN_DELETE_USER_DATAPACK_FAILED",
   ADMIN_DELETE_SERVER_DATAPACK_FAILED = "ADMIN_DELETE_SERVER_DATAPACK_FAILED",
   ADMIN_CANNOT_DELETE_ROOT_DATAPACK = "ADMIN_CANNOT_DELETE_ROOT_DATAPACK",
-  INVALID_SERVER_DATAPACK_REQUEST = "INVALID_SERVER_DATAPACK_REQUEST"
+  INVALID_SERVER_DATAPACK_REQUEST = "INVALID_SERVER_DATAPACK_REQUEST",
+  SERVER_FILE_METADATA_ERROR = "SERVER_FILE_METADATA_ERROR"
 }
 
 export const ErrorMessages = {
@@ -137,5 +138,6 @@ export const ErrorMessages = {
   [ErrorCodes.ADMIN_DELETE_USER_DATAPACK_FAILED]: "Unable to delete user datapack. Please try again later.",
   [ErrorCodes.ADMIN_DELETE_SERVER_DATAPACK_FAILED]: "Unable to delete server datapack. Please try again later.",
   [ErrorCodes.ADMIN_CANNOT_DELETE_ROOT_DATAPACK]: "Cannot delete root datapack. Ask server admin for assistance.",
-  [ErrorCodes.INVALID_SERVER_DATAPACK_REQUEST]: "Invalid server datapack request. Please try again later."
+  [ErrorCodes.INVALID_SERVER_DATAPACK_REQUEST]: "Invalid server datapack request. Please try again later.",
+  [ErrorCodes.SERVER_FILE_METADATA_ERROR]: "Server file metadata error. Please try again later."
 };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -278,7 +278,7 @@ server.post("/upload-profile-picture", moderateRateLimit, loginRoutes.uploadProf
 // generates chart and sends to proper directory
 // will return url chart path and hash that was generated for it
 server.post<{ Params: { usecache: string; useSuggestedAge: string; username: string } }>(
-  "/charts/:usecache/:useSuggestedAge/:username",
+  "/chart",
   looseRateLimit,
   routes.fetchChart
 );
@@ -291,8 +291,9 @@ server.get<{ Params: { datapackName: string; imageName: string } }>(
   routes.fetchImage
 );
 
-setInterval(() => {
-  checkFileMetadata(assetconfigs.fileMetadata);
+setInterval(async () => {
+  await checkFileMetadata(assetconfigs.fileMetadata);
+  console.log("Successfully checked file metadata");
 }, sunsetInterval);
 setInterval(
   () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -292,8 +292,11 @@ server.get<{ Params: { datapackName: string; imageName: string } }>(
 );
 
 setInterval(async () => {
-  await checkFileMetadata(assetconfigs.fileMetadata);
-  console.log("Successfully checked file metadata");
+  await checkFileMetadata(assetconfigs.fileMetadata)
+    .catch((e) => {
+      console.error("Error checking file metadata: ", e);
+    })
+    .finally(() => console.log("Successfully checked file metadata"));
 }, sunsetInterval);
 setInterval(
   () => {

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -9,7 +9,6 @@ import {
   TimescaleItem,
   assertChartRequest,
   assertDatapackIndex,
-  assertIndexResponse,
   assertTimescale,
   assertMapPackIndex
 } from "@tsconline/shared";
@@ -245,27 +244,24 @@ export const fetchUserDatapacks = async function fetchUserDatapacks(request: Fas
   try {
     await access(userDir);
     await access(path.join(userDir, "DatapackIndex.json"));
+    await access(path.join(userDir, "MapPackIndex.json"));
   } catch (e) {
-    reply.status(404).send({ error: "User has no uploaded datapacks" });
+    reply.send({ datapackIndex: {}, mapPackIndex: {} });
     return;
   }
-
-  const datapackIndex: DatapackIndex = JSON.parse(JSON.stringify(serverDatapackindex));
-  const mapPackIndex: MapPackIndex = JSON.parse(JSON.stringify(serverMapPackIndex));
   try {
-    const dataPackData = await readFile(path.join(userDir, "DatapackIndex.json"), "utf8");
-    Object.assign(datapackIndex, JSON.parse(dataPackData));
-    const mapPackData = await readFile(path.join(userDir, "MapPackIndex.json"), "utf8");
-    Object.assign(mapPackIndex, JSON.parse(mapPackData));
+    const datapackIndex = JSON.parse(await readFile(path.join(userDir, "DatapackIndex.json"), "utf8"));
+    assertDatapackIndex(datapackIndex);
+    const mapPackIndex = JSON.parse(await readFile(path.join(userDir, "MapPackIndex.json"), "utf8"));
+    assertMapPackIndex(mapPackIndex);
+    const indexResponse = { datapackIndex, mapPackIndex };
+    reply.status(200).send(indexResponse);
   } catch (e) {
     reply
       .status(500)
       .send({ error: "Failed to load indexes, corrupt json files present. Please contact customer service." });
     return;
   }
-  const indexResponse = { datapackIndex, mapPackIndex };
-  assertIndexResponse(indexResponse);
-  reply.status(200).send(indexResponse);
 };
 
 // If at some point a delete datapack function is needed, this function needs to be modified for race conditions

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -84,6 +84,11 @@ export type DatapackWarning = {
   warning: string;
 };
 
+export type ChartErrorResponse = {
+  error: string;
+  errorCode: number;
+};
+
 export type IndexResponse = {
   datapackIndex: DatapackIndex;
   mapPackIndex: MapPackIndex;
@@ -558,6 +563,12 @@ export type TimescaleItem = {
 };
 
 export type DefaultChronostrat = "USGS" | "UNESCO";
+
+export function assertChartErrorResponse(o: any): asserts o is ChartErrorResponse {
+  if (!o || typeof o !== "object") throw new Error("ChartErrorResponse must be a non-null object");
+  if (typeof o.error !== "string") throwError("ChartErrorResponse", "error", "string", o.error);
+  if (typeof o.errorCode !== "number") throwError("ChartErrorResponse", "errorCode", "number", o.errorCode);
+}
 
 export function isDefaultChronostrat(o: any): o is DefaultChronostrat {
   return /^(USGS|UNESCO)$/.test(o);


### PR DESCRIPTION
## Main Change
- just some back end fixing for making sure that errors are caught properly when updating a datapack's metadata when a chart is used. 
- one thing to note is that if for some reason a file exists and the metadata does not note this, i'm not sure what to really do so it cancels the chart request. i would normally want to make the entry if it doesn't exist, but that feels like a lot of spaghetti code since we have to verify whether the datapack is valid, all the parts are present, etc (basically the whole upload workflow) so i thought it would be better to just cancel and if errors persist with the metadata, we manually add it (or create a route to verify and add the entry) for admins

## Small additions
- additionally changed fetching user datapacks and fetching server datapacks into their own seperate calls so that routes are specifically what they are named

- added logic for removing user datapacks on logout 

- seperate `errorCode` for chart generation failures (only for metadata issues, and jar generation issues)

- one potential error is that a website could be up for so long that an admin might remove a datapack from the server, which would make any requests with that datapack fail and essentially that datapack in the user's app would be "stale". this is something i wrote in the TODO (this pops up because we never remove/restart the datapack index on fetch so we can't just refetch unless we add more logic for that)