### PR TITLE
fix problem with manually loading columns

### DIFF
--- a/app/__tests__/parse-settings.test.ts
+++ b/app/__tests__/parse-settings.test.ts
@@ -13,6 +13,10 @@ import {
 import * as parseSettings from "../src/state/parse-settings";
 import { ChartSettings } from "../src/types";
 import { readFileSync } from "fs";
+vi.mock("../src/state/actions/util-actions", () => ({
+  changeManuallyAddedColumns: vi.fn(),
+  normalizeColumnProperties: vi.fn()
+}));
 const tests = JSON.parse(readFileSync("./app/__tests__/__data__/parse-settings-tests.json").toString());
 const keys = JSON.parse(readFileSync("./app/__tests__/__data__/parse-settings-keys.json").toString());
 describe("escape html chars", () => {
@@ -603,6 +607,6 @@ describe("json to xml", () => {
       `    <column id="class datastore.RootColumn:Chart Root">\n` +
       `    </column>\n` +
       `</TSCreator>`;
-    expect(parseSettings.jsonToXml({} as ColumnInfo, {} as ChartSettings)).toEqual(key);
+    expect(parseSettings.jsonToXml({} as ColumnInfo, new Map<string, ColumnInfo>(), {} as ChartSettings)).toEqual(key);
   });
 });

--- a/app/src/settings_tabs/SaveSettings.tsx
+++ b/app/src/settings_tabs/SaveSettings.tsx
@@ -30,7 +30,9 @@ const SaveSettings = observer(() => {
     }
     const columnCopy: ColumnInfo = cloneDeep(state.settingsTabs.columns!);
     const settingsCopy: ChartSettings = cloneDeep(state.settings);
-    const blob = new Blob([jsonToXml(columnCopy, settingsCopy)], { type: "text/plain;charset=utf-8" });
+    const blob = new Blob([jsonToXml(columnCopy, state.settingsTabs.columnHashMap, settingsCopy)], {
+      type: "text/plain;charset=utf-8"
+    });
     FileSaver.saveAs(blob, filename + ".tsc");
     actions.pushSnackbar("Successfully saved settings!", "success");
   }

--- a/app/src/state/actions/util-actions.ts
+++ b/app/src/state/actions/util-actions.ts
@@ -1,6 +1,53 @@
+import { action } from "mobx";
 import { ErrorCodes } from "../../util/error-codes";
-import { pushError } from "./general-actions";
-import { isServerResponseError } from "@tsconline/shared";
+import { pushError, pushSnackbar } from "./general-actions";
+import { ColumnInfo, isServerResponseError } from "@tsconline/shared";
+
+/**
+ * Since we hash by name only to allow consistency between facies maps and
+ * the column page, a generic like Facies Label will cause errors.
+ * The solution @Paolo came up with is to prepend the name of the parent
+ * and change before the conversion to xml. The downside is we must check
+ * every ColumnInfo object which may cause problems with time consistency.
+ * However, this is asyncronous, which makes it less likely to cause problems.
+ * @param column
+ */
+export const changeManuallyAddedColumns = action((column: ColumnInfo, columnHashMap: Map<string, ColumnInfo>) => {
+  const parent = column.parent && columnHashMap.get(column.parent);
+  if (parent && parent.columnDisplayType === "BlockSeriesMetaColumn") {
+    if (column.name === `${column.parent} Facies Label`) {
+      column.name = "Facies Label";
+    } else if (column.name === `${column.parent} Series Label`) {
+      column.name = "Series Label";
+    } else if (column.name === `${column.parent} Members`) {
+      column.name = "Members";
+    } else if (column.name === `${column.parent} Facies`) {
+      column.name = "Facies";
+    } else if (column.name === `${column.parent} Chron`) {
+      column.name = "Chron";
+    } else if (column.name === `${column.parent} Chron Label`) {
+      column.name = "Chron Label";
+    }
+  }
+  if (column.columnDisplayType === "RootColumn" && column.name.substring(0, 14) === "Chart Title in") {
+    column.name = column.name.substring(15, column.name.length);
+  }
+  for (const child of column.children) {
+    changeManuallyAddedColumns(child, columnHashMap);
+  }
+});
+
+export const normalizeColumnProperties = action((column: ColumnInfo) => {
+  if (column.width !== undefined && (isNaN(column.width) || column.width < 20)) {
+    column.width = 20;
+    let name = column.name.substring(0, 17);
+    if (name.length < column.name.length) name += "...";
+    pushSnackbar("Invalid width input found, updating " + name + " width to 20", "warning");
+  }
+  for (const child of column.children) {
+    normalizeColumnProperties(child);
+  }
+});
 
 /**
  * Display error to dialog popup, same as pushError but with a message logged to console (Use this for server response errors)

--- a/app/src/state/parse-settings.ts
+++ b/app/src/state/parse-settings.ts
@@ -41,6 +41,7 @@ import { cloneDeep, range } from "lodash";
 //for testing purposes
 //https://stackoverflow.com/questions/51269431/jest-mock-inner-function
 import * as parseSettings from "./parse-settings";
+import { changeManuallyAddedColumns, normalizeColumnProperties } from "./actions/util-actions";
 
 /**
  * casts a string to a specified type
@@ -665,7 +666,14 @@ export function columnInfoTSCToXml(column: ColumnInfoTSC, indent: string): strin
   return xml;
 }
 
-export function jsonToXml(state: ColumnInfo, settings: ChartSettings, version: string = "PRO8.1"): string {
+export function jsonToXml(
+  state: ColumnInfo,
+  hash: Map<string, ColumnInfo>,
+  settings: ChartSettings,
+  version: string = "PRO8.1"
+): string {
+  normalizeColumnProperties(state);
+  changeManuallyAddedColumns(state, hash);
   let settingsTSC = JSON.parse(JSON.stringify(parseSettings.columnInfoToSettingsTSC(state, settings)));
   let xml = `<?xml version="1.0" encoding="UTF-8"?>\n`;
   xml += `<TSCreator version="${version}">\n`;

--- a/app/src/state/state.ts
+++ b/app/src/state/state.ts
@@ -1,4 +1,4 @@
-import { observable } from "mobx";
+import { configure, observable } from "mobx";
 
 import {
   SnackbarInfo,
@@ -31,6 +31,7 @@ import { ErrorCodes } from "../util/error-codes";
 import { defaultColors } from "../util/constant";
 import { settings } from "../constants";
 import { getInitialDarkMode } from "./actions";
+configure({ enforceActions: "observed" });
 
 export type State = {
   chartTab: {


### PR DESCRIPTION
changed manual changes to the columns for writing/loading to be included in `jsonToXml`

fixes gabi's problem where saving a settings file and loading the same settings file on the website produces an error/does not produce correct results

since we change `Facies` and `Series Label` to include the parent name and need to remove it when writing ( we did it on chart generation, but since we do the same thing/need the same thing for the writing to file we move those manual changes into the write file function )