### PR TITLE
Tsc 522 add assets config class function implementation that makes it more modular easier to test

### DIFF
--- a/app/src/state/actions/admin-actions.ts
+++ b/app/src/state/actions/admin-actions.ts
@@ -304,7 +304,7 @@ export const adminUploadServerDatapack = action(async (file: File, metadata: Dat
       if (!pack) {
         return;
       }
-      addDatapackToServerDatapackIndex(file.name, pack);
+      addDatapackToServerDatapackIndex(pack.title, pack);
       pushSnackbar("Successfully uploaded " + title + " datapack", "success");
     } else {
       displayServerError(data, ErrorCodes.INVALID_DATAPACK_UPLOAD, ErrorMessages[ErrorCodes.INVALID_DATAPACK_UPLOAD]);

--- a/server/src/add-dev-config.ts
+++ b/server/src/add-dev-config.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { AdminConfig, assertAdminConfig } from "./types.js";
+import { AdminConfigType, assertAdminConfig } from "./types.js";
 import { readFile, writeFile } from "fs/promises";
 import { checkFileExists } from "./util.js";
 import { assertDatapackMetadataArray } from "@tsconline/shared";
@@ -8,7 +8,7 @@ import chalk from "chalk";
 const adminConfigPath = path.resolve(process.cwd(), "assets", "admin-config.json");
 const devConfigPath = path.resolve(process.cwd(), "assets", "dev-config.json");
 async function readAdminConfig() {
-  let adminConfig: AdminConfig = { datapacks: [] };
+  let adminConfig: AdminConfigType = { datapacks: [] };
   if (await checkFileExists(adminConfigPath)) {
     adminConfig = JSON.parse(await readFile(adminConfigPath, "utf8"));
   }
@@ -53,7 +53,7 @@ try {
       unaddedDatapacks.push(datapack);
     }
   }
-  const newAdminConfig: AdminConfig = {
+  const newAdminConfig: AdminConfigType = {
     datapacks: adminConfig.datapacks.concat(unaddedDatapacks)
   };
   await writeFile(adminConfigPath, JSON.stringify(newAdminConfig, null, 2));

--- a/server/src/admin/admin-config.ts
+++ b/server/src/admin/admin-config.ts
@@ -29,6 +29,7 @@ export async function loadAdminConfig(newFilepath?: string) {
       setAdminConfig(ADMIN_DEFAULT_CONFIG);
     } else {
       handleError(e);
+      throw e;
     }
   } finally {
     filepath = tempPath;

--- a/server/src/admin/admin-config.ts
+++ b/server/src/admin/admin-config.ts
@@ -1,0 +1,110 @@
+import { readFile, writeFile } from "fs/promises";
+import { assertAdminConfig } from "../types";
+import { AdminConfigType } from "../types";
+import { Mutex } from "async-mutex";
+import { DatapackMetadata } from "@tsconline/shared";
+
+const ADMIN_DEFAULT_CONFIG: AdminConfigType = {
+  datapacks: []
+};
+
+export class AdminConfig {
+  private mutex = new Mutex();
+  private _adminConfig: AdminConfigType;
+  private _filepath: string;
+  constructor(filepath: string) {
+    this._filepath = filepath;
+    this._adminConfig = ADMIN_DEFAULT_CONFIG;
+  }
+  /**
+   * Load the admin config file
+   */
+  async loadFile() {
+    const release = await this.mutex.acquire();
+    try {
+      const raw = await readFile(this._filepath, "utf8");
+      const adminconfig = JSON.parse(raw);
+      assertAdminConfig(adminconfig);
+      this.setAdminConfig(adminconfig);
+    } catch (e) {
+      if (e instanceof Error && (e as NodeJS.ErrnoException).code === "ENOENT") {
+        console.error("Admin config file not found. Loading default admin config.");
+        this.setAdminConfig(ADMIN_DEFAULT_CONFIG);
+      }
+      this.handleError(e);
+    } finally {
+      release();
+    }
+  }
+  /**
+   * Save the admin config to the file
+   */
+  async saveFile() {
+    const release = await this.mutex.acquire();
+    try {
+      await writeFile(this._filepath, JSON.stringify(this._adminConfig, null, 2));
+    } catch (e) {
+      this.handleError(e);
+    } finally {
+      release();
+    }
+  }
+  /**
+   * set the admin config
+   * @param adminConfig the admin config
+   */
+  async setAdminConfig(adminConfig: AdminConfigType) {
+    this._adminConfig = adminConfig;
+  }
+
+  /**
+   * get the admin config
+   * @returns admin config
+   */
+  getAdminConfig() {
+    return this._adminConfig;
+  }
+
+  /**
+   * remove a datapack from the admin config
+   * @param datapack the datapack to remove
+   */
+  async removeAdminConfigDatapack(datapack: DatapackMetadata) {
+    if (this._adminConfig.datapacks.find((d) => d.title === datapack.title)) {
+      this._adminConfig.datapacks = this._adminConfig.datapacks.filter((d) => d.title !== datapack.title);
+      await this.saveFile();
+    } else {
+      this.handleError(`Datapack ${datapack.title} not found in admin config`);
+    }
+  }
+  /**
+   * add a datapack to the admin config
+   * @param datapack the datapack to add
+   */
+  async addAdminConfigDatapack(datapack: DatapackMetadata) {
+    if (!this._adminConfig.datapacks.find((d) => d.title === datapack.title)) {
+      this._adminConfig.datapacks.push(datapack);
+      await this.saveFile();
+    } else {
+      this.handleError(`Datapack ${datapack.title} already in admin config`);
+    }
+  }
+  /**
+   * reset the admin config to the default config
+   */
+  async resetAdminConfig() {
+    this._adminConfig = ADMIN_DEFAULT_CONFIG;
+    await this.saveFile();
+  }
+  /**
+   * error handler
+   * @param e the error to handle
+   */
+  handleError(e: unknown) {
+    if (e instanceof Error) {
+      console.error(e.message);
+    } else {
+      console.error(e);
+    }
+  }
+}

--- a/server/src/admin/admin-config.ts
+++ b/server/src/admin/admin-config.ts
@@ -89,6 +89,9 @@ export class AdminConfig {
       this.handleError(`Datapack ${datapack.title} already in admin config`);
     }
   }
+  getAdminConfigDatapacks() {
+    return this._adminConfig.datapacks;
+  }
   /**
    * reset the admin config to the default config
    */

--- a/server/src/admin/admin-config.ts
+++ b/server/src/admin/admin-config.ts
@@ -1,12 +1,12 @@
 import { readFile, writeFile } from "fs/promises";
-import { assertAdminConfig } from "../types";
-import { AdminConfigType } from "../types";
+import { AdminConfigType, assertAdminConfig } from "../types.js";
 import { Mutex } from "async-mutex";
 import { DatapackMetadata } from "@tsconline/shared";
 
 const ADMIN_DEFAULT_CONFIG: AdminConfigType = {
   datapacks: []
 };
+let adminConfig: AdminConfig;
 
 export class AdminConfig {
   private mutex = new Mutex();
@@ -50,7 +50,7 @@ export class AdminConfig {
     }
   }
   /**
-   * set the admin config
+   * set the admin config NOTE: this does not save the file
    * @param adminConfig the admin config
    */
   async setAdminConfig(adminConfig: AdminConfigType) {
@@ -110,4 +110,22 @@ export class AdminConfig {
       console.error(e);
     }
   }
+}
+
+/**
+ * This loads the admin config to be exported
+ * @param file 
+ */
+export async function loadAdminConfig(file: string) {
+  try {
+    adminConfig = new AdminConfig(file);
+    await adminConfig.loadFile();
+  } catch (e) {
+    console.log("ERROR: Failed to load admin configs from assets/admin-config.json.  Error was: ", e);
+    process.exit(1);
+  }
+}
+
+export function getAdminConfig() {
+  return adminConfig;
 }

--- a/server/src/admin/admin-config.ts
+++ b/server/src/admin/admin-config.ts
@@ -52,7 +52,7 @@ export async function saveAdminConfig() {
  * set the admin config NOTE: this does not save the file
  * @param adminConfig the admin config
  */
-function  setAdminConfig(newAdminConfig: AdminConfigType) {
+function setAdminConfig(newAdminConfig: AdminConfigType) {
   adminConfig = newAdminConfig;
 }
 /**

--- a/server/src/admin/admin-routes.ts
+++ b/server/src/admin/admin-routes.ts
@@ -190,7 +190,6 @@ export const adminUploadServerDatapack = async function adminUploadServerDatapac
   let decryptedFilepath: string | undefined;
   const fields: { [fieldname: string]: string } = {};
   const datapacks = getAdminConfigDatapacks();
-  console.log(datapacks);
   for await (const part of parts) {
     if (part.type === "file") {
       // DOWNLOAD FILE HERE AND SAVE TO FILE

--- a/server/src/admin/admin-routes.ts
+++ b/server/src/admin/admin-routes.ts
@@ -19,7 +19,7 @@ import { NewUser } from "../types.js";
 import { uploadUserDatapackHandler } from "../upload-handlers.js";
 import { parseExcelFile } from "../parse-excel-file.js";
 import logger from "../error-logger.js";
-import { getAdminConfig } from "./admin-config.js";
+import { addAdminConfigDatapack, getAdminConfigDatapacks, removeAdminConfigDatapack } from "./admin-config.js";
 
 /**
  * Get all users for admin to configure on frontend
@@ -189,7 +189,8 @@ export const adminUploadServerDatapack = async function adminUploadServerDatapac
   let filepath: string | undefined;
   let decryptedFilepath: string | undefined;
   const fields: { [fieldname: string]: string } = {};
-  const datapacks = getAdminConfig().getAdminConfigDatapacks();
+  const datapacks = getAdminConfigDatapacks();
+  console.log(datapacks);
   for await (const part of parts) {
     if (part.type === "file") {
       // DOWNLOAD FILE HERE AND SAVE TO FILE
@@ -309,7 +310,7 @@ export const adminUploadServerDatapack = async function adminUploadServerDatapac
     return;
   }
   try {
-    await getAdminConfig().addAdminConfigDatapack(datapackMetadata);
+    await addAdminConfigDatapack(datapackMetadata);
   } catch (e) {
     await errorHandler("Error updating admin config");
     return;
@@ -332,7 +333,7 @@ export const adminDeleteServerDatapack = async function adminDeleteServerDatapac
     reply.status(400).send({ error: "Missing datapack id" });
     return;
   }
-  const datapackMetadata = getAdminConfig().getAdminConfigDatapacks().find((dp) => dp.title === datapack);
+  const datapackMetadata = getAdminConfigDatapacks().find((dp) => dp.title === datapack);
   if (!datapackMetadata) {
     reply.status(404).send({ error: "Datapack not found" });
     return;
@@ -350,7 +351,7 @@ export const adminDeleteServerDatapack = async function adminDeleteServerDatapac
     return;
   }
   try {
-    await getAdminConfig().removeAdminConfigDatapack(datapackMetadata);
+    await removeAdminConfigDatapack(datapackMetadata);
   } catch (e) {
     reply.status(500).send({
       error:

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,7 +25,7 @@ import PQueue from "p-queue";
 import { userRoutes } from "./routes/user-auth.js";
 import { fetchUserDatapacks, fetchPublicDatapacks } from "./routes/user-routes.js";
 import { loadPublicUserDatapacks } from "./public-datapack-handler.js";
-import { AdminConfig } from "./admin/admin-config.js";
+import { getAdminConfig, loadAdminConfig } from "./admin/admin-config.js";
 
 const maxConcurrencySize = 2;
 export const maxQueueSize = 30;
@@ -48,8 +48,7 @@ const server = fastify({
 const presets = await loadPresets();
 // Load the current asset config:
 await loadAssetConfigs();
-export const adminConfig = new AdminConfig(assetconfigs.adminConfigPath);
-await adminConfig.loadFile();
+await loadAdminConfig(assetconfigs.adminConfigPath);
 // Check if the required JAR files exist
 const activeJarPath = path.join(assetconfigs.activeJar);
 const decryptionJarPath = path.join(assetconfigs.decryptionJar);
@@ -64,6 +63,7 @@ if (!(await checkFileExists(decryptionJarPath))) {
 }
 
 // this try will run the decryption jar to decrypt all files in the datapack folder
+const adminConfig = getAdminConfig();
 try {
   const datapackPaths = adminConfig
     .getAdminConfigDatapacks()

--- a/server/src/load-packs.ts
+++ b/server/src/load-packs.ts
@@ -19,7 +19,7 @@ import { grabFilepaths, rgbToHex, assetconfigs } from "./util.js";
 import chalk from "chalk";
 import sharp from "sharp";
 import Vibrant from "node-vibrant";
-import { adminConfig } from "./index.js";
+import { getAdminConfigDatapacks } from "./admin/admin-config.js";
 
 /**
  * Loads all the indexes for the active datapacks and mapPacks (if they exist)
@@ -139,7 +139,7 @@ async function getDominantRGB(filepath: string) {
  * For access from fastify server servicing
  */
 export async function grabMapImages(
-  datapacks: string[] = adminConfig.getAdminConfigDatapacks().map((datapack) => datapack.file),
+  datapacks: string[] = getAdminConfigDatapacks().map((datapack) => datapack.file),
   decryptionDirectory: string = assetconfigs.decryptionDirectory
 ): Promise<{ images: string[]; successful: boolean }> {
   if (datapacks.length === 0) return { images: [], successful: true };

--- a/server/src/load-packs.ts
+++ b/server/src/load-packs.ts
@@ -15,10 +15,11 @@ import { readFile } from "fs/promises";
 import nearestColor from "nearest-color";
 import path from "path";
 import { assertColors } from "./types.js";
-import { grabFilepaths, rgbToHex, assetconfigs, adminconfig } from "./util.js";
+import { grabFilepaths, rgbToHex, assetconfigs } from "./util.js";
 import chalk from "chalk";
 import sharp from "sharp";
 import Vibrant from "node-vibrant";
+import { adminConfig } from "./index.js";
 
 /**
  * Loads all the indexes for the active datapacks and mapPacks (if they exist)
@@ -138,7 +139,7 @@ async function getDominantRGB(filepath: string) {
  * For access from fastify server servicing
  */
 export async function grabMapImages(
-  datapacks: string[] = adminconfig.datapacks.map((datapack) => datapack.file),
+  datapacks: string[] = adminConfig.getAdminConfigDatapacks().map((datapack) => datapack.file),
   decryptionDirectory: string = assetconfigs.decryptionDirectory
 ): Promise<{ images: string[]; successful: boolean }> {
   if (datapacks.length === 0) return { images: [], successful: true };

--- a/server/src/routes/routes.ts
+++ b/server/src/routes/routes.ts
@@ -79,7 +79,7 @@ export const fetchImage = async function (request: FastifyRequest, reply: Fastif
       const file = await readFile(filepath);
       return file;
     } catch (e) {
-      if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+      if (e instanceof Error && (e as NodeJS.ErrnoException).code === "ENOENT") {
         return null;
       }
       throw e;

--- a/server/src/routes/routes.ts
+++ b/server/src/routes/routes.ts
@@ -8,14 +8,14 @@ import {
   assertChartRequest,
   assertTimescale
 } from "@tsconline/shared";
-import { deleteDirectory, assetconfigs, adminconfig, verifyFilepath } from "../util.js";
+import { deleteDirectory, assetconfigs, verifyFilepath } from "../util.js";
 import md5 from "md5";
 import svgson from "svgson";
 import fs, { realpathSync } from "fs";
 import { parseExcelFile } from "../parse-excel-file.js";
 import path from "path";
 import { updateFileMetadata } from "../file-metadata-handler.js";
-import { publicDatapackIndex, serverDatapackIndex } from "../index.js";
+import { publicDatapackIndex, serverDatapackIndex, adminConfig } from "../index.js";
 import { queue, maxQueueSize } from "../index.js";
 import { containsKnownError } from "../chart-error-handler.js";
 import { getDirectories } from "../user/user-handler.js";
@@ -222,7 +222,8 @@ export const fetchChart = async function fetchChart(request: FastifyRequest, rep
   const userDatapacks = uuid ? await getDirectories(path.join(assetconfigs.uploadDirectory, uuid)) : [];
   const datapacksToSendToCommandLine: string[] = [];
   const usedUserDatapackFilepaths: string[] = [];
-  const serverDatapacks = adminconfig.datapacks.map((datapackInfo) => datapackInfo.title);
+  const adminConfigDatapacks = adminConfig.getAdminConfigDatapacks();
+  const serverDatapacks = adminConfigDatapacks.map((datapackInfo) => datapackInfo.title);
 
   for (const datapack of chartrequest.datapacks) {
     switch (datapack.type) {
@@ -231,7 +232,7 @@ export const fetchChart = async function fetchChart(request: FastifyRequest, rep
           datapacksToSendToCommandLine.push(`${assetconfigs.datapacksDirectory}/${datapack.file}`);
         } else {
           console.log("ERROR: datapack: ", datapack, " is not included in the server configuration");
-          console.log("adminconfig.datapacks: ", adminconfig.datapacks);
+          console.log("adminconfig.datapacks: ", adminConfigDatapacks);
           console.log("chartrequest.datapacks: ", chartrequest.datapacks);
           reply.send({ error: "ERROR: failed to load datapacks" });
           return;

--- a/server/src/routes/routes.ts
+++ b/server/src/routes/routes.ts
@@ -15,10 +15,11 @@ import fs, { realpathSync } from "fs";
 import { parseExcelFile } from "../parse-excel-file.js";
 import path from "path";
 import { updateFileMetadata } from "../file-metadata-handler.js";
-import { publicDatapackIndex, serverDatapackIndex, adminConfig } from "../index.js";
+import { publicDatapackIndex, serverDatapackIndex } from "../index.js";
 import { queue, maxQueueSize } from "../index.js";
 import { containsKnownError } from "../chart-error-handler.js";
 import { getDirectories } from "../user/user-handler.js";
+import { getAdminConfigDatapacks } from "../admin/admin-config.js";
 
 export const fetchServerDatapack = async function fetchServerDatapack(
   request: FastifyRequest<{ Params: { name: string } }>,
@@ -222,7 +223,7 @@ export const fetchChart = async function fetchChart(request: FastifyRequest, rep
   const userDatapacks = uuid ? await getDirectories(path.join(assetconfigs.uploadDirectory, uuid)) : [];
   const datapacksToSendToCommandLine: string[] = [];
   const usedUserDatapackFilepaths: string[] = [];
-  const adminConfigDatapacks = adminConfig.getAdminConfigDatapacks();
+  const adminConfigDatapacks = getAdminConfigDatapacks();
   const serverDatapacks = adminConfigDatapacks.map((datapackInfo) => datapackInfo.title);
 
   for (const datapack of chartrequest.datapacks) {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -73,7 +73,7 @@ export type AssetConfig = {
   publicUserDatapacksDirectory: string;
 };
 
-export type AdminConfig = {
+export type AdminConfigType = {
   datapacks: DatapackMetadata[];
 };
 
@@ -91,9 +91,9 @@ export type FileMetadata = {
   uuid: string;
 };
 
-export function assertAdminConfig(o: any): asserts o is AdminConfig {
-  if (typeof o !== "object" || !o) throw "AdminConfig must be an object";
-  if (!o.datapacks || !Array.isArray(o.datapacks)) throw 'AdminConfig must have a "datapacks" array';
+export function assertAdminConfig(o: any): asserts o is AdminConfigType {
+  if (typeof o !== "object" || !o) throw "AdminConfigType must be an object";
+  if (!o.datapacks || !Array.isArray(o.datapacks)) throw 'AdminConfigType must have a "datapacks" array';
   for (const datapack of o.datapacks) {
     assertDatapackMetadata(datapack);
   }

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -76,7 +76,8 @@ export async function grabFilepaths(files: string[], topDirectory: string, botDi
       .map((name) => {
         const lastIndex = name.lastIndexOf(".");
         const filename = lastIndex !== -1 ? name.substring(0, lastIndex) : name;
-        return `${topDirectory}/${filename}/${botDirectory}/.*`;
+        const escapedFilename = filename.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
+        return `${topDirectory}/${escapedFilename}/${botDirectory}/.*`;
       })
       .join("|")
   );

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -5,7 +5,7 @@ import { glob } from "glob";
 import { createInterface } from "readline/promises";
 import { constants } from "fs";
 import levenshtein from "js-levenshtein";
-import { AdminConfig, assertAdminConfig, assertAssetConfig, AssetConfig } from "./types.js";
+import { AdminConfigType, assertAdminConfig, assertAssetConfig, AssetConfig } from "./types.js";
 
 /**
  * Recursively deletes directory INCLUDING directoryPath
@@ -198,7 +198,7 @@ export async function checkFileExists(filePath: string): Promise<boolean> {
 }
 
 export let assetconfigs: AssetConfig;
-export let adminconfig: AdminConfig = { datapacks: [] };
+export let adminconfig: AdminConfigType = { datapacks: [] };
 export async function loadAssetConfigs() {
   try {
     const contents = JSON.parse((await readFile("assets/config.json")).toString());

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -6,7 +6,6 @@ import { createInterface } from "readline/promises";
 import { constants } from "fs";
 import levenshtein from "js-levenshtein";
 import { assertAssetConfig, AssetConfig } from "./types.js";
-import { AdminConfig } from "./admin/admin-config.js";
 
 /**
  * Recursively deletes directory INCLUDING directoryPath
@@ -77,7 +76,7 @@ export async function grabFilepaths(files: string[], topDirectory: string, botDi
       .map((name) => {
         const lastIndex = name.lastIndexOf(".");
         const filename = lastIndex !== -1 ? name.substring(0, lastIndex) : name;
-        const escapedFilename = filename.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
+        const escapedFilename = filename.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
         return `${topDirectory}/${escapedFilename}/${botDirectory}/.*`;
       })
       .join("|")

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -1,11 +1,11 @@
 import fs, { createReadStream } from "fs";
 import path from "path";
-import { rm, readFile, access, mkdir, readdir, copyFile, writeFile, realpath } from "fs/promises";
+import { readFile, access, mkdir, readdir, copyFile, realpath } from "fs/promises";
 import { glob } from "glob";
 import { createInterface } from "readline/promises";
 import { constants } from "fs";
 import levenshtein from "js-levenshtein";
-import { AdminConfigType, assertAdminConfig, assertAssetConfig, AssetConfig } from "./types.js";
+import { assertAssetConfig, AssetConfig } from "./types.js";
 
 /**
  * Recursively deletes directory INCLUDING directoryPath
@@ -198,7 +198,6 @@ export async function checkFileExists(filePath: string): Promise<boolean> {
 }
 
 export let assetconfigs: AssetConfig;
-export let adminconfig: AdminConfigType = { datapacks: [] };
 export async function loadAssetConfigs() {
   try {
     const contents = JSON.parse((await readFile("assets/config.json")).toString());
@@ -208,28 +207,6 @@ export async function loadAssetConfigs() {
     console.log("ERROR: Failed to load asset configs from assets/config.json.  Error was: ", e);
     process.exit(1);
   }
-  if (await checkFileExists(assetconfigs.adminConfigPath)) {
-    try {
-      adminconfig = await loadAdminConfig();
-    } catch (e) {
-      console.log("ERROR: Failed to load admin configs from assets/admin-config.json.  Error was: ", e);
-      console.error("Removing admin-config.json and writing a new config file");
-      adminconfig = { datapacks: [] };
-      try {
-        await rm(assetconfigs.adminConfigPath);
-        await writeFile(assetconfigs.adminConfigPath, JSON.stringify(adminconfig, null, 2));
-      } catch (e) {
-        console.log("ERROR: Failed to write admin configs to assets/admin-config.json.  Error was: ", e);
-        process.exit(1);
-      }
-    }
-  }
-}
-
-export async function loadAdminConfig() {
-  const content = JSON.parse((await readFile(assetconfigs.adminConfigPath)).toString());
-  assertAdminConfig(content);
-  return content;
 }
 
 /**

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -77,7 +77,7 @@ export async function grabFilepaths(files: string[], topDirectory: string, botDi
         const lastIndex = name.lastIndexOf(".");
         const filename = lastIndex !== -1 ? name.substring(0, lastIndex) : name;
         const escapedFilename = filename.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
-        return `${topDirectory}/${escapedFilename}/${botDirectory}/.*`;
+        return path.join(topDirectory, escapedFilename, botDirectory, ".*");
       })
       .join("|")
   );

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -6,6 +6,7 @@ import { createInterface } from "readline/promises";
 import { constants } from "fs";
 import levenshtein from "js-levenshtein";
 import { assertAssetConfig, AssetConfig } from "./types.js";
+import { AdminConfig } from "./admin/admin-config.js";
 
 /**
  * Recursively deletes directory INCLUDING directoryPath


### PR DESCRIPTION
# Main 
- made loading/removing a datapack modular for ease of use in testing and in making atomic (for when we do edits)
- fix after uploading a server datapack, it doesn't add the correct datapack to the index
- fix for spaces in title name saving to the correct directory/name in the filesystem when decrypting
