### PR TITLE
Tsc 565 add more compact datapack rows

### DIFF
--- a/app/src/settings_tabs/Datapack.module.css
+++ b/app/src/settings_tabs/Datapack.module.css
@@ -90,12 +90,13 @@
   align-items: center;
   flex-direction: column;
 }
+.container.buttonContainer {
+  flex-direction: row;
+}
 .item {
   display: flex;
   flex-wrap: wrap;
-  padding: 4px;
   width: 100%;
-  margin-bottom: 3px;
 }
 .wrapItem > *,
 .datapackDisplayContainer > .container:not(.official, .cards) {
@@ -106,7 +107,6 @@
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
-  padding: 16px;
 }
 .datapackDisplayContainer:not(.cards) {
   align-items: flex-start;
@@ -115,6 +115,13 @@
 .datapackDisplayContainer.cards {
   align-items: center;
   width: 90%;
+}
+.container.cards,
+.container.cards > .item {
+  gap: 10px;
+}
+.container.cards {
+  margin: 0px 20px 20px;
 }
 
 .buttons {

--- a/app/src/settings_tabs/Datapack.module.css
+++ b/app/src/settings_tabs/Datapack.module.css
@@ -66,7 +66,8 @@
   margin: 0px;
 }
 
-.container {
+.container,
+.wrappedDatapackCategories:not(.cards) {
   display: flex;
   overflow-y: auto;
   flex-wrap: wrap;
@@ -74,6 +75,7 @@
   width: 70%;
   margin-bottom: 3px;
   justify-content: center;
+  align-items: flex-start;
 }
 .item {
   display: flex;
@@ -82,24 +84,17 @@
   width: 100%;
   margin-bottom: 3px;
 }
-.wrapItem > *, .wrappedDatapackCategories > .container {
+.wrapItem > *,
+.wrappedDatapackCategories > .container {
   flex: 1 1 50%;
 }
-.wrappedDatapackCategories {
-  display: flex;
-  flex-direction: row;
-  width: 70%;
-  flex-wrap: wrap;
-  align-items: flex-start;
-}
 
-.container.cards {
+.container.cards,
+.wrappedDatapackCategories.cards {
   gap: 10px;
-  width: 100%;
+  width: 90%;
   margin: 0 20px 20px 20px;
   justify-content: flex-start;
-  justify-self: center;
-  align-self: center;
 }
 
 .buttons {

--- a/app/src/settings_tabs/Datapack.module.css
+++ b/app/src/settings_tabs/Datapack.module.css
@@ -97,6 +97,7 @@
   display: flex;
   flex-wrap: wrap;
   width: 100%;
+  overflow-x: hidden;
 }
 .wrapItem > *,
 .datapackDisplayContainer > .container:not(.official, .cards) {

--- a/app/src/settings_tabs/Datapack.module.css
+++ b/app/src/settings_tabs/Datapack.module.css
@@ -4,6 +4,7 @@
   align-items: center;
   width: 100%;
   min-height: 100vh;
+  flex-wrap: wrap;
 }
 
 .h {
@@ -74,10 +75,27 @@
   margin-bottom: 3px;
   justify-content: center;
 }
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 4px;
+  width: 100%;
+  margin-bottom: 3px;
+}
+.wrapItem > *, .wrappedDatapackCategories > .container {
+  flex: 1 1 50%;
+}
+.wrappedDatapackCategories {
+  display: flex;
+  flex-direction: row;
+  width: 70%;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
 
 .container.cards {
   gap: 10px;
-  width: 90%;
+  width: 100%;
   margin: 0 20px 20px 20px;
   justify-content: flex-start;
   justify-self: center;

--- a/app/src/settings_tabs/Datapack.module.css
+++ b/app/src/settings_tabs/Datapack.module.css
@@ -4,7 +4,6 @@
   align-items: center;
   width: 100%;
   min-height: 100vh;
-  flex-wrap: wrap;
 }
 
 .h {
@@ -66,6 +65,11 @@
   margin: 0px;
 }
 
+.showBox {
+  align-self: flex-start;
+  justify-self: flex-start;
+  margin-left: 45px;
+}
 .show {
   font-style: italic;
   width: max-content;
@@ -75,16 +79,16 @@
   text-decoration: underline;
 }
 
-.container,
-.wrappedDatapackCategories:not(.cards) {
+.container {
   display: flex;
   overflow-y: auto;
   flex-wrap: wrap;
   padding: 4px;
-  width: 70%;
+  width: 100%;
   margin-bottom: 3px;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
+  flex-direction: column;
 }
 .item {
   display: flex;
@@ -94,16 +98,23 @@
   margin-bottom: 3px;
 }
 .wrapItem > *,
-.wrappedDatapackCategories > .container {
+.datapackDisplayContainer > .container:not(.official, .cards) {
   flex: 1 1 50%;
 }
-
-.container.cards,
-.wrappedDatapackCategories.cards {
-  gap: 10px;
+.datapackDisplayContainer {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 16px;
+}
+.datapackDisplayContainer:not(.cards) {
+  align-items: flex-start;
+  width: 70%;
+}
+.datapackDisplayContainer.cards {
+  align-items: center;
   width: 90%;
-  margin: 0 20px 20px 20px;
-  justify-content: flex-start;
 }
 
 .buttons {

--- a/app/src/settings_tabs/Datapack.module.css
+++ b/app/src/settings_tabs/Datapack.module.css
@@ -66,6 +66,15 @@
   margin: 0px;
 }
 
+.show {
+  font-style: italic;
+  width: max-content;
+}
+.show:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 .container,
 .wrappedDatapackCategories:not(.cards) {
   display: flex;

--- a/app/src/settings_tabs/Datapack.tsx
+++ b/app/src/settings_tabs/Datapack.tsx
@@ -86,31 +86,33 @@ export const Datapacks = observer(function Datapacks() {
           </ToggleButton>
         </ToggleButtonGroup>
       </div>
-      <DatapackGroupDisplay datapacks={[]} header={t("settings.datapacks.title.workshop")} HeaderIcon={School} />
       <DatapackGroupDisplay
         datapacks={getPublicOfficialDatapacks(state.datapacks)}
         header={t("settings.datapacks.title.public-official")}
         HeaderIcon={Verified}
       />
-      {state.user.isAdmin && (
+      <Box className={`${styles.wrappedDatapackCategories}`}>
+        {state.user.isAdmin && (
+          <DatapackGroupDisplay
+            datapacks={getPrivateOfficialDatapacks(state.datapacks)}
+            header={t("settings.datapacks.title.private-official")}
+            HeaderIcon={Security}
+          />
+        )}
+        <DatapackGroupDisplay datapacks={[]} header={t("settings.datapacks.title.workshop")} HeaderIcon={School} />
+        {state.isLoggedIn && state.user && (
+          <DatapackGroupDisplay
+            datapacks={getCurrentUserDatapacks(state.user.uuid, state.datapacks)}
+            header={t("settings.datapacks.title.your")}
+            HeaderIcon={Lock}
+          />
+        )}
         <DatapackGroupDisplay
-          datapacks={getPrivateOfficialDatapacks(state.datapacks)}
-          header={t("settings.datapacks.title.private-official")}
-          HeaderIcon={Security}
+          datapacks={getPublicDatapacksWithoutCurrentUser(state.datapacks, state.user?.uuid)}
+          header={t("settings.datapacks.title.contributed")}
+          HeaderIcon={People}
         />
-      )}
-      {state.isLoggedIn && state.user && (
-        <DatapackGroupDisplay
-          datapacks={getCurrentUserDatapacks(state.user.uuid, state.datapacks)}
-          header={t("settings.datapacks.title.your")}
-          HeaderIcon={Lock}
-        />
-      )}
-      <DatapackGroupDisplay
-        datapacks={getPublicDatapacksWithoutCurrentUser(state.datapacks, state.user?.uuid)}
-        header={t("settings.datapacks.title.contributed")}
-        HeaderIcon={People}
-      />
+      </Box>
       <Box className={styles.container}>
         {state.isLoggedIn && (
           <TSCButton
@@ -189,6 +191,8 @@ const DatapackGroupDisplay: React.FC<DatapackGroupDisplayProps> = observer(({ da
     }
   };
   const numberOfDatapacks = datapacks.length;
+  const shouldWrap =
+    header === t("settings.datapacks.title.public-official") && state.settingsTabs.datapackDisplayType !== "cards";
 
   return (
     <Box className={`${styles.container} ${state.settingsTabs.datapackDisplayType === "cards" ? styles.cards : ""}`}>
@@ -203,16 +207,20 @@ const DatapackGroupDisplay: React.FC<DatapackGroupDisplayProps> = observer(({ da
           className={styles.idh}>{`${header} (${numberOfDatapacks})`}</Typography>
       </Box>
       <CustomDivider className={styles.divider} />
-      {datapacks.map((datapack) => {
-        const value = state.unsavedDatapackConfig.some((dp) => compareExistingDatapacks(dp, datapack));
-        return state.settingsTabs.datapackDisplayType === "rows" ? (
-          <TSCDatapackRow key={datapack.title} datapack={datapack} value={value} onChange={onChange} />
-        ) : state.settingsTabs.datapackDisplayType === "compact" ? (
-          <TSCCompactDatapackRow key={datapack.title} datapack={datapack} value={value} onChange={onChange} />
-        ) : (
-          <TSCDatapackCard key={datapack.title} datapack={datapack} value={value} onChange={onChange} />
-        );
-      })}
+      {numberOfDatapacks !== 0 && (
+        <Box className={`${styles.item} ${shouldWrap && styles.wrapItem}`}>
+          {datapacks.map((datapack) => {
+            const value = state.unsavedDatapackConfig.some((dp) => compareExistingDatapacks(dp, datapack));
+            return state.settingsTabs.datapackDisplayType === "rows" ? (
+              <TSCDatapackRow key={datapack.title} datapack={datapack} value={value} onChange={onChange} />
+            ) : state.settingsTabs.datapackDisplayType === "compact" ? (
+              <TSCCompactDatapackRow key={datapack.title} datapack={datapack} value={value} onChange={onChange} />
+            ) : (
+              <TSCDatapackCard key={datapack.title} datapack={datapack} value={value} onChange={onChange} />
+            );
+          })}
+        </Box>
+      )}
       {numberOfDatapacks === 0 && (
         <Typography>
           {t("settings.datapacks.no")} {header} {t("settings.datapacks.avaliable")}

--- a/app/src/settings_tabs/Datapack.tsx
+++ b/app/src/settings_tabs/Datapack.tsx
@@ -182,6 +182,10 @@ type DatapackGroupDisplayProps = {
 const DatapackGroupDisplay: React.FC<DatapackGroupDisplayProps> = observer(({ datapacks, header, HeaderIcon }) => {
   const { state, actions } = useContext(context);
   const { t } = useTranslation();
+  const [showAll, setShowAll] = useState(false);
+  const isOfficial = header === t("settings.datapacks.title.public-official");
+  const visibleLimit = isOfficial ? 12 : 6;
+  const visibleDatapacks = showAll ? datapacks : datapacks.slice(0, visibleLimit);
   const onChange = (newDatapack: DatapackConfigForChartRequest) => {
     if (state.unsavedDatapackConfig.includes(newDatapack)) {
       actions.setUnsavedDatapackConfig(
@@ -192,8 +196,7 @@ const DatapackGroupDisplay: React.FC<DatapackGroupDisplayProps> = observer(({ da
     }
   };
   const numberOfDatapacks = datapacks.length;
-  const shouldWrap =
-    header === t("settings.datapacks.title.public-official") && state.settingsTabs.datapackDisplayType !== "cards";
+  const shouldWrap = isOfficial && state.settingsTabs.datapackDisplayType !== "cards";
 
   return (
     <Box className={`${styles.container} ${state.settingsTabs.datapackDisplayType === "cards" ? styles.cards : ""}`}>
@@ -210,7 +213,7 @@ const DatapackGroupDisplay: React.FC<DatapackGroupDisplayProps> = observer(({ da
       <CustomDivider className={styles.divider} />
       {numberOfDatapacks !== 0 && (
         <Box className={`${styles.item} ${shouldWrap && styles.wrapItem}`}>
-          {datapacks.map((datapack) => {
+          {visibleDatapacks.map((datapack) => {
             const value = state.unsavedDatapackConfig.some((dp) => compareExistingDatapacks(dp, datapack));
             return state.settingsTabs.datapackDisplayType === "rows" ? (
               <TSCDatapackRow key={datapack.title} datapack={datapack} value={value} onChange={onChange} />
@@ -220,6 +223,13 @@ const DatapackGroupDisplay: React.FC<DatapackGroupDisplayProps> = observer(({ da
               <TSCDatapackCard key={datapack.title} datapack={datapack} value={value} onChange={onChange} />
             );
           })}
+          {numberOfDatapacks > visibleLimit && (
+            <Box onClick={() => setShowAll(!showAll)}>
+              <Typography className={styles.show} variant="body2" color="primary">
+                {!showAll ? t("settings.datapacks.seeMore") : t("settings.datapacks.seeLess")}
+              </Typography>
+            </Box>
+          )}
         </Box>
       )}
       {numberOfDatapacks === 0 && (

--- a/app/src/settings_tabs/Datapack.tsx
+++ b/app/src/settings_tabs/Datapack.tsx
@@ -86,13 +86,13 @@ export const Datapacks = observer(function Datapacks() {
           </ToggleButton>
         </ToggleButtonGroup>
       </div>
-      <DatapackGroupDisplay
-        datapacks={getPublicOfficialDatapacks(state.datapacks)}
-        header={t("settings.datapacks.title.public-official")}
-        HeaderIcon={Verified}
-      />
       <Box
-        className={`${state.settingsTabs.datapackDisplayType === "cards" && styles.cards} ${styles.wrappedDatapackCategories}`}>
+        className={`${styles.datapackDisplayContainer} ${state.settingsTabs.datapackDisplayType === "cards" && styles.cards}`}>
+        <DatapackGroupDisplay
+          datapacks={getPublicOfficialDatapacks(state.datapacks)}
+          header={t("settings.datapacks.title.public-official")}
+          HeaderIcon={Verified}
+        />
         {state.user.isAdmin && (
           <DatapackGroupDisplay
             datapacks={getPrivateOfficialDatapacks(state.datapacks)}
@@ -199,7 +199,8 @@ const DatapackGroupDisplay: React.FC<DatapackGroupDisplayProps> = observer(({ da
   const shouldWrap = isOfficial && state.settingsTabs.datapackDisplayType !== "cards";
 
   return (
-    <Box className={`${styles.container} ${state.settingsTabs.datapackDisplayType === "cards" ? styles.cards : ""}`}>
+    <Box
+      className={`${styles.container} ${state.settingsTabs.datapackDisplayType === "cards" ? styles.cards : ""} ${isOfficial && styles.official}`}>
       <Box className={styles.header}>
         <SvgIcon className={styles.sdi}>
           <HeaderIcon />
@@ -223,13 +224,13 @@ const DatapackGroupDisplay: React.FC<DatapackGroupDisplayProps> = observer(({ da
               <TSCDatapackCard key={datapack.title} datapack={datapack} value={value} onChange={onChange} />
             );
           })}
-          {numberOfDatapacks > visibleLimit && (
-            <Box onClick={() => setShowAll(!showAll)}>
-              <Typography className={styles.show} variant="body2" color="primary">
-                {!showAll ? t("settings.datapacks.seeMore") : t("settings.datapacks.seeLess")}
-              </Typography>
-            </Box>
-          )}
+        </Box>
+      )}
+      {numberOfDatapacks > visibleLimit && (
+        <Box className={styles.showBox} onClick={() => setShowAll(!showAll)}>
+          <Typography className={styles.show} variant="body2" color="primary">
+            {!showAll ? t("settings.datapacks.seeMore") : t("settings.datapacks.seeLess")}
+          </Typography>
         </Box>
       )}
       {numberOfDatapacks === 0 && (

--- a/app/src/settings_tabs/Datapack.tsx
+++ b/app/src/settings_tabs/Datapack.tsx
@@ -91,7 +91,8 @@ export const Datapacks = observer(function Datapacks() {
         header={t("settings.datapacks.title.public-official")}
         HeaderIcon={Verified}
       />
-      <Box className={`${styles.wrappedDatapackCategories}`}>
+      <Box
+        className={`${state.settingsTabs.datapackDisplayType === "cards" && styles.cards} ${styles.wrappedDatapackCategories}`}>
         {state.user.isAdmin && (
           <DatapackGroupDisplay
             datapacks={getPrivateOfficialDatapacks(state.datapacks)}

--- a/app/src/settings_tabs/Datapack.tsx
+++ b/app/src/settings_tabs/Datapack.tsx
@@ -114,7 +114,7 @@ export const Datapacks = observer(function Datapacks() {
           HeaderIcon={People}
         />
       </Box>
-      <Box className={styles.container}>
+      <Box className={`${styles.container} ${styles.buttonContainer}`}>
         {state.isLoggedIn && (
           <TSCButton
             className={styles.buttons}

--- a/app/translation/en.json
+++ b/app/translation/en.json
@@ -225,6 +225,8 @@
                 "no": "No",
                 "avaliable": "Avaliable",
                 "upload": "Upload Datapack",
+                "seeMore": "See More...",
+                "seeLess": "See Less...",
                 "upload-form": {
                     "title": "Upload Your Own Datapack",
                     "no-file": "No file selected",


### PR DESCRIPTION
# Main

* added wrapping to datapacks page
* added see more/see less when there are more than 9 datapacks (for official it is 18 because it wraps)
* demo shows 6 to illustrate my point but with that it still seems like a lot when looking at the non compact
* let me know if 9 is too much or if i should go with 6. the compact isn't really the issue, the bigger row one might be a lot of datapacks at once, but tbh if you're on that page you want more info anyways
* 

![Screenshot 2024-11-05 at 7 28 46 PM](https://github.com/user-attachments/assets/238b473c-6ef0-4d3b-8a6a-f069bffe915d)

![Screenshot 2024-11-05 at 7 29 13 PM](https://github.com/user-attachments/assets/29c25a7a-b5d1-4c74-b5ca-daa42482687c)

https://github.com/user-attachments/assets/100b9086-0212-46d4-9507-bd5cf8b05afd

