### PR TITLE
Tsc 491 change error text to black and make bigger

### DIFF
--- a/app/src/NavBar.tsx
+++ b/app/src/NavBar.tsx
@@ -65,6 +65,7 @@ export const NavBar = observer(function Navbar() {
               sx={{
                 "& .MuiTab-root": {
                   color: "dark.contrastText",
+                  fontWeight: 600,
                   "&:hover:not(.Mui-selected)": {
                     color: "button.main"
                   }

--- a/app/src/components/TSCError.tsx
+++ b/app/src/components/TSCError.tsx
@@ -41,7 +41,7 @@ export const TSCError: React.FC<TSCErrorProps> = observer(({ errorContext, messa
       <div
         className="alert"
         style={{
-          backgroundColor: Color(theme.palette.error.light).lighten(0.1).string(),
+          backgroundColor: Color(theme.palette.error.light).lighten(0.3).string(),
           border: `1px solid ${Color(theme.palette.error.light).darken(0.4)}`
         }}>
         <div className="alert-header">
@@ -55,7 +55,7 @@ export const TSCError: React.FC<TSCErrorProps> = observer(({ errorContext, messa
             <CloseIcon className="alert-close-icon" style={{ color: theme.palette.error.dark }} />
           </IconButton>
         </div>
-        <CustomDivider key={`${index} error`} />
+        <CustomDivider key={`${index} error`} style={{ borderColor: theme.palette.error.dark }} />
         <StyledScrollbar className="alert-text">
           <Typography className="alert-info-text" color="error.dark">
             {message}

--- a/app/src/components/datapack_display/TSCCompactDatapackRow.module.css
+++ b/app/src/components/datapack_display/TSCCompactDatapackRow.module.css
@@ -9,6 +9,7 @@
   line-height: 1.2rem;
   border-radius: 10px;
   margin: 1px 0;
+  cursor: pointer;
 }
 .cc {
   display: flex;


### PR DESCRIPTION
## Changes (TSC-492)

- clickable cursor pointer on `TSCDatapackCompactRow`
- divider has error color on `TSCError`

<img width="338" alt="Screenshot 2024-08-14 at 4 56 42 PM" src="https://github.com/user-attachments/assets/ab4f9f3e-c8a6-4a5c-ab98-85c0f6142915">

<img width="364" alt="Screenshot 2024-08-14 at 4 57 23 PM" src="https://github.com/user-attachments/assets/8485f3bd-50ae-4935-9a38-1e02b395944d">


## Before 

<img width="362" alt="Screenshot 2024-08-14 at 4 56 58 PM" src="https://github.com/user-attachments/assets/8fe72301-13d0-41f7-9e7a-ef578ae2e836">

<img width="407" alt="Screenshot 2024-08-14 at 4 57 15 PM" src="https://github.com/user-attachments/assets/ec3ad349-e671-451d-84e6-d12ba459cd20">
