### PR TITLE
Tsc 533 edit datapack information

### DIFF
--- a/server/__tests__/user-handler.test.ts
+++ b/server/__tests__/user-handler.test.ts
@@ -1,7 +1,56 @@
 import { describe, it, vi, expect, beforeEach } from "vitest";
-import { fetchAllUsersDatapacks, getDirectories } from "../src/user/user-handler";
+import {
+  fetchAllUsersDatapacks,
+  fetchUserDatapack,
+  getDirectories,
+  getUserDirectory,
+  renameUserDatapack,
+  writeUserDatapack
+} from "../src/user/user-handler";
 import * as fsPromises from "fs/promises";
 import * as util from "../src/util";
+import * as shared from "@tsconline/shared";
+import * as logger from "../src/error-logger";
+import path from "path";
+import * as fileMetadataHandler from "../src/file-metadata-handler";
+import { Dirent } from "fs";
+
+vi.mock("../src/file-metadata-handler", () => {
+  return {
+    changeFileMetadataKey: vi.fn(async () => {})
+  };
+});
+
+vi.mock("@tsconline/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof shared>();
+  return {
+    ...actual,
+    assertPrivateUserDatapack: vi.fn(),
+    assertDatapack: vi.fn()
+  };
+});
+
+vi.mock("path", async (importOriginal) => {
+  const actual = await importOriginal<typeof path>();
+  return {
+    ...actual,
+    default: {
+      resolve: vi.fn((...args: string[]) => {
+        return args.join("/");
+      }),
+      join: vi.fn(actual.join)
+    }
+  };
+});
+
+vi.mock("../src/error-logger", () => {
+  return {
+    default: {
+      error: vi.fn().mockResolvedValue(undefined)
+    }
+  };
+});
+
 vi.mock("fs/promises", () => {
   return {
     readdir: vi.fn(async () => {
@@ -11,12 +60,19 @@ vi.mock("fs/promises", () => {
         { isDirectory: () => true, name: "test3" }
       ];
     }),
-    mkdir: vi.fn(async () => {})
+    rename: vi.fn(async () => {}),
+    mkdir: vi.fn(async () => {}),
+    writeFile: vi.fn(async () => {}),
+    readFile: vi.fn(async () => JSON.stringify({ title: "test" }))
   };
 });
 vi.mock("../src/util", () => {
   return {
-    checkFileExists: vi.fn(async () => true)
+    checkFileExists: vi.fn(async () => true),
+    verifyFilepath: vi.fn(async () => true),
+    assetconfigs: {
+      uploadDirectory: "test"
+    }
   };
 });
 describe("getDirectories test", () => {
@@ -36,6 +92,10 @@ describe("getDirectories test", () => {
 
 describe("fetchAllUsersDatapacks test", () => {
   const checkFileExists = vi.spyOn(util, "checkFileExists");
+  const readFile = vi.spyOn(fsPromises, "readFile");
+  const assertPrivateUserDatapack = vi.spyOn(shared, "assertPrivateUserDatapack");
+  const readdir = vi.spyOn(fsPromises, "readdir");
+  const assertDatapack = vi.spyOn(shared, "assertDatapack");
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -46,7 +106,6 @@ describe("fetchAllUsersDatapacks test", () => {
     expect(mkdir).toHaveBeenCalledOnce();
   });
   it("should thow an error if readdir fails", async () => {
-    const readdir = vi.spyOn(fsPromises, "readdir");
     readdir.mockRejectedValueOnce(new Error("readdir error"));
     await expect(fetchAllUsersDatapacks("test")).rejects.toThrow("readdir error");
     expect(readdir).toHaveBeenCalledOnce();
@@ -55,5 +114,184 @@ describe("fetchAllUsersDatapacks test", () => {
     checkFileExists.mockRejectedValueOnce(new Error("checkFileExists error"));
     await expect(fetchAllUsersDatapacks("test")).rejects.toThrow("checkFileExists error");
     expect(checkFileExists).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if readFile fails for a datapack", async () => {
+    readFile.mockRejectedValueOnce(new Error("readFile error"));
+    await expect(fetchAllUsersDatapacks("test")).rejects.toThrow("readFile error");
+    expect(readFile).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if the datapack does not pass the private user datapack assertion", async () => {
+    assertPrivateUserDatapack.mockImplementationOnce(() => {
+      throw new Error("assertPrivateUserDatapack error");
+    });
+    await expect(fetchAllUsersDatapacks("test")).rejects.toThrow("assertPrivateUserDatapack error");
+    expect(assertPrivateUserDatapack).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if the datapack does not pass the datapack assertion", async () => {
+    assertDatapack.mockImplementationOnce(() => {
+      throw new Error("assertDatapack error");
+    });
+    await expect(fetchAllUsersDatapacks("test")).rejects.toThrow("assertDatapack error");
+    expect(assertDatapack).toHaveBeenCalledOnce();
+    expect(assertPrivateUserDatapack).toHaveBeenCalledOnce();
+  });
+  it("should log an error if multiple datapacks exist in the same directory", async () => {
+    const error = vi.spyOn(logger.default, "error");
+    readdir.mockResolvedValueOnce([
+      { isDirectory: () => true, name: "test1" } as Dirent,
+      { isDirectory: () => true, name: "test1" } as Dirent
+    ]);
+    checkFileExists.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+    await expect(fetchAllUsersDatapacks("test")).rejects.toThrow("Datapack test1 already exists in the index");
+    expect(error).toHaveBeenCalledOnce();
+  });
+  it("should return a datapack index", async () => {
+    expect(await fetchAllUsersDatapacks("test")).toEqual({
+      test1: { title: "test" },
+      test3: { title: "test" }
+    });
+  });
+});
+
+describe("getUserDirectory test", () => {
+  const verifyFilepath = vi.spyOn(util, "verifyFilepath");
+  it("should throw an error if the filepath is invalid", async () => {
+    verifyFilepath.mockResolvedValueOnce(false);
+    await expect(getUserDirectory("test")).rejects.toThrow("Invalid filepath");
+    expect(verifyFilepath).toHaveBeenCalledOnce();
+  });
+  it("should return a user directory", async () => {
+    expect(await getUserDirectory("test")).toBe("test/test");
+  });
+});
+
+describe("fetchUserDatapack test", () => {
+  const verifyFilepath = vi.spyOn(util, "verifyFilepath");
+  const checkFileExists = vi.spyOn(util, "checkFileExists");
+  const readFile = vi.spyOn(fsPromises, "readFile");
+  const assertPrivateUserDatapack = vi.spyOn(shared, "assertPrivateUserDatapack");
+  const assertDatapack = vi.spyOn(shared, "assertDatapack");
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it("should throw an error if the filepath is invalid", async () => {
+    verifyFilepath.mockResolvedValueOnce(false);
+    await expect(fetchUserDatapack("test", "test")).rejects.toThrow("File test doesn't exist");
+    expect(verifyFilepath).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if the file does not exist", async () => {
+    checkFileExists.mockResolvedValueOnce(false);
+    await expect(fetchUserDatapack("test", "test")).rejects.toThrow("File test doesn't exist");
+    expect(checkFileExists).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if readFile fails", async () => {
+    readFile.mockRejectedValueOnce(new Error("readFile error"));
+    await expect(fetchUserDatapack("test", "test")).rejects.toThrow("readFile error");
+    expect(readFile).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if the datapack does not pass the private asserts", async () => {
+    assertPrivateUserDatapack.mockImplementationOnce(() => {
+      throw new Error("assertPrivateUserDatapack error");
+    });
+    await expect(fetchUserDatapack("test", "test")).rejects.toThrow("assertPrivateUserDatapack error");
+    expect(assertPrivateUserDatapack).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if the datapack does not pass the assert datapack check", async () => {
+    assertDatapack.mockImplementationOnce(() => {
+      throw new Error("assertDatapack error");
+    });
+    await expect(fetchUserDatapack("test", "test")).rejects.toThrow("assertDatapack error");
+    expect(assertDatapack).toHaveBeenCalledOnce();
+  });
+});
+describe("renameUserDatapack test", () => {
+  const verifyFilepath = vi.spyOn(util, "verifyFilepath");
+  const readFile = vi.spyOn(fsPromises, "readFile");
+  const resolve = vi.spyOn(path, "resolve");
+  const datapack = { title: "test" } as shared.Datapack;
+  const changeFileMetadataKey = vi.spyOn(fileMetadataHandler, "changeFileMetadataKey");
+  const writeFile = vi.spyOn(fsPromises, "writeFile");
+  const rename = vi.spyOn(fsPromises, "rename");
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it("should throw an error if the old datapack does not exist", async () => {
+    verifyFilepath.mockRejectedValueOnce(new Error("fetchUserDatapack error"));
+    await expect(renameUserDatapack("test", "test", datapack)).rejects.toThrow("fetchUserDatapack error");
+    expect(verifyFilepath).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if the filepath is invalid", async () => {
+    verifyFilepath.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    await expect(renameUserDatapack("test", "test", datapack)).rejects.toThrow("Invalid filepath");
+    expect(verifyFilepath).toHaveBeenCalledTimes(2);
+    expect(changeFileMetadataKey).not.toHaveBeenCalled();
+  });
+  it("should throw an error if the new datapack path is malicious", async () => {
+    resolve.mockReturnValueOnce("BADFILE");
+    await expect(renameUserDatapack("test", "test", datapack)).rejects.toThrow("Invalid filepath");
+    expect(resolve).toHaveBeenCalledTimes(2);
+    expect(changeFileMetadataKey).not.toHaveBeenCalled();
+  });
+  it("should throw an error if readFile fails", async () => {
+    readFile.mockRejectedValueOnce(new Error("readFile error"));
+    await expect(renameUserDatapack("test", "test", datapack)).rejects.toThrow("readFile error");
+    expect(readFile).toHaveBeenCalledOnce();
+    expect(changeFileMetadataKey).not.toHaveBeenCalled();
+  });
+  it("should throw an error if rename fails", async () => {
+    rename.mockRejectedValueOnce(new Error("rename error"));
+    await expect(renameUserDatapack("test", "test", datapack)).rejects.toThrow("rename error");
+    expect(rename).toHaveBeenCalledOnce();
+    expect(changeFileMetadataKey).not.toHaveBeenCalled();
+  });
+  it("should throw an error if writeUserDatapack fails and rename the renamed dir", async () => {
+    writeFile.mockRejectedValueOnce(new Error("writeFile error"));
+    await expect(
+      renameUserDatapack("userDir", "oldDatapack", { title: "newDatapack" } as shared.Datapack)
+    ).rejects.toThrow("writeFile error");
+    expect(rename).toHaveBeenCalledTimes(2);
+    expect(rename).toHaveBeenNthCalledWith(1, "userDir/oldDatapack", "userDir/newDatapack");
+    expect(rename).toHaveBeenNthCalledWith(2, "userDir/newDatapack", "userDir/oldDatapack");
+    expect(changeFileMetadataKey).not.toHaveBeenCalled();
+  });
+  it("should throw an error if changeFileMetadataKey fails and rename the renamed dir and rewrite the index json", async () => {
+    changeFileMetadataKey.mockRejectedValueOnce(new Error("changeFileMetadataKey error"));
+    await expect(
+      renameUserDatapack("userDir", "oldDatapack", { title: "newDatapack" } as shared.Datapack)
+    ).rejects.toThrow("changeFileMetadataKey error");
+    expect(rename).toHaveBeenCalledTimes(2);
+    expect(rename).toHaveBeenNthCalledWith(1, "userDir/oldDatapack", "userDir/newDatapack");
+    expect(rename).toHaveBeenNthCalledWith(2, "userDir/newDatapack", "userDir/oldDatapack");
+    expect(changeFileMetadataKey).toHaveBeenCalledOnce();
+    expect(writeFile).toHaveBeenCalledTimes(2);
+  });
+  it("should rename/edit the datapack", async () => {
+    await renameUserDatapack("userDir", "oldDatapack", { title: "newDatapack" } as shared.Datapack);
+    expect(rename).toHaveBeenCalledTimes(1);
+    expect(changeFileMetadataKey).toHaveBeenCalledOnce();
+    expect(writeFile).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("writeUserDatapack test", () => {
+  const verifyFilepath = vi.spyOn(util, "verifyFilepath");
+  const writeFile = vi.spyOn(fsPromises, "writeFile");
+  const datapack = { title: "test" } as shared.Datapack;
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it("should throw an error if the filepath is invalid", async () => {
+    verifyFilepath.mockResolvedValueOnce(false);
+    await expect(writeUserDatapack("test", datapack)).rejects.toThrow("Invalid filepath");
+    expect(verifyFilepath).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if writeFile fails", async () => {
+    writeFile.mockRejectedValueOnce(new Error("writeFile error"));
+    await expect(writeUserDatapack("test", datapack)).rejects.toThrow("writeFile error");
+    expect(writeFile).toHaveBeenCalledOnce();
+  });
+  it("should write a datapack", async () => {
+    await writeUserDatapack("test", datapack);
+    expect(writeFile).toHaveBeenCalledOnce();
   });
 });

--- a/server/__tests__/user-handler.test.ts
+++ b/server/__tests__/user-handler.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, vi, expect, beforeEach } from "vitest";
+import { fetchAllUsersDatapacks, getDirectories } from "../src/user/user-handler";
+import * as fsPromises from "fs/promises";
+import * as util from "../src/util";
+vi.mock("fs/promises", () => {
+  return {
+    readdir: vi.fn(async () => {
+      return [
+        { isDirectory: () => true, name: "test1" },
+        { isDirectory: () => false, name: "test2" },
+        { isDirectory: () => true, name: "test3" }
+      ];
+    }),
+    mkdir: vi.fn(async () => {})
+  };
+});
+vi.mock("../src/util", () => {
+  return {
+    checkFileExists: vi.fn(async () => true)
+  };
+});
+describe("getDirectories test", () => {
+  const readdir = vi.spyOn(fsPromises, "readdir");
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it("should return an array of directories", async () => {
+    expect(await getDirectories("test")).toEqual(["test1", "test3"]);
+  });
+  it("should throw an error if readdir fails", async () => {
+    readdir.mockRejectedValueOnce(new Error("readdir error"));
+    await expect(getDirectories("test")).rejects.toThrow("readdir error");
+    expect(readdir).toHaveBeenCalledOnce();
+  });
+});
+
+describe("fetchAllUsersDatapacks test", () => {
+  const checkFileExists = vi.spyOn(util, "checkFileExists");
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it("should throw an error if mkdir fails", async () => {
+    const mkdir = vi.spyOn(fsPromises, "mkdir");
+    mkdir.mockRejectedValueOnce(new Error("mkdir error"));
+    await expect(fetchAllUsersDatapacks("test")).rejects.toThrow("mkdir error");
+    expect(mkdir).toHaveBeenCalledOnce();
+  });
+  it("should thow an error if readdir fails", async () => {
+    const readdir = vi.spyOn(fsPromises, "readdir");
+    readdir.mockRejectedValueOnce(new Error("readdir error"));
+    await expect(fetchAllUsersDatapacks("test")).rejects.toThrow("readdir error");
+    expect(readdir).toHaveBeenCalledOnce();
+  });
+  it("should throw an error if checkFileExists fails for a datapack", async () => {
+    checkFileExists.mockRejectedValueOnce(new Error("checkFileExists error"));
+    await expect(fetchAllUsersDatapacks("test")).rejects.toThrow("checkFileExists error");
+    expect(checkFileExists).toHaveBeenCalledOnce();
+  });
+});

--- a/server/__tests__/user-routes.test.ts
+++ b/server/__tests__/user-routes.test.ts
@@ -1,4 +1,4 @@
-import { vi, beforeAll, afterAll, describe, beforeEach, it, expect } from "vitest";
+import { test, vi, beforeAll, afterAll, describe, beforeEach, it, expect } from "vitest";
 import fastify, { FastifyInstance, HTTPMethods, InjectOptions } from "fastify";
 import fastifySecureSession from "@fastify/secure-session";
 import * as runJavaEncryptModule from "../src/encryption";
@@ -304,6 +304,20 @@ describe("edit datapack tests", () => {
     expect(response.json().error).toBe("Missing body");
     expect(response.statusCode).toBe(400);
   });
+  test.each([{ storedFileName: "new_title" }, { originalFileName: "new_title" }, { size: 100 }])(
+    `should reply 400 if bad body (DatapackMetadata props)`,
+    async (body) => {
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/user/datapack/test",
+        headers,
+        body
+      });
+      expect(getUserDirectory).not.toHaveBeenCalled();
+      expect(renameUserDatapack).not.toHaveBeenCalled();
+      expect(response.json().error).toBe("Cannot edit originalFileName, storedFileName, or size");
+    }
+  );
   it("should reply 400 if body is not partial datapack metadata", async () => {
     const response = await app.inject({
       method: "PATCH",

--- a/server/src/routes/user-auth.ts
+++ b/server/src/routes/user-auth.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance, FastifyReply, FastifyRequest, RegisterOptions } from "fastify";
-import { requestDownload, uploadDatapack, userDeleteDatapack } from "./user-routes.js";
+import { editDatapackMetadata, requestDownload, uploadDatapack, userDeleteDatapack } from "./user-routes.js";
 import { findUser } from "../database.js";
 import { checkRecaptchaToken } from "../verify.js";
 import { googleRecaptchaBotThreshold } from "./login-routes.js";
@@ -78,5 +78,10 @@ export const userRoutes = async (fastify: FastifyInstance, _options: RegisterOpt
     "/datapack/:datapack",
     { config: { rateLimit: moderateRateLimit }, schema: { params: datapackTitleParams } },
     userDeleteDatapack
+  );
+  fastify.post(
+    "/datapack/:datapack",
+    { config: { rateLimit: moderateRateLimit }, schema: { params: datapackTitleParams } },
+    editDatapackMetadata
   );
 };

--- a/server/src/routes/user-auth.ts
+++ b/server/src/routes/user-auth.ts
@@ -79,7 +79,7 @@ export const userRoutes = async (fastify: FastifyInstance, _options: RegisterOpt
     { config: { rateLimit: moderateRateLimit }, schema: { params: datapackTitleParams } },
     userDeleteDatapack
   );
-  fastify.post(
+  fastify.patch(
     "/datapack/:datapack",
     { config: { rateLimit: moderateRateLimit }, schema: { params: datapackTitleParams } },
     editDatapackMetadata

--- a/server/src/routes/user-routes.ts
+++ b/server/src/routes/user-routes.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { runJavaEncrypt } from "../encryption.js";
 import { assetconfigs, checkFileExists, checkHeader, verifyFilepath, makeTempFilename } from "../util.js";
 import { MultipartFile } from "@fastify/multipart";
-import { DatapackIndex, DatapackMetadata, assertDatapackMetadata, isPartialDatapackMetadata } from "@tsconline/shared";
+import { DatapackIndex, DatapackMetadata, isPartialDatapackMetadata } from "@tsconline/shared";
 import { exec } from "child_process";
 import { createWriteStream } from "fs";
 import { pipeline } from "stream/promises";
@@ -57,7 +57,7 @@ export const editDatapackMetadata = async function editDatapackMetadata(
     return;
   }
   const metadata = await fetchUserDatapack(userDir, datapack).catch(() => {
-    reply.status(500).send({ error: "Failed to load cached user datapacks in user directory" });
+    reply.status(500).send({ error: "Datapack does not exist or cannot be found" });
   });
   if (!metadata) {
     return;
@@ -70,6 +70,7 @@ export const editDatapackMetadata = async function editDatapackMetadata(
     try {
       await renameUserDatapack(userDir, datapack, metadata);
     } catch (e) {
+      console.error(e);
       reply.status(500).send({ error: "Failed to change datapack title." });
       return;
     }

--- a/server/src/routes/user-routes.ts
+++ b/server/src/routes/user-routes.ts
@@ -37,6 +37,10 @@ export const editDatapackMetadata = async function editDatapackMetadata(
     reply.status(400).send({ error: "Missing body" });
     return;
   }
+  if (body.originalFileName || body.storedFileName || body.size) {
+    reply.status(400).send({ error: "Cannot edit originalFileName, storedFileName, or size" });
+    return;
+  }
   if (!isPartialDatapackMetadata(body)) {
     reply.status(400).send({ error: "Invalid body" });
     return;

--- a/server/src/routes/user-routes.ts
+++ b/server/src/routes/user-routes.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { runJavaEncrypt } from "../encryption.js";
 import { assetconfigs, checkFileExists, checkHeader, verifyFilepath, makeTempFilename } from "../util.js";
 import { MultipartFile } from "@fastify/multipart";
-import { DatapackIndex, DatapackMetadata } from "@tsconline/shared";
+import { DatapackIndex, DatapackMetadata, assertDatapackMetadata, isPartialDatapackMetadata } from "@tsconline/shared";
 import { exec } from "child_process";
 import { createWriteStream } from "fs";
 import { pipeline } from "stream/promises";
@@ -19,7 +19,8 @@ import {
   fetchAllUsersDatapacks,
   fetchUserDatapack,
   getDirectories,
-  renameUserDatapack} from "../user/user-handler.js";
+  renameUserDatapack
+} from "../user/user-handler.js";
 
 export const editDatapackMetadata = async function editDatapackMetadata(
   request: FastifyRequest<{ Params: { datapack: string }; Body: Partial<DatapackMetadata> }>,
@@ -33,6 +34,10 @@ export const editDatapackMetadata = async function editDatapackMetadata(
   }
   if (!body) {
     reply.status(400).send({ error: "Missing body" });
+    return;
+  }
+  if (!isPartialDatapackMetadata(body)) {
+    reply.status(400).send({ error: "Invalid body" });
     return;
   }
   const uuid = request.session.get("uuid");

--- a/server/src/routes/user-routes.ts
+++ b/server/src/routes/user-routes.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { runJavaEncrypt } from "../encryption.js";
 import { assetconfigs, checkFileExists, checkHeader, verifyFilepath, makeTempFilename } from "../util.js";
 import { MultipartFile } from "@fastify/multipart";
-import { DatapackIndex } from "@tsconline/shared";
+import { DatapackIndex, DatapackMetadata } from "@tsconline/shared";
 import { exec } from "child_process";
 import { createWriteStream } from "fs";
 import { pipeline } from "stream/promises";
@@ -14,7 +14,63 @@ import { getFileNameFromCachedDatapack, uploadUserDatapackHandler } from "../upl
 import { findUser } from "../database.js";
 import { addPublicUserDatapack, loadPublicUserDatapacks } from "../public-datapack-handler.js";
 import { CACHED_USER_DATAPACK_FILENAME, PUBLIC_DATAPACK_INDEX_FILENAME } from "../constants.js";
-import { fetchAllUsersDatapacks } from "../user/user-handler.js";
+import {
+  constructUserDirectory,
+  fetchAllUsersDatapacks,
+  fetchUserDatapack,
+  getDirectories,
+  renameUserDatapack} from "../user/user-handler.js";
+
+export const editDatapackMetadata = async function editDatapackMetadata(
+  request: FastifyRequest<{ Params: { datapack: string }; Body: Partial<DatapackMetadata> }>,
+  reply: FastifyReply
+) {
+  const { datapack } = request.params;
+  const body = request.body;
+  if (!datapack) {
+    reply.status(400).send({ error: "Missing datapack" });
+    return;
+  }
+  if (!body) {
+    reply.status(400).send({ error: "Missing body" });
+    return;
+  }
+  const uuid = request.session.get("uuid");
+  if (!uuid) {
+    reply.status(401).send({ error: "User not logged in" });
+    return;
+  }
+  const userDir = await constructUserDirectory(uuid).catch((e) => {
+    reply.status(500).send({ error: "Failed to create user directory with error " + e });
+  });
+  if (!userDir) {
+    return;
+  }
+  const datapackTitles = await getDirectories(userDir);
+  if (body.title && datapackTitles.includes(body.title)) {
+    reply.status(400).send({ error: "Title already exists" });
+    return;
+  }
+  const metadata = await fetchUserDatapack(userDir, datapack).catch(() => {
+    reply.status(500).send({ error: "Failed to load cached user datapacks in user directory" });
+  });
+  if (!metadata) {
+    return;
+  }
+  // edit metadata
+  Object.assign(metadata, body);
+
+  // check if title is being changed so that we can rename the directory
+  if (body.title && metadata.title !== datapack) {
+    try {
+      await renameUserDatapack(userDir, datapack, metadata);
+    } catch (e) {
+      reply.status(500).send({ error: "Failed to change datapack title." });
+      return;
+    }
+  }
+  reply.send({ message: `Successfully updated ${datapack}` });
+};
 
 export const requestDownload = async function requestDownload(
   request: FastifyRequest<{ Params: { datapack: string }; Querystring: { needEncryption?: boolean } }>,

--- a/server/src/user/user-handler.ts
+++ b/server/src/user/user-handler.ts
@@ -1,9 +1,10 @@
-import { mkdir, readFile, readdir } from "fs/promises";
+import { mkdir, readFile, readdir, rename, writeFile } from "fs/promises";
 import path from "path";
 import { CACHED_USER_DATAPACK_FILENAME } from "../constants.js";
-import { checkFileExists } from "../util.js";
-import { DatapackIndex, assertDatapack, assertPrivateUserDatapack } from "@tsconline/shared";
+import { assetconfigs, checkFileExists, verifyFilepath } from "../util.js";
+import { Datapack, DatapackIndex, assertDatapack, assertPrivateUserDatapack } from "@tsconline/shared";
 import logger from "../error-logger.js";
+import { changeFileMetadataKey } from "../file-metadata-handler.js";
 
 export async function getDirectories(source: string): Promise<string[]> {
   const entries = await readdir(source, { withFileTypes: true });
@@ -28,4 +29,47 @@ export async function fetchAllUsersDatapacks(userDirectory: string): Promise<Dat
     datapackIndex[datapack] = parsedCachedDatapack;
   }
   return datapackIndex;
+}
+
+export async function constructUserDirectory(uuid: string): Promise<string> {
+  const userDirectory = path.join(assetconfigs.uploadDirectory, uuid);
+  if (!(await verifyFilepath(userDirectory))) {
+    throw new Error("Invalid filepath");
+  }
+  return userDirectory;
+}
+
+export async function fetchUserDatapack(userDirectory: string, datapack: string): Promise<Datapack> {
+  const cachedDatapack = path.join(userDirectory, datapack, CACHED_USER_DATAPACK_FILENAME);
+  if (!(await verifyFilepath(cachedDatapack)) || !(await checkFileExists(cachedDatapack))) {
+    throw new Error(`File ${datapack} doesn't exist`);
+  }
+  const parsedCachedDatapack = JSON.parse(await readFile(cachedDatapack, "utf-8"));
+  assertPrivateUserDatapack(parsedCachedDatapack);
+  assertDatapack(parsedCachedDatapack);
+  return parsedCachedDatapack;
+}
+
+// here we rename a user datapack title which means we have to rename the folder and the file metadata (the key only)
+export async function renameUserDatapack(
+  userDirectory: string,
+  oldDatapack: string,
+  datapack: Datapack
+): Promise<void> {
+  const oldDatapackPath = path.join(userDirectory, oldDatapack);
+  const newDatapackPath = path.join(userDirectory, datapack.title);
+  if (!(await verifyFilepath(oldDatapackPath)) || !(await verifyFilepath(newDatapackPath))) {
+    throw new Error("Invalid filepath");
+  }
+  await rename(oldDatapackPath, newDatapackPath);
+  await writeUserDatapack(userDirectory, datapack);
+  await changeFileMetadataKey(assetconfigs.fileMetadata, oldDatapackPath, newDatapackPath);
+}
+
+export async function writeUserDatapack(userDirectory: string, datapack: Datapack): Promise<void> {
+  const datapackPath = path.join(userDirectory, datapack.title);
+  if (!(await verifyFilepath(datapackPath))) {
+    throw new Error("Invalid filepath");
+  }
+  await writeFile(datapackPath, JSON.stringify(datapack, null, 2));
 }

--- a/server/src/user/user-handler.ts
+++ b/server/src/user/user-handler.ts
@@ -31,7 +31,7 @@ export async function fetchAllUsersDatapacks(userDirectory: string): Promise<Dat
   return datapackIndex;
 }
 
-export async function constructUserDirectory(uuid: string): Promise<string> {
+export async function getUserDirectory(uuid: string): Promise<string> {
   const userDirectory = path.join(assetconfigs.uploadDirectory, uuid);
   if (!(await verifyFilepath(userDirectory))) {
     throw new Error("Invalid filepath");

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -995,6 +995,24 @@ export function assertPatterns(o: any): asserts o is Patterns {
 
 export function isPartialDatapackMetadata(o: any): o is Partial<DatapackMetadata> {
   if (!o || typeof o !== "object") return false;
+  const validKeys = [
+    "description",
+    "title",
+    "originalFileName",
+    "storedFileName",
+    "size",
+    "authoredBy",
+    "tags",
+    "date",
+    "references",
+    "contact",
+    "notes"
+  ];
+  for (const key in o) {
+    if (!validKeys.includes(key)) {
+      return false;
+    }
+  }
   if ("description" in o && typeof o.description !== "string") return false;
   if ("title" in o && typeof o.title !== "string") return false;
   if ("originalFileName" in o && typeof o.originalFileName !== "string") return false;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -993,6 +993,21 @@ export function assertPatterns(o: any): asserts o is Patterns {
   }
 }
 
+export function isPartialDatapackMetadata(o: any): o is Partial<DatapackMetadata> {
+  if (!o || typeof o !== "object") return false;
+  if ("description" in o && typeof o.description !== "string") return false;
+  if ("title" in o && typeof o.title !== "string") return false;
+  if ("originalFileName" in o && typeof o.originalFileName !== "string") return false;
+  if ("storedFileName" in o && typeof o.storedFileName !== "string") return false;
+  if ("size" in o && typeof o.size !== "string") return false;
+  if ("authoredBy" in o && typeof o.authoredBy !== "string") return false;
+  if ("tags" in o && !Array.isArray(o.tags)) return false;
+  if ("date" in o && typeof o.date !== "string") return false;
+  if ("references" in o && !Array.isArray(o.references)) return false;
+  if ("contact" in o && typeof o.contact !== "string") return false;
+  if ("notes" in o && typeof o.notes !== "string") return false;
+  return true;
+}
 export function assertDatapackMetadata(o: any): asserts o is DatapackMetadata {
   if (!o || typeof o !== "object") throw new Error("DatapackMetadata must be a non-null object");
   if (typeof o.description !== "string") throw new Error("DatapackMetadata description must be of type string");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,8 @@ export default defineConfig({
         "server/src/routes/login-routes.ts": thresholdConfig,
         "server/src/parse-datapacks.ts": thresholdConfig,
         "server/src/parse-map-packs.ts": thresholdConfig,
-        "shared/src/util.ts": thresholdConfig
+        "shared/src/util.ts": thresholdConfig,
+        "server/src/user/user-handler.ts": thresholdConfig
       },
       ignoreEmptyLines: true
     },


### PR DESCRIPTION
# Main
- basically just backend changes
- all fields that you upload a file with are editable (both use `DatapackMetadata`)
- outsourced changing files into `user-handler.ts`
- made tests for each
- will work on front end for this in another pr
- also don't know if admins should be allowed to edit other people's datapacks but that's probably not something we want.