### PR TITLE
Dependabot Fix

### DIFF
--- a/.github/workflows/merge-pipeline.yml
+++ b/.github/workflows/merge-pipeline.yml
@@ -171,10 +171,12 @@ jobs:
           ssh-keyscan -H bitbucket.org >> ~/.ssh/known_hosts
 
       - name: Checkout code from Bitbucket
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           git clone git@bitbucket.org:strat/tscreator.git
 
       - name: Set up jdk
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
@@ -182,6 +184,7 @@ jobs:
           java-package: "jdk"
 
       - name: Build and compile TSCreator Jar for tests
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           cd ${{ github.workspace }}/tscreator/devel
           make
@@ -196,10 +199,20 @@ jobs:
 
       - name: Run Tests
         id: run_tests
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           Xvfb :1 -screen 0 1024x768x16 &
           export DISPLAY=:1
           yarn coverage:ci > test_output.log 2>&1 || (grep -q 'ERROR: Coverage' test_output.log && echo "coverage_failed=true" >> $GITHUB_OUTPUT) || echo "test_failed=true" >> $GITHUB_OUTPUT
+        continue-on-error: true
+
+      - name: Run Tests and Coverage (Exclude Encryption)
+        id: run_tests_exclude_encryption
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        run: | 
+          Xvfb :1 -screen 0 1024x768x16 &
+          export DISPLAY=:1
+          yarn coverage:ci:exclude-encryption > test_output.log 2>&1 || (grep -q 'ERROR: Coverage' test_output.log && echo "coverage_failed=true" >> $GITHUB_OUTPUT) || echo "test_failed=true" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Post Coverage Comment

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:ui": "vitest --ui",
     "test:case": "vitest run -t",
     "coverage:ci": "vitest run --coverage --no-color",
+    "coverage:ci:exclude-encryption": "vitest run --coverage --no-color --exclude **/encryption.test.ts",
     "coverage": "vitest run --coverage",
     "clean": "yarn workspaces foreach -A --parallel run clean"
   },


### PR DESCRIPTION
- dependabot will no longer checkout code from bitbucket
- dependabot will exclude encryption tests
- added script in package.json for running all tests except for encryption test
![a380371f4316669a621ebf9bc91b9626](https://github.com/user-attachments/assets/071a76da-8224-41ba-b302-36919c1bac17)
^ build-and-test action for "Bump rollup from 4.17.2 to 4.24.0" (dependabot PR)