### PR TITLE
add unsafe content for download so svg downloads and displays properly

### DIFF
--- a/app/src/ChartOptionsBar.tsx
+++ b/app/src/ChartOptionsBar.tsx
@@ -215,7 +215,7 @@ export const OptionsBar: React.FC<OptionsBarProps> = observer(({ transformRef, s
     async function downloadChart() {
       actions.setChartTabIsSavingChart(true);
       if (state.chartTab.downloadFiletype === "svg") {
-        const blob = new Blob([state.chartContent]);
+        const blob = new Blob([state.chartTab.unsafeChartContent]);
         FileSaver.saveAs(blob, state.chartTab.downloadFilename + ".svg");
         actions.pushSnackbar("Saved Chart as SVG!", "success");
         actions.setChartTabIsSavingChart(false);

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -1195,3 +1195,6 @@ export const setChartTabEnableScrollZoom = action("setChartTabEnableScrollZoom",
 export const setChartTabIsSavingChart = action((term: boolean) => {
   state.chartTab.isSavingChart = term;
 });
+export const setUnsafeChartContent = action((content: string) => {
+  state.chartTab.unsafeChartContent = content;
+});

--- a/app/src/state/actions/generate-chart-actions.ts
+++ b/app/src/state/actions/generate-chart-actions.ts
@@ -180,6 +180,9 @@ export const fetchChartFromServer = action("fetchChartFromServer", async (naviga
         ADD_URI_SAFE_ATTR: ["docbase", "popuptext"]
       };
       const sanitizedSVG = DOMPurify.sanitize(content, domPurifyConfig);
+      // for download ONLY
+      generalActions.setUnsafeChartContent(content);
+      // the display version
       generalActions.setChartContent(sanitizedSVG);
       generalActions.setChartTimelineEnabled(false);
       generalActions.setChartTimelineLocked(false);

--- a/app/src/state/state.ts
+++ b/app/src/state/state.ts
@@ -40,6 +40,7 @@ export type State = {
     downloadFiletype: "svg" | "pdf" | "png";
     isSavingChart: boolean;
     enableScrollZoom: boolean;
+    unsafeChartContent: string;
   };
   loadSaveFilename: string;
   cookieConsent: boolean | null;
@@ -117,7 +118,8 @@ export const state = observable<State>({
     downloadFilename: "chart",
     downloadFiletype: "svg",
     isSavingChart: false,
-    enableScrollZoom: false
+    enableScrollZoom: false,
+    unsafeChartContent: "" // this is used to store the chart content for download which is vulnerable to XSS
   },
   loadSaveFilename: "settings", //name without extension (.tsc)
   cookieConsent: null,


### PR DESCRIPTION
## main

- the sanitization of the svg makes the downloadable svg catch errors
- could unsanitize, but this way it's a 1:1 with the export
- store the unsafe svg for download use only
- see below for errors
- svg download is now normal/the same as the export of the java file

![image](https://github.com/user-attachments/assets/d67601a0-1c13-4b64-b656-7515f6ce0845)

![image](https://github.com/user-attachments/assets/a5155a6e-d443-4017-8196-abbf7e27123f)

