### PR TITLE
Tsc 436 load settings doesn t work properly for a certain settings file

### DIFF
--- a/app/src/state/actions/column-actions.ts
+++ b/app/src/state/actions/column-actions.ts
@@ -59,7 +59,7 @@ function extractColumnType(text: string): string {
 function setColumnProperties(column: ColumnInfo, settings: ColumnInfoTSC) {
   console.log("Settings(setColProp):", settings);
   console.log("Column(setColProp):", column);
-  
+
   setEditName(settings.title, column);
   setEnableTitle(settings.drawTitle, column);
   if ("showUncertaintyLabels" in column) setShowUncertaintyLabels(settings.drawUncertaintyLabel, column);
@@ -257,15 +257,15 @@ export function addColumnToDataMiningCache(settings: ColumnInfoTSC) {
 
 export const applyChartColumnSettings = action("applyChartColumnSettings", (settings: ColumnInfoTSC) => {
   const columnName = extractName(settings._id);
-  let curcol: ColumnInfo | undefined =
+  const curcol: ColumnInfo | undefined =
     state.settingsTabs.columnHashMap.get(columnName) ||
     state.settingsTabs.columnHashMap.get("Chart Title in " + columnName);
   console.log(`Processing column: ${columnName}`);
-  console.log('Current column:', curcol);
-  console.log('Settings:', settings);
+  console.log("Current column:", curcol);
+  console.log("Settings:", settings);
   // Apply settings to the current column
   if (curcol) {
-    console.log('Applying settings to column:', columnName);
+    console.log("Applying settings to column:", columnName);
     setColumnProperties(curcol, settings);
   } else {
     console.warn(`Column not found in hash map: ${columnName}`);


### PR DESCRIPTION
From what I can tell, I was able to fix one of the loading issues for the settings, the issue was that leaf settings weren't being processed correctly, I'm honestly not 100% sure what the original code was doing, just that it seemed to be trying to change settings of a nonexistent child settings for leaf settings. By leaf settings, I mean:
![image](https://github.com/user-attachments/assets/de794ede-aecc-4b13-a5ed-a048dfe3027d)

I don't really understand what datamining even is, so I'm hoping I didn't break anything regards to that
  addColumnToDataMiningCache(settings);


Now for the other issue Gabi had, which was 
![image](https://github.com/user-attachments/assets/95bb99d1-2dc3-49a8-8712-d54471627695)

The unitsperMY not changing, I think the issue is that it isn't parsing the unitsPerMY properly prior to being passed into the function to apply the settings, because my console.log showed that setting as being empty.

I have some questions though, why in the code is there a for loop to do this? It looks like unitsPerMY was supposed to be an array? But isn't it just a single value we change in the image above?

  for (const unit of unitsPerMY) {
    if (!state.settings.timeSettings[unit.unit]) {
      state.settings.timeSettings[unit.unit] = JSON.parse(JSON.stringify(defaultTimeSettings));
    }
    setUnitsPerMY(unit.text / 30, unit.unit);
  }

The code snippet is in /app/src/state/actions/general-actions.ts

Also, what's up with the division by 30? When saving, we also multiplied by 30, what's up with that? Why even have that 30 if we are just going to remove it.

The above is just some weird code I saw, but the actual issue might be in the parser, which I'm looking at still.