### PR TITLE
TSC-471-concurrency-stress-testing

### DIFF
--- a/scripts/stress_test.py
+++ b/scripts/stress_test.py
@@ -1,0 +1,152 @@
+import concurrent.futures
+import requests
+import time
+import os
+import itertools
+
+CHART_URL = "https://dev.timescalecreator.org/chart"
+SVG_STATUS_URL = "https://dev.timescalecreator.org/svgstatus/"
+GET_CHART_URL = "https://dev.timescalecreator.org"
+DATA_DIR = "./ping_files/data"
+SVG_DIR = "./ping_files/charts"
+data_files = {os.path.splitext(file)[0]: os.path.join(DATA_DIR, file) for file in os.listdir(DATA_DIR)}
+svg_files = {os.path.splitext(file)[0]: os.path.join(SVG_DIR, file) for file in os.listdir(SVG_DIR)}
+
+HEADERS = {"Content-Type": "text/plain"}
+
+common_files = list(set(data_files.keys()).intersection(svg_files.keys()))
+
+def read_file(file_path):
+    with open(file_path, "r") as file:
+        return file.read()
+
+def ping_endpoint(file_key, thread_id, silent=False):
+    def log(message):
+        if not silent:
+            print(message)
+
+    try:
+        data_file = data_files[file_key]
+        svg_file = svg_files[file_key]
+        DATA = read_file(data_file)
+        expected_svg = read_file(svg_file)
+
+        start_time = time.time()
+        response = requests.post(CHART_URL, data=DATA, headers=HEADERS)
+        initial_response_time = time.time() - start_time
+        if response.status_code == 200:
+            log(f"[Thread-{thread_id}] [{file_key}] Initial request successful, status code 200")
+            json_response = response.json()
+            chart_hash_url = json_response.get("hash")
+            if chart_hash_url:
+                log(f"[Thread-{thread_id}] [{file_key}] chart_hash_url obtained: {chart_hash_url}")
+                # Ping /svgstatus/hash
+                while time.time() - start_time < 500:
+                    status_response = requests.get(SVG_STATUS_URL + chart_hash_url, headers=HEADERS)
+                    if status_response.status_code == 200:
+                        status_data = status_response.json()
+                        log(f"[Thread-{thread_id}] [{file_key}] Status response received, status code 200, status data: {status_data}")
+                        log(f"[Thread-{thread_id}] [{file_key}] Full SVG Status Response: {status_response.text}")
+                        if status_data.get("ready") == True:
+                            log(f"[Thread-{thread_id}] [{file_key}] Status is ready")
+                            chart_path = json_response.get("chartpath")
+                            if chart_path:
+                                log(f"[Thread-{thread_id}] [{file_key}] chart_path obtained: {chart_path}")
+                                # Get the actual chart
+                                chart_response = requests.get(GET_CHART_URL + chart_path, headers=HEADERS)
+                                response_time = time.time() - start_time
+                                log(f"[Thread-{thread_id}] [{file_key}] Final chart received, status code {chart_response.status_code}")
+                                #log(f"[Thread-{thread_id}] [{file_key}] Full Chart Response: {chart_response.text}")
+                                return file_key, initial_response_time, response_time, chart_response.status_code, chart_response.text, expected_svg
+                            else:
+                                log(f"[Thread-{thread_id}] [{file_key}] chart_path not found in json_response")
+                        else:
+                            log(f"[Thread-{thread_id}] [{file_key}] Status not ready yet")
+                    else:
+                        log(f"[Thread-{thread_id}] [{file_key}] Status response error, status code: {status_response.status_code}")
+                        log(f"[Thread-{thread_id}] [{file_key}] Full Status Response Error: {status_response.text}")
+                    time.sleep(5)
+            else:
+                log(f"[Thread-{thread_id}] [{file_key}] chart_hash_url not found in json_response")
+        else:
+            log(f"[Thread-{thread_id}] [{file_key}] Initial request failed, status code: {response.status_code}, response text: {response.text}")
+        log(f"[Thread-{thread_id}] [{file_key}] Request failed, status code: {response.status_code}, response text: {response.text}")
+        return file_key, None, None, response.status_code, response.text, None
+    except requests.exceptions.Timeout:
+        log(f"[Thread-{thread_id}] [{file_key}] Request timeout occurred")
+        return file_key, None, None, 408, None, None
+    except requests.exceptions.RequestException as e:
+        log(f"[Thread-{thread_id}] [{file_key}] Request exception: {e}")
+        if hasattr(e, 'response') and e.response is not None:
+            return file_key, None, None, e.response.status_code, None, None
+        else:
+            return file_key, None, None, None, None, None
+
+def do_ping(num_users, silent=False):
+    timeouts = []
+    server_busy = []
+    gateway_timeout = []
+    other_errors = []
+    initial_response_times = []
+    response_times = []
+    match_count = 0
+    mismatch_count = 0
+    results = []
+
+    print("*" * 50)
+    print(f"Simulating {num_users} users pinging the endpoint")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_users) as executor:
+        selected_files = list(itertools.islice(itertools.cycle(common_files), num_users))
+        futures = [executor.submit(ping_endpoint, file_key, i, silent) for i, file_key in enumerate(selected_files)]
+        for future in concurrent.futures.as_completed(futures):
+            file_key, initial_response_time, response_time, status_code, response_body, expected_svg = future.result()
+            if initial_response_time is not None and response_time is not None and status_code == 200:
+                initial_response_times.append(initial_response_time)
+                response_times.append(response_time)
+                results.append((file_key, initial_response_time, response_time))
+                if response_body == expected_svg:
+                    match_count += 1
+                else:
+                    mismatch_count += 1
+            elif status_code == 408:
+                timeouts.append(file_key)
+            elif status_code == 503:
+                server_busy.append(file_key)
+            elif status_code == 504:
+                gateway_timeout.append(file_key)
+            else:
+                other_errors.append((file_key, status_code, response_body))
+
+    if initial_response_times:
+        average_initial_response_time = sum(initial_response_times) / len(initial_response_times)
+    else:
+        average_initial_response_time = float("inf")
+    if response_times:
+        average_response_time = sum(response_times) / len(response_times)
+    else:
+        average_response_time = float("inf")
+
+    print(f"Number of successful responses (200): {len(response_times)}")
+    print(f"Number of timeouts (408): {len(timeouts)} - {timeouts}")
+    print(f"Number of server busy (503): {len(server_busy)} - {server_busy}")
+    print(f"Number of gateway timeouts (504): {len(gateway_timeout)} - {gateway_timeout}")
+    print(f"Other errors: {other_errors}")
+    print(f"Number of matching responses: {match_count}")
+    print(f"Number of mismatching responses: {mismatch_count}")
+    print(f"Average response time of chart request: {average_initial_response_time:.2f} seconds")
+    print(f"All chart request times: {initial_response_times}")
+    print(f"Average total response time: {average_response_time:.2f} seconds")
+    print(f"All total response times: {response_times}")
+    print("\nDetails for each request:")
+    for file_key, initial_resp_time, total_resp_time in results:
+        print(f"File: {file_key}, Initial Response Time: {initial_resp_time:.2f} seconds, Total Response Time: {total_resp_time:.2f} seconds")
+    print("*" * 50)
+    print("\n")
+
+def main():
+    num_of_users = [5, 10, 20]
+    for num_users in num_of_users:
+        do_ping(num_users, silent=True)
+
+if __name__ == "__main__":
+    main()

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "@fastify/static": "^6.10.1",
     "@tsconline/shared": "1.0.0",
     "@xmldom/xmldom": "0.8.10",
+    "async-mutex": "^0.5.0",
     "bcrypt-ts": "^5.0.2",
     "better-sqlite3": "^9.4.4",
     "chalk": "^5.3.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,8 +25,8 @@ import PQueue from "p-queue";
 import { userRoutes } from "./routes/user-auth.js";
 import { fetchUserDatapacks } from "./routes/user-routes.js";
 
-const maxConcurrencySize = 3;
-export const maxQueueSize = 15;
+const maxConcurrencySize = 2;
+export const maxQueueSize = 30;
 
 const server = fastify({
   logger: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,6 +2467,7 @@ __metadata:
     "@types/pump": "npm:^1.1.3"
     "@types/validator": "npm:^13"
     "@xmldom/xmldom": "npm:0.8.10"
+    async-mutex: "npm:^0.5.0"
     bcrypt-ts: "npm:^5.0.2"
     better-sqlite3: "npm:^9.4.4"
     chalk: "npm:^5.3.0"
@@ -3744,6 +3745,15 @@ __metadata:
   version: 1.1.0
   resolution: "assertion-error@npm:1.1.0"
   checksum: fd9429d3a3d4fd61782eb3962ae76b6d08aa7383123fca0596020013b3ebd6647891a85b05ce821c47d1471ed1271f00b0545cf6a4326cf2fc91efcc3b0fbecf
+  languageName: node
+  linkType: hard
+
+"async-mutex@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "async-mutex@npm:0.5.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 4c6bfce1cc9cd43f723c4d96403ac5f4757f885c953b839cde6956ec8817ff39623b82d67614de10c7933e21626925882fb9bac367db7d15d7cb4f84228722c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Added mutex to metadata handler to fix race condition. After testing a max of 2 for concurrency and a queue size of 30 seemed best, increasing the concurrency anymore leads to a large increase in timeouts.

Example with 2 and 30 as values:
Simulating 50 users pinging the endpoint
Number of successful responses (200): 49
Number of timeouts (408): 0 - []
Number of server busy (503): 0 - []
Number of gateway timeouts (504): 0 - []
Other errors: [('south_america', 200, '{"error":"Unknown error occurred during chart generation"}')]
Number of matching responses: 49
Number of mismatching responses: 0
Average response time of chart request: 108.65 seconds

When increased to concurrency of 3:
Simulating 50 users pinging the endpoint
Number of successful responses (200): 37
Number of timeouts (408): 12 - ['south_america', 'south_america', 'south_america', 'south_america', 'south_america', 'south_america', 'south_america', 'south_america', 'south_america', 'south_america', 'south_america', 'south_america']
Number of server busy (503): 0 - []
Number of gateway timeouts (504): 0 - []
Other errors: [('south_america', 200, '{"error":"Unknown error occurred during chart generation"}')]
Number of matching responses: 37
Number of mismatching responses: 0
Average response time of chart request: 96.06 seconds