### PR TITLE
add fix for map point display and for map point hierarchy bug

### DIFF
--- a/app/src/settings_tabs/Results.tsx
+++ b/app/src/settings_tabs/Results.tsx
@@ -19,7 +19,7 @@ import { ErrorOutline } from "@mui/icons-material";
 import NotesIcon from "@mui/icons-material/Notes";
 import { useTheme } from "@mui/material/styles";
 import { EventSearchInfo, GroupedEventSearchInfo } from "../types";
-import { checkIfDataIsInRange, trimQuotes } from "../util/util";
+import { checkIfDataIsInRange, trimQuotes, willColumnBeVisibleOnChart } from "../util/util";
 import bigDecimal from "js-big-decimal";
 import HorizontalRuleIcon from "@mui/icons-material/HorizontalRule";
 import VerticalAlignCenterIcon from "@mui/icons-material/VerticalAlignCenter";
@@ -40,21 +40,7 @@ const Status = observer(({ info }: { info: EventSearchInfo }) => {
       </SvgIcon>
     );
   }
-  const ColumnPathToRootOn = () => {
-    let currColumn = column!;
-    while (currColumn.parent) {
-      if (currColumn.on === false) {
-        return false;
-      }
-      const parent = state.settingsTabs.columnHashMap.get(currColumn.parent);
-      if (!parent) {
-        console.error("parent of " + currColumn.name + "not found");
-        return false;
-      }
-      currColumn = parent;
-    }
-    return true;
-  };
+  const on = willColumnBeVisibleOnChart(column, state.settingsTabs.columnHashMap);
   const ages = info.age;
   const dataInRange = ages
     ? checkIfDataIsInRange(
@@ -72,12 +58,12 @@ const Status = observer(({ info }: { info: EventSearchInfo }) => {
           enterNextDelay={tooltipDelayTime}
           disableInteractive
           placement="top"
-          title={ColumnPathToRootOn() ? "Column Toggled ON" : "Column Toggled OFF"}>
+          title={on ? "Column Toggled ON" : "Column Toggled OFF"}>
           <TSCCheckbox
             className="status-checkbox"
             size="large"
             onClick={() => actions.toggleSettingsTabColumn(column)}
-            checked={ColumnPathToRootOn()}
+            checked={on}
           />
         </CustomTooltip>
       ) : (

--- a/app/src/settings_tabs/map_points/MapButtons.tsx
+++ b/app/src/settings_tabs/map_points/MapButtons.tsx
@@ -12,7 +12,7 @@ import {
 } from "@tsconline/shared";
 import { useContext, useState } from "react";
 import { observer } from "mobx-react-lite";
-import { actions, context } from "../../state";
+import { context } from "../../state";
 import { useTransformEffect } from "react-zoom-pan-pinch";
 import { calculateRectBoundsPosition, calculateRectButton, calculateVertBoundsPosition } from "../../util/coordinates";
 import NotListedLocationIcon from "@mui/icons-material/NotListedLocation";
@@ -20,7 +20,7 @@ import LocationOffIcon from "@mui/icons-material/LocationOff";
 import LocationOnSharpIcon from "@mui/icons-material/LocationOnSharp";
 import { devSafeUrl } from "../../util";
 import { BorderedIcon } from "../../components";
-import { checkIfDataIsInRange } from "../../util/util";
+import { checkIfDataIsInRange, willColumnBeVisibleOnChart } from "../../util/util";
 
 const IconSize = 40;
 export const InfoIcon = NotListedLocationIcon;
@@ -74,12 +74,12 @@ type MapPointButtonProps = {
 const MapPointButton: React.FC<MapPointButtonProps> = observer(
   ({ mapPoint, x, y, name, isInfo = false, container }) => {
     const theme = useTheme();
-    const { state } = useContext(context);
+    const { state, actions } = useContext(context);
     const column = state.settingsTabs.columnHashMap.get(name);
     if (!column) {
       console.log(`Column ${name} not found in columnHashMap`);
     }
-    const clicked = column ? column.on : false;
+    const clicked = column ? willColumnBeVisibleOnChart(column, state.settingsTabs.columnHashMap) : false;
     // is an info point if given or doesn't exist in hash map
     isInfo = isInfo || !column;
     const disabled = column
@@ -165,7 +165,7 @@ interface TransectLineProps {
  */
 const TransectLine: React.FC<TransectLineProps> = observer(
   ({ name, startPosition, endPosition, transect, onColor, offColor, container }) => {
-    const { state } = useContext(context);
+    const { state, actions } = useContext(context);
     const column = state.settingsTabs.columnHashMap.get(name);
     if (!column) {
       console.log(`Column ${name} not found in columnHashMap`);

--- a/app/src/settings_tabs/map_points/MapViewer.tsx
+++ b/app/src/settings_tabs/map_points/MapViewer.tsx
@@ -134,6 +134,7 @@ export const MapViewer: React.FC<MapProps> = observer(({ name, isFacies }) => {
                       true,
                       mapViewerRef.current
                     )}
+                  {/* Load all the transects */}
                   {imageLoaded &&
                     imageRef &&
                     imageRef.current &&

--- a/app/src/util/util.ts
+++ b/app/src/util/util.ts
@@ -25,7 +25,7 @@ export function checkIfDataIsInRange(minDataAge: number, maxDataAge: number, use
   return (minDataAge > userTopAge && minDataAge < userBaseAge) || (maxDataAge < userBaseAge && maxDataAge > userTopAge);
 }
 
-export const willColumnBeVisibleOnChart = (column: ColumnInfo, columnHashMap: Map<string, ColumnInfo>) => {
+export const willColumnBeVisibleOnChart = (column: ColumnInfo, columnHashMap: Map<string, ColumnInfo>): boolean => {
   if (!column.on) return false;
   // reached the top, so it will be visible
   if (!column.parent) return true;

--- a/app/src/util/util.ts
+++ b/app/src/util/util.ts
@@ -1,4 +1,4 @@
-import { RGB } from "@tsconline/shared";
+import { ColumnInfo, RGB } from "@tsconline/shared";
 import Color from "color";
 
 /**
@@ -24,6 +24,18 @@ export function checkIfDataIsInRange(minDataAge: number, maxDataAge: number, use
   }
   return (minDataAge > userTopAge && minDataAge < userBaseAge) || (maxDataAge < userBaseAge && maxDataAge > userTopAge);
 }
+
+export const willColumnBeVisibleOnChart = (column: ColumnInfo, columnHashMap: Map<string, ColumnInfo>) => {
+  if (!column.on) return false;
+  // reached the top, so it will be visible
+  if (!column.parent) return true;
+  const parent = columnHashMap.get(column.parent);
+  if (!parent) {
+    console.log("WARNING: tried to get", column.parent, "in columnHashMap, but is undefined");
+    return false;
+  }
+  return willColumnBeVisibleOnChart(parent, columnHashMap);
+};
 
 /**
  * Compare viewport height and px height

--- a/app/src/util/workers/set-datapack-config.ts
+++ b/app/src/util/workers/set-datapack-config.ts
@@ -87,7 +87,7 @@ const setDatapackConfig = (datapacks: DatapackConfigForChartRequest[], stateCopy
     for (const parent in mapPack.mapHierarchy) {
       const children = mapPack.mapHierarchy[parent];
       if (mapHierarchy[parent]) {
-        mapHierarchy[parent].concat(children);
+        mapHierarchy[parent] = mapHierarchy[parent].concat(children);
       } else {
         mapHierarchy[parent] = children;
       }


### PR DESCRIPTION
# Main

- Simple fix for hierarchy which only caused one datapack's information to be shown in a parent
- another fix for column on display for mappoints (refactored the `Event Search` to use the same function)
  - This makes it so the path checks all parents if they are on, then displays the correct icon based on that path instead of the on/off of itself.