### PR TITLE
add logic for system preference listening and local storage checking

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,11 +32,18 @@ export default observer(function App() {
   const navigate = useNavigate();
   const location = useLocation();
   const theme = state.user.settings.darkMode ? originalDarkTheme : originalLightTheme;
+  const backgroundColor = theme.palette.backgroundColor.main;
+  document.documentElement.style.backgroundColor = backgroundColor;
+  document.body.style.backgroundColor = backgroundColor;
+  // listen for changes in preferred color scheme
   useEffect(() => {
-    const backgroundColor = theme.palette.backgroundColor.main;
-    document.documentElement.style.backgroundColor = backgroundColor;
-    document.body.style.backgroundColor = backgroundColor;
-  }, [theme]);
+    const cleanup = actions.listenForSystemDarkMode();
+    return () => {
+      cleanup();
+    };
+  }, []);
+
+  // on theme change, update the background color
   const checkOpen =
     location.pathname === "/settings" &&
     state.settingsTabs.selected !== "datapacks" &&

--- a/app/src/state/state.ts
+++ b/app/src/state/state.ts
@@ -26,6 +26,7 @@ import type {
 import { ErrorCodes } from "../util/error-codes";
 import { defaultColors } from "../util/constant";
 import { settings } from "../constants";
+import { getInitialDarkMode } from "./actions";
 
 export type State = {
   chartTab: {
@@ -132,7 +133,7 @@ export const state = observable<State>({
     isGoogleUser: false,
     isAdmin: false,
     settings: {
-      darkMode: false,
+      darkMode: getInitialDarkMode(),
       language: "English"
     }
   },


### PR DESCRIPTION
# Main
- this adds logic to dark mode cookies/system preferences
- will load regard preference regardless of user status (logged in or not)
- if user has manually switched one or the other, it won't change when changing system preferences
- potentially will have a task to create light, dark, and system modes so that they stay seperate although that use case is so small and could not be worth the time of the nuanced logic.


# Demo

https://github.com/user-attachments/assets/24b536f5-ebe7-4675-9c99-e19aa0b7bd1d

