### PR TITLE
Tsc 617 parsing ideas sql to txt

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "better-sqlite3": "^9.4.4",
     "chalk": "^5.3.0",
     "cors": "^2.8.5",
+    "csv-writer": "^1.6.0",
     "dompurify": "^3.1.3",
     "dotenv": "^16.4.5",
     "fastify": "^4.27.0",
@@ -75,7 +76,8 @@
     "dev:config:overwrite": "node dist/add-dev-config.js --overwrite",
     "migrate-datapacks": "node dist/migrate-cached-datapacks.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "clean": "rm -rf ./dist"
+    "clean": "rm -rf ./dist",
+    "london": "node dist/london-db/dump-to-csv.js"
   },
   "type": "module"
 }

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "better-sqlite3": "^9.4.4",
     "chalk": "^5.3.0",
     "cors": "^2.8.5",
+    "csv-parser": "^3.2.0",
     "csv-writer": "^1.6.0",
     "dompurify": "^3.1.3",
     "dotenv": "^16.4.5",
@@ -77,7 +78,7 @@
     "migrate-datapacks": "node dist/migrate-cached-datapacks.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf ./dist",
-    "london": "node dist/london-db/dump-to-csv.js"
+    "london": "node dist/london-db/london-database.js"
   },
   "type": "module"
 }

--- a/server/package.json
+++ b/server/package.json
@@ -78,7 +78,8 @@
     "migrate-datapacks": "node dist/migrate-cached-datapacks.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf ./dist",
-    "london": "node dist/london-db/london-database.js"
+    "london": "node dist/london-db/london-database.js",
+    "sqlite": "node dist/sqlite-db/csv-to-sqlite.js"
   },
   "type": "module"
 }

--- a/server/package.json
+++ b/server/package.json
@@ -78,8 +78,7 @@
     "migrate-datapacks": "node dist/migrate-cached-datapacks.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf ./dist",
-    "london": "node dist/london-db/london-database.js",
-    "sqlite": "node dist/sqlite-db/csv-to-sqlite.js"
+    "london": "node dist/london-db/london-database.js"
   },
   "type": "module"
 }

--- a/server/src/london-db/csv-to-sqlite.ts
+++ b/server/src/london-db/csv-to-sqlite.ts
@@ -1,35 +1,57 @@
 import csv from "csv-parser";
 import { createReadStream } from "fs";
-import { LondonDatabaseKey, isLondonDatabaseType, londonDb, outputCSVDir } from "./london-database.js";
-import { readdir } from "fs/promises";
+import {
+  LondonDatabaseKey,
+  assertLondonDatabaseKey,
+  isLondonDatabaseType,
+  londonDb,
+  outputCSVDir,
+  toCamelCase
+} from "./london-database.js";
+import { readFile, readdir } from "fs/promises";
 import { join } from "path";
+import { createInterface } from "readline/promises";
 
 const BATCH_SIZE = 1;
 
-async function insertLargeCSVData(tableName: LondonDatabaseKey, filePath: string) {
-  const batch: Record<string, unknown>[] = [];
+const surroundedByQuotes = (value: string) => value.startsWith('"') && value.endsWith('"');
+
+async function insertLargeCSVData(tableName: string, filePath: string) {
+  const key = toCamelCase(tableName);
+  assertLondonDatabaseKey(key);
   return new Promise<void>((resolve, reject) => {
-    createReadStream(filePath)
+    let batch: Record<string, string | null | number>[] = [];
+    const stream = createReadStream(filePath)
       .pipe(csv())
-      .on("data", async (row: Record<string, unknown>) => {
-        row = Object.fromEntries(Object.entries(row).map(([key, value]) => [key, value === "" ? null : value]));
-        batch.push(row);
+      .on("data", async (row: Record<string, string>) => {
+        stream.pause();
+        const batchRow = Object.fromEntries(
+          Object.entries(row).map(([key, value]) => [
+            key,
+            value === "" ? null : surroundedByQuotes(value) ? value : !isNaN(Number(value)) ? Number(value) : value
+          ])
+        );
+        batch.push(batchRow);
         if (batch.length >= BATCH_SIZE) {
           try {
-            await londonDb.insertInto(tableName).values(batch).execute();
+            await londonDb.insertInto(key).values(batch).execute();
           } catch (error) {
             reject(error);
+            return;
+          } finally {
+            // reset batch
+            batch = [];
+            stream.resume();
           }
-          batch.pop();
-          batch.length = 0;
         }
       })
       .on("end", async () => {
         if (batch.length > 0) {
           try {
-            await londonDb.insertInto(tableName).values(batch).execute();
+            await londonDb.insertInto(key).values(batch).execute();
           } catch (error) {
             reject(error);
+            return;
           }
         }
         console.log(`Imported ${filePath} into ${tableName}`);
@@ -37,6 +59,22 @@ async function insertLargeCSVData(tableName: LondonDatabaseKey, filePath: string
       })
       .on("error", reject);
   });
+}
+
+async function insertLargeCSVDataReadFile(tableName: LondonDatabaseKey, filePath: string) {
+  const fileStream = createReadStream(filePath);
+  const readline = createInterface({ input: fileStream, crlfDelay: Infinity });
+  const headers = readline.line.split(",");
+
+  let batch: (string | null)[][] = [];
+  for await (const line of readline) {
+    const row = line.split(",").map((value) => (value === "" ? null : value));
+    batch.push(row);
+    if (batch.length >= BATCH_SIZE) {
+      await londonDb.insertInto(tableName).values(batch).execute();
+      batch = [];
+    }
+  }
 }
 async function getCSVFiles(directory: string): Promise<string[]> {
   try {

--- a/server/src/london-db/csv-to-sqlite.ts
+++ b/server/src/london-db/csv-to-sqlite.ts
@@ -1,53 +1,59 @@
-import csv from 'csv-parser';
-import { OUTPUT_DIR } from './dump-to-csv.js';
-import { createReadStream } from 'fs';
-import { LondonDatabaseKey, isLondonDatabaseType, londonDb } from './london-database.js';
-import { readdir } from 'fs/promises';
-import { join } from 'path';
+import csv from "csv-parser";
+import { createReadStream } from "fs";
+import { LondonDatabaseKey, isLondonDatabaseType, londonDb, outputCSVDir } from "./london-database.js";
+import { readdir } from "fs/promises";
+import { join } from "path";
 
-const BATCH_SIZE = 1000;
+const BATCH_SIZE = 1;
 
 async function insertLargeCSVData(tableName: LondonDatabaseKey, filePath: string) {
-  const batch: string[] = [];
-
+  const batch: Record<string, unknown>[] = [];
   return new Promise<void>((resolve, reject) => {
     createReadStream(filePath)
       .pipe(csv())
-      .on('data', async (row: string) => {
+      .on("data", async (row: Record<string, unknown>) => {
+        row = Object.fromEntries(Object.entries(row).map(([key, value]) => [key, value === "" ? null : value]));
         batch.push(row);
         if (batch.length >= BATCH_SIZE) {
-          await londonDb.insertInto(tableName).values(batch).execute();
+          try {
+            await londonDb.insertInto(tableName).values(batch).execute();
+          } catch (error) {
+            console.log(row);
+            reject(error);
+          }
           batch.length = 0;
         }
       })
-      .on('end', async () => {
+      .on("end", async () => {
         if (batch.length > 0) {
-          await londonDb.insertInto(tableName).values(batch).execute();
+          try {
+            await londonDb.insertInto(tableName).values(batch).execute();
+          } catch (error) {
+            reject(error);
+          }
         }
         console.log(`Imported ${filePath} into ${tableName}`);
         resolve();
       })
-      .on('error', reject);
+      .on("error", reject);
   });
 }
 async function getCSVFiles(directory: string): Promise<string[]> {
-    try {
-      const files = await readdir(directory);
-      return files.filter(file => file.endsWith('.csv') && isLondonDatabaseType(file.split(".csv")[0] || ""));
-    } catch (error) {
-      console.error('Error reading directory:', error);
-      return [];
-    }
+  try {
+    const files = await readdir(directory);
+    return files.filter((file) => file.endsWith(".csv") && isLondonDatabaseType(file.split(".csv")[0] || ""));
+  } catch (error) {
+    console.error("Error reading directory:", error);
+    return [];
   }
-
-// Import all tables
-async function importAllTables() {
-    const files = await getCSVFiles(OUTPUT_DIR);
-    for (const csv of files) {
-        const tableName = csv.split(".csv")[0] as LondonDatabaseKey; // we checked this in getCSVFiles
-        const filePath = join(OUTPUT_DIR, csv);
-        await insertLargeCSVData(tableName, filePath);
-    }
 }
 
-await importAllTables();
+// Import all tables
+export async function importAllTables() {
+  const files = await getCSVFiles(outputCSVDir);
+  for (const csv of files) {
+    const tableName = csv.split(".csv")[0] as LondonDatabaseKey; // we checked this in getCSVFiles
+    const filePath = join(outputCSVDir, csv);
+    await insertLargeCSVData(tableName, filePath);
+  }
+}

--- a/server/src/london-db/csv-to-sqlite.ts
+++ b/server/src/london-db/csv-to-sqlite.ts
@@ -1,0 +1,53 @@
+import csv from 'csv-parser';
+import { OUTPUT_DIR } from './dump-to-csv.js';
+import { createReadStream } from 'fs';
+import { LondonDatabaseKey, isLondonDatabaseType, londonDb } from './london-database.js';
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+
+const BATCH_SIZE = 1000;
+
+async function insertLargeCSVData(tableName: LondonDatabaseKey, filePath: string) {
+  const batch: string[] = [];
+
+  return new Promise<void>((resolve, reject) => {
+    createReadStream(filePath)
+      .pipe(csv())
+      .on('data', async (row: string) => {
+        batch.push(row);
+        if (batch.length >= BATCH_SIZE) {
+          await londonDb.insertInto(tableName).values(batch).execute();
+          batch.length = 0;
+        }
+      })
+      .on('end', async () => {
+        if (batch.length > 0) {
+          await londonDb.insertInto(tableName).values(batch).execute();
+        }
+        console.log(`Imported ${filePath} into ${tableName}`);
+        resolve();
+      })
+      .on('error', reject);
+  });
+}
+async function getCSVFiles(directory: string): Promise<string[]> {
+    try {
+      const files = await readdir(directory);
+      return files.filter(file => file.endsWith('.csv') && isLondonDatabaseType(file.split(".csv")[0] || ""));
+    } catch (error) {
+      console.error('Error reading directory:', error);
+      return [];
+    }
+  }
+
+// Import all tables
+async function importAllTables() {
+    const files = await getCSVFiles(OUTPUT_DIR);
+    for (const csv of files) {
+        const tableName = csv.split(".csv")[0] as LondonDatabaseKey; // we checked this in getCSVFiles
+        const filePath = join(OUTPUT_DIR, csv);
+        await insertLargeCSVData(tableName, filePath);
+    }
+}
+
+await importAllTables();

--- a/server/src/london-db/csv-to-sqlite.ts
+++ b/server/src/london-db/csv-to-sqlite.ts
@@ -18,9 +18,9 @@ async function insertLargeCSVData(tableName: LondonDatabaseKey, filePath: string
           try {
             await londonDb.insertInto(tableName).values(batch).execute();
           } catch (error) {
-            console.log(row);
             reject(error);
           }
+          batch.pop();
           batch.length = 0;
         }
       })

--- a/server/src/london-db/csv-to-sqlite.ts
+++ b/server/src/london-db/csv-to-sqlite.ts
@@ -4,6 +4,7 @@ import { londonDb, outputCSVDir } from "./london-database.js";
 import { readdir } from "fs/promises";
 import { join } from "path";
 import { toCamelCase, assertLondonDatabaseKey, isLondonDatabaseType, LondonDatabaseKey } from "../types.js";
+import chalk from "chalk";
 
 const BATCH_SIZE = 1;
 
@@ -47,7 +48,7 @@ async function insertLargeCSVData(tableName: string, filePath: string) {
             return;
           }
         }
-        console.log(`Imported ${filePath} into ${tableName}`);
+        console.log(chalk.cyan(`Imported ${filePath} into ${tableName}`));
         resolve();
       })
       .on("error", reject);

--- a/server/src/london-db/csv-to-sqlite.ts
+++ b/server/src/london-db/csv-to-sqlite.ts
@@ -1,16 +1,9 @@
 import csv from "csv-parser";
 import { createReadStream } from "fs";
-import {
-  LondonDatabaseKey,
-  assertLondonDatabaseKey,
-  isLondonDatabaseType,
-  londonDb,
-  outputCSVDir,
-  toCamelCase
-} from "./london-database.js";
-import { readFile, readdir } from "fs/promises";
+import { londonDb, outputCSVDir } from "./london-database.js";
+import { readdir } from "fs/promises";
 import { join } from "path";
-import { createInterface } from "readline/promises";
+import { toCamelCase, assertLondonDatabaseKey, isLondonDatabaseType, LondonDatabaseKey } from "../types.js";
 
 const BATCH_SIZE = 1;
 
@@ -61,21 +54,6 @@ async function insertLargeCSVData(tableName: string, filePath: string) {
   });
 }
 
-async function insertLargeCSVDataReadFile(tableName: LondonDatabaseKey, filePath: string) {
-  const fileStream = createReadStream(filePath);
-  const readline = createInterface({ input: fileStream, crlfDelay: Infinity });
-  const headers = readline.line.split(",");
-
-  let batch: (string | null)[][] = [];
-  for await (const line of readline) {
-    const row = line.split(",").map((value) => (value === "" ? null : value));
-    batch.push(row);
-    if (batch.length >= BATCH_SIZE) {
-      await londonDb.insertInto(tableName).values(batch).execute();
-      batch = [];
-    }
-  }
-}
 async function getCSVFiles(directory: string): Promise<string[]> {
   try {
     const files = await readdir(directory);
@@ -86,7 +64,6 @@ async function getCSVFiles(directory: string): Promise<string[]> {
   }
 }
 
-// Import all tables
 export async function importAllTables() {
   const files = await getCSVFiles(outputCSVDir);
   for (const csv of files) {

--- a/server/src/london-db/csv-to-sqlite.ts
+++ b/server/src/london-db/csv-to-sqlite.ts
@@ -3,8 +3,9 @@ import { createReadStream } from "fs";
 import { londonDb, outputCSVDir } from "./london-database.js";
 import { readdir } from "fs/promises";
 import { join } from "path";
-import { toCamelCase, assertLondonDatabaseKey, isLondonDatabaseType, LondonDatabaseKey } from "../types.js";
+import { assertLondonDatabaseKey, isLondonDatabaseType, LondonDatabaseKey } from "../types.js";
 import chalk from "chalk";
+import { toCamelCase } from "../util.js";
 
 const BATCH_SIZE = 1;
 

--- a/server/src/london-db/dump-to-csv.ts
+++ b/server/src/london-db/dump-to-csv.ts
@@ -144,13 +144,13 @@ function processSchema(statement: string) {
   } else {
     return;
   }
-  const columnRegex = /`(\w+)` (\w+)(\([\d,]+\))?( unsigned)?( NOT NULL)?( DEFAULT ([^,]+))?/g;
+  const columnRegex = /`([\w-]+)` (\w+)(\([\d,]+\))?( unsigned)?( NOT NULL)?( DEFAULT ([^,]+))?/g;
   let columnMatch;
   while ((columnMatch = columnRegex.exec(cleanLine)) !== null) {
     if (columnMatch) {
       let [, columnName, type, size, unsigned, notNull, , defaultValue] = columnMatch;
       if (columnName && type) {
-        const tsColumnName = /^\d/.test(columnName) ? `"${columnName}"` : columnName;
+        const tsColumnName = /^\d|\w+-\w+/.test(columnName) ? `"${columnName}"` : columnName;
         let tsType = "string";
         let mappedType = typeMapping[type.toLowerCase()];
         if (mappedType) {

--- a/server/src/london-db/dump-to-csv.ts
+++ b/server/src/london-db/dump-to-csv.ts
@@ -14,7 +14,6 @@ if (!existsSync(OUTPUT_DIR)) {
   mkdirSync(OUTPUT_DIR);
 }
 
-// Function to clean up MySQL values (handles quotes, NULLs, etc.)
 const cleanValue = (value: string) => {
   if (value === "NULL") return null;
   return value.trim().replace(/^'|'$/g, '"').replace(/\\'/g, "'");
@@ -114,7 +113,6 @@ function processInsert(
   }
 }
 
-// Define type mapping from MySQL to TypeScript
 const typeMapping: Record<string, string> = {
   int: "number",
   "int unsigned": "number",
@@ -130,7 +128,6 @@ const typeMapping: Record<string, string> = {
   boolean: "boolean"
 };
 
-// Function to extract column definitions from CREATE TABLE
 function processSchema(statement: string) {
   const cleanLine = statement.trim();
   let tableName = "";
@@ -191,7 +188,5 @@ function processSchema(statement: string) {
   return "";
 }
 
-// Run the script
-processSchema(DUMP_FILE); // Replace with your actual SQL file
-
+processSchema(DUMP_FILE);
 convertSQLDumpToCSV(DUMP_FILE);

--- a/server/src/london-db/dump-to-csv.ts
+++ b/server/src/london-db/dump-to-csv.ts
@@ -73,7 +73,7 @@ export async function convertSQLDumpToCSV(dumpFile: string) {
       );
 
       await csvWriter.writeRecords(records);
-      console.log(`Exported: ` + chalk.green(`${table}.csv`));
+      console.log(chalk.cyan(`Exported: ${table}.csv to ${outputCSVDir}`));
     } catch (e) {
       console.error(e);
       console.log(chalk.yellow(`Error exporting ${table} to CSV`));
@@ -83,13 +83,13 @@ export async function convertSQLDumpToCSV(dumpFile: string) {
   try {
     // write the schemas
     await writeFile(join(outputCSVDir, "kysely-schema.ts"), schemas.join("\n\n"));
-    console.log(`Exported: ` + chalk.green(`kysely_schema.ts`));
+    console.log(chalk.cyan("Exported schemas to kysely_schema.ts"));
   } catch (e) {
     console.error(e);
     console.log(chalk.yellow(`Error exporting schemas to kysely_schema.ts`));
   }
 
-  console.log(chalk.green("✅ All tables exported successfully!"));
+  console.log(chalk.green("All tables exported successfully to csv!"));
 }
 
 function processInsert(

--- a/server/src/london-db/dump-to-csv.ts
+++ b/server/src/london-db/dump-to-csv.ts
@@ -1,0 +1,95 @@
+import * as readline from "readline";
+import { createObjectCsvWriter } from "csv-writer";
+import { createReadStream, existsSync, mkdirSync } from "fs";
+import chalk from "chalk";
+import { join } from "path";
+
+const DUMP_FILE = join("db", "london", "london.sql");
+const OUTPUT_DIR = join("db", "london", "output_csvs");
+
+if (!existsSync(OUTPUT_DIR)) {
+  mkdirSync(OUTPUT_DIR);
+}
+
+// Function to clean up MySQL values (handles quotes, NULLs, etc.)
+const cleanValue = (value: string) => {
+  if (value === "NULL") return null;
+  return value.trim().replace(/^'|'$/g, "").replace(/\\'/g, "'");
+};
+
+async function convertSQLDumpToCSV(dumpFile: string) {
+  const fileStream = createReadStream(dumpFile);
+  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+  let tables: Record<string, { columns: string[]; rows: (string | null)[][] }> = {};
+  let currentInsert = "";
+  let tableName = "";
+  let columns: string[] = [];
+
+  try {
+    for await (const line of rl) {
+      // statements shouln't have empty lines
+      if (line.trim() === "") {
+        currentInsert = "";
+        continue;
+      }
+      currentInsert += line.trim() + " ";
+      if (!line.trim().endsWith(";")) continue; // keep going until a statement is completed
+
+      const insertMatch = currentInsert.match(/^INSERT INTO `?(\w+)`? \(([^)]+)\) VALUES/i);
+      if (insertMatch && insertMatch[1] && insertMatch[2]) {
+        tableName = insertMatch[1];
+        columns = insertMatch[2].split(",").map((col) => col.trim().replace(/`/g, ""));
+
+        if (!tables[tableName]) {
+          tables[tableName] = { columns, rows: [] };
+        }
+
+        let valuesPart = currentInsert.split("VALUES")[1];
+        if (valuesPart) {
+          let valueGroups = valuesPart
+            .split(/\),\s?\(/)
+            .map((row) => row.trim().replace(/^\(/, "").replace(/\);?$/, "").split(",").map(cleanValue));
+          tables[tableName]!.rows.push(...valueGroups);
+        }
+
+        currentInsert = "";
+      }
+    }
+  } catch (e) {
+    console.error(e);
+    console.log(chalk.red("Error parsing SQL dump"));
+    return;
+  }
+  console.log(chalk.green("SQL dump parsed successfully!"));
+  for (const [table, { columns, rows }] of Object.entries(tables)) {
+    try {
+      const csvWriter = createObjectCsvWriter({
+        path: join(OUTPUT_DIR, `${table}.csv`),
+        header: columns.map((col) => ({ id: col, title: col }))
+      });
+
+      const records = rows.map((row) =>
+        // create a hash of column name to value for each row
+        row.reduce(
+          (acc, val, i) => {
+            if (!columns[i]) return acc;
+            acc[columns[i]!] = val;
+            return acc;
+          },
+          {} as Record<string, string | null>
+        )
+      );
+
+      await csvWriter.writeRecords(records);
+      console.log(`Exported: ` + chalk.green(`${table}.csv`));
+    } catch (e) {
+      console.error(e);
+      console.log(chalk.yellow(`Error exporting ${table} to CSV`));
+    }
+  }
+
+  console.log(chalk.green("✅ All tables exported successfully!"));
+}
+
+convertSQLDumpToCSV(DUMP_FILE);

--- a/server/src/london-db/dump-to-csv.ts
+++ b/server/src/london-db/dump-to-csv.ts
@@ -85,8 +85,14 @@ async function convertSQLDumpToCSV(dumpFile: string) {
     }
   }
 
-  // write the schemas
-  writeFileSync(join(OUTPUT_DIR, "kysely_schema.ts"), schemas.join("\n\n"));
+  try {
+    // write the schemas
+    writeFileSync(join(OUTPUT_DIR, "kysely_schema.ts"), schemas.join("\n\n"));
+    console.log(`Exported: ` + chalk.green(`kysely_schema.ts`));
+  } catch (e) {
+    console.error(e);
+    console.log(chalk.yellow(`Error exporting schemas to kysely_schema.ts`));
+  }
 
   console.log(chalk.green("✅ All tables exported successfully!"));
 }

--- a/server/src/london-db/dump-to-csv.ts
+++ b/server/src/london-db/dump-to-csv.ts
@@ -1,11 +1,13 @@
 import * as readline from "readline";
 import { createObjectCsvWriter } from "csv-writer";
-import { createReadStream, existsSync, mkdirSync } from "fs";
+import { createReadStream, existsSync, mkdirSync, writeFileSync } from "fs";
 import chalk from "chalk";
 import { join } from "path";
 
 const DUMP_FILE = join("db", "london", "london.sql");
 const OUTPUT_DIR = join("db", "london", "output_csvs");
+
+const tableRegex = /CREATE TABLE `?(\w+)`? \(/;
 
 if (!existsSync(OUTPUT_DIR)) {
   mkdirSync(OUTPUT_DIR);
@@ -21,8 +23,9 @@ async function convertSQLDumpToCSV(dumpFile: string) {
   const fileStream = createReadStream(dumpFile);
   const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
 
-  let tables: Record<string, { columns: string[]; rows: (string | null)[][] }> = {};
-  let currentInsert = "";
+  const tables: Record<string, { columns: string[]; rows: (string | null)[][] }> = {};
+  const schemas: string[] = [];
+  let currentLine = "";
   let tableName = "";
   let columns: string[] = [];
 
@@ -30,13 +33,19 @@ async function convertSQLDumpToCSV(dumpFile: string) {
     for await (const line of rl) {
       // statements shouln't have empty lines
       if (line.trim() === "") {
-        currentInsert = "";
+        currentLine = "";
         continue;
       }
-      currentInsert += line.trim() + " ";
+      currentLine += line.trim() + " ";
       if (!line.trim().endsWith(";")) continue; // keep going until a statement is completed
 
-      const insertMatch = currentInsert.match(/^INSERT INTO `?(\w+)`? \(([^)]+)\) VALUES/i);
+      if (tableRegex.test(currentLine)) {
+        const schema = processSchema(currentLine);
+        currentLine = "";
+        if (schema) schemas.push(schema);
+        continue;
+      }
+      const insertMatch = currentLine.match(/^INSERT INTO `?(\w+)`? \(([^)]+)\) VALUES/i);
       if (insertMatch && insertMatch[1] && insertMatch[2]) {
         tableName = insertMatch[1];
         columns = insertMatch[2].split(",").map((col) => col.trim().replace(/`/g, ""));
@@ -45,7 +54,7 @@ async function convertSQLDumpToCSV(dumpFile: string) {
           tables[tableName] = { columns, rows: [] };
         }
 
-        let valuesPart = currentInsert.split("VALUES")[1];
+        let valuesPart = currentLine.split("VALUES")[1];
         if (valuesPart) {
           let valueGroups = valuesPart
             .split(/\),\s?\(/)
@@ -53,7 +62,7 @@ async function convertSQLDumpToCSV(dumpFile: string) {
           tables[tableName]!.rows.push(...valueGroups);
         }
 
-        currentInsert = "";
+        currentLine = "";
       }
     }
   } catch (e) {
@@ -62,6 +71,8 @@ async function convertSQLDumpToCSV(dumpFile: string) {
     return;
   }
   console.log(chalk.green("SQL dump parsed successfully!"));
+
+  // write the csv
   for (const [table, { columns, rows }] of Object.entries(tables)) {
     try {
       const csvWriter = createObjectCsvWriter({
@@ -89,7 +100,90 @@ async function convertSQLDumpToCSV(dumpFile: string) {
     }
   }
 
+  // write the schemas
+  writeFileSync(join(OUTPUT_DIR, "kysely_schema.ts"), schemas.join("\n\n"));
+
   console.log(chalk.green("✅ All tables exported successfully!"));
 }
+
+// Define type mapping from MySQL to TypeScript
+const typeMapping: Record<string, string> = {
+  int: "number",
+  "int unsigned": "number",
+  varchar: "string",
+  mediumtext: "string",
+  text: "string",
+  longtext: "string",
+  datetime: "Date",
+  timestamp: "Date",
+  float: "number",
+  double: "number",
+  decimal: "number",
+  boolean: "boolean"
+};
+
+// Function to extract column definitions from CREATE TABLE
+function processSchema(statement: string) {
+  const cleanLine = statement.trim();
+  let tableName = "";
+  const columns: string[] = [];
+  const interfaceLines: string[] = [];
+  const uniqueConstraints: string[] = [];
+  const tableMatch = cleanLine.match(tableRegex);
+  if (tableMatch && tableMatch[1]) {
+    tableName = tableMatch[1];
+  } else {
+    return;
+  }
+  const columnRegex = /`(\w+)` (\w+)(\([\d,]+\))?( unsigned)?( NOT NULL)?( DEFAULT ([^,]+))?/g;
+  let columnMatch;
+  while ((columnMatch = columnRegex.exec(cleanLine)) !== null) {
+    if (columnMatch) {
+      let [, columnName, type, size, unsigned, notNull, , defaultValue] = columnMatch;
+      if (columnName && type) {
+        const tsColumnName = /^\d/.test(columnName) ? `"${columnName}"` : columnName;
+        let tsType = "string";
+        let mappedType = typeMapping[type.toLowerCase()];
+        if (mappedType) {
+          tsType = mappedType;
+        }
+        if (!notNull) {
+          tsType += " | null";
+        }
+        columns.push(tsColumnName);
+        interfaceLines.push(
+          `  ${tsColumnName}: ${tsType}; // ${type}${size || ""}${unsigned || ""}${notNull || ""}${defaultValue ? " DEFAULT " + defaultValue : ""}`
+        );
+      }
+    }
+  }
+  const uniqueKeyRegex = /UNIQUE KEY `?(\w+)`? \(([^)]+)\)/g;
+  let uniqueMatch;
+  while ((uniqueMatch = uniqueKeyRegex.exec(cleanLine)) !== null) {
+    if (uniqueMatch[2]) {
+      const uniqueColumns = uniqueMatch[2].split(",").map((col) => col.trim().replace(/`/g, ""));
+      uniqueConstraints.push(`  UNIQUE: [${uniqueColumns.map((col) => `"${col}"`).join(", ")}],`);
+    }
+  }
+  const primaryKeyRegex = /PRIMARY KEY \(([^)]+)\)/;
+  if (primaryKeyRegex.test(cleanLine)) {
+    const primaryKeyColumns = cleanLine.match(primaryKeyRegex);
+    if (primaryKeyColumns && primaryKeyColumns[1]) {
+      const primaryColumns = primaryKeyColumns[1].split(",").map((col) => col.trim().replace(/`/g, ""));
+      uniqueConstraints.push(`  PRIMARY KEY: [${primaryColumns.map((col) => `"${col}"`).join(", ")}],`);
+    }
+  }
+
+  if (tableName && columns.length > 0) {
+    const unique =
+      uniqueConstraints.length > 0 ? uniqueConstraints.map((constraint) => `// ${constraint}`).join("\n") : "";
+    const kyselySchema = `${unique}\nexport interface ${tableName} {\n${interfaceLines.join("\n")}\n}`;
+    return kyselySchema;
+  }
+  return "";
+}
+
+// Run the script
+processSchema(DUMP_FILE); // Replace with your actual SQL file
 
 convertSQLDumpToCSV(DUMP_FILE);

--- a/server/src/london-db/london-database.ts
+++ b/server/src/london-db/london-database.ts
@@ -18,6 +18,19 @@ export interface LondonDatabase {
 export function isLondonDatabaseType(key: string): boolean {
   return ["CPdinos", "CPdinos_icons", "CPdinos_images", "CPdinos_reflinks", "CPdinos_refs"].includes(key);
 }
+export function isLondonDatabaseKey(key: string): key is LondonDatabaseKey {
+  return ["cpdinos", "cpdinosIcons", "cpdinosImages", "cpdinosReflinks", "cpdinosRefs"].includes(key);
+}
+export function assertLondonDatabaseKey(key: string): asserts key is LondonDatabaseKey {
+  if (!isLondonDatabaseKey(key)) {
+    throw new Error(`Invalid London database key: ${key}`);
+  }
+}
+export function toCamelCase(str: string): string {
+  return str
+    .toLowerCase() // Convert everything to lowercase
+    .replace(/[^a-zA-Z0-9]+(.)/g, (match, char) => char.toUpperCase()); // Remove non-alphanumeric & capitalize next letter
+}
 // get the table names
 export type LondonDatabaseKey = keyof LondonDatabase;
 
@@ -115,10 +128,11 @@ export async function initializeLondonDatabase() {
     .addColumn("search_age", "text", (col) => col.defaultTo(null))
     .addColumn("rating", "real", (col) => col.defaultTo(null))
     .addColumn("source", "text", (col) => col.defaultTo(null))
+    .addColumn("source-old", "text", (col) => col.defaultTo(null))
     .addColumn("source_refno", "integer", (col) => col.defaultTo(null))
     .addColumn("notes", "text", (col) => col.defaultTo(null))
     .addColumn("lat_long", "text", (col) => col.defaultTo(null))
-    .addColumn("latitute", "real", (col) => col.defaultTo(null))
+    .addColumn("latitude", "real", (col) => col.defaultTo(null))
     .addColumn("longitude", "real", (col) => col.defaultTo(null))
     .addColumn("water_depth", "text", (col) => col.defaultTo(null))
     .addColumn("collection_details", "text", (col) => col.defaultTo(null))

--- a/server/src/london-db/london-database.ts
+++ b/server/src/london-db/london-database.ts
@@ -1,0 +1,172 @@
+import { access, mkdir } from "fs/promises";
+import { Kysely, SqliteDialect } from "kysely";
+import { CPdinos, CPdinos_icons, CPdinos_images, CPdinos_reflinks, CPdinos_refs } from "./types";
+import BetterSqlite3 from "better-sqlite3";
+import { join } from "path";
+import { exec } from "child_process";
+
+export interface LondonDatabase {
+    cpdinos: CPdinos;
+    cpdinosIcons: CPdinos_icons;
+    cpdinosImages: CPdinos_images;
+    cpdinosReflinks: CPdinos_reflinks;
+    cpdinosRefs: CPdinos_refs;
+}
+
+export function isLondonDatabaseType(key: string): boolean {
+    return ["CPdinos", "CPdinos_icons", "CPdinos_images", "CPdinos_reflinks", "CPdinos_refs"].includes(key);
+}
+// get the table names
+export type LondonDatabaseKey = keyof LondonDatabase;
+
+const londonDBFilePath = join("db", "london", "london.db");
+const londonDBDir = join("db", "london");
+
+export let londonDb: Kysely<LondonDatabase>;
+
+export async function initializeLondonDatabase() {
+    try {
+        await access(londonDBDir);
+    } catch (e) {
+        if ((e as any).code === "ENOENT") {
+            console.log("London database directory does not exist. Creating it now...");
+            await mkdir(londonDBDir, { recursive: true });
+        }
+    }
+    londonDb = new Kysely<LondonDatabase>({
+        dialect: new SqliteDialect({
+            database: new BetterSqlite3(londonDBFilePath),
+        })
+    });
+    await londonDb.schema.createTable("cpdinos").ifNotExists()
+    .addColumn("id", "integer", (col) => col.primaryKey().notNull())
+    .addColumn("Taxon", "text", (col) => col.unique())
+    .addColumn("citation", "text", (col) => col.defaultTo(null))
+    .addColumn("basionym", "text", (col) => col.defaultTo(""))
+    .addColumn("synonyms", "text", (col) => col.defaultTo(null))
+    .addColumn("type_species", "text", (col) => col.defaultTo(null))
+    .addColumn("tax_rank", "text", (col) => col.defaultTo(null))
+    .addColumn("tax_rank_sorter", "integer", (col) => col.defaultTo(null))
+    .addColumn("weight", "integer", (col) => col.defaultTo(0))
+    .addColumn("EURA_number", "text", (col) => col.defaultTo(null))
+    .addColumn("diagnosis", "text", (col) => col.defaultTo(null))
+    .addColumn("FCPD_weblink", "text", (col) => col.defaultTo(null))
+    .addColumn("3D_scanning", "text", (col) => col.defaultTo(null))
+    .addColumn("strat_notes", "text", (col) => col.defaultTo(null))
+    .addColumn("lad_text", "text", (col) => col.defaultTo(null))
+    .addColumn("fad_text", "text", (col) => col.defaultTo(null))
+    .addColumn("Age_Ma", "integer", (col) => col.defaultTo(null))
+    .addColumn("Subject", "text", (col) => col.defaultTo(null))
+    .addColumn("Construction", "text", (col) => col.defaultTo(null))
+    .addColumn("Conservation", "text", (col) => col.defaultTo(null))
+    .addColumn("Cons_summary", "text", (col) => col.defaultTo(null))
+    .addColumn("review2022", "text", (col) => col.defaultTo(null))
+    .addColumn("review2023", "text", (col) => col.defaultTo(null))
+    .addColumn("refs", "text", (col) => col.defaultTo(null))
+    .addColumn("refs_linked", "text", (col) => col.defaultTo(null))
+    .addColumn("Parent", "text", (col) => col.defaultTo(null))
+    .addColumn("detached_from", "text", (col) => col.defaultTo(null))
+    .addColumn("detached_from_id", "integer", (col) => col.defaultTo(null))
+    .addColumn("table_header", "text", (col) => col.defaultTo(null))
+    .addColumn("table_caption", "text", (col) => col.defaultTo(null))
+    .addColumn("path", "text", (col) => col.defaultTo(null))
+    .addColumn("path_flag", "text", (col) => col.defaultTo(null))
+    .addColumn("last_edit", "text", (col) => col.defaultTo(null))
+    .execute();
+
+    await londonDb.schema.createTable("cpdinosIcons").ifNotExists()
+    .addColumn("file_name", "text", (col) => col.defaultTo('').notNull())
+    .addColumn("file_module", "text", (col) => col.defaultTo(null))
+    .addColumn("taxon", "text", (col) => col.defaultTo("").notNull())
+    .addColumn("module", "text", (col) => col.defaultTo("").notNull())
+    .addColumn("rating", "integer", (col) => col.defaultTo(null))
+    .addPrimaryKeyConstraint("cpdinosIconsPrimaryKey", ["file_name", "taxon", "module"])
+    .execute();
+
+    await londonDb.schema.createTable("cpdinosImages").ifNotExists()
+    .addColumn("file_name", "text", (col) => col.defaultTo('').notNull().primaryKey())
+    .addColumn("image_type", "text", (col) => col.defaultTo(null))
+    .addColumn("species_f", "text", (col) => col.defaultTo(null))
+    .addColumn("taxon_id", "integer", (col) => col.defaultTo(null))
+    .addColumn("caption", "text", (col) => col.defaultTo(null))
+    .addColumn("type_status", "text", (col) => col.defaultTo(null))
+    .addColumn("location", "text", (col) => col.defaultTo(null))
+    .addColumn("sample", "text", (col) => col.defaultTo(null))
+    .addColumn("geol_age", "text", (col) => col.defaultTo(null))
+    .addColumn("search_age", "text", (col) => col.defaultTo(null))
+    .addColumn("rating", "real", (col) => col.defaultTo(null))
+    .addColumn("source", "text", (col) => col.defaultTo(null))
+    .addColumn("source_refno", "integer", (col) => col.defaultTo(null))
+    .addColumn("notes", "text", (col) => col.defaultTo(null))
+    .addColumn("lat_long", "text", (col) => col.defaultTo(null))
+    .addColumn("latitute", "real", (col) => col.defaultTo(null))
+    .addColumn("longitude", "real", (col) => col.defaultTo(null))
+    .addColumn("water_depth", "text", (col) => col.defaultTo(null))
+    .addColumn("collection_details", "text", (col) => col.defaultTo(null))
+    .addColumn("path", "text", (col) => col.defaultTo(null))
+    .addColumn("path_flag", "text", (col) => col.defaultTo(null))
+    .addColumn("width", "integer", (col) => col.defaultTo(null))
+    .addColumn("height", "text", (col) => col.defaultTo(null))
+    .addColumn("capture_date", "text", (col) => col.defaultTo(null))
+    .addColumn("display_field", "text", (col) => col.defaultTo(null))
+    .addColumn("uploaded", "text", (col) => col.defaultTo(null))
+    .execute();
+
+    await londonDb.schema.createTable("cpdinosReflinks").ifNotExists()
+    .addColumn("id", "integer", (col) => col.primaryKey().notNull())
+    .addColumn("refno", "integer", (col) => col.defaultTo(null))
+    .addColumn("taxon_id", "integer", (col) => col.defaultTo(null))
+    .addColumn("category", "text", (col) => col.defaultTo(''))
+    .execute();
+
+    await londonDb.schema.createTable("cpdinosRefs").ifNotExists()
+    .addColumn("refno", "integer", (col) => col.primaryKey().notNull())
+    .addColumn("abv_ref", "text", (col) => col.defaultTo(null))
+    .addColumn("authors", "text", (col) => col.defaultTo(null))
+    .addColumn("year", "integer", (col) => col.defaultTo(null))
+    .addColumn("disambig", "text", (col) => col.defaultTo(null))
+    .addColumn("title", "text", (col) => col.defaultTo(null))
+    .addColumn("journal", "text", (col) => col.defaultTo(null))
+    .addColumn("journalid", "integer", (col) => col.defaultTo(null))
+    .addColumn("series", "text", (col) => col.defaultTo(null))
+    .addColumn("vol", "text", (col) => col.defaultTo(null))
+    .addColumn("part", "text", (col) => col.defaultTo(null))
+    .addColumn("firstP", "text", (col) => col.defaultTo(null))
+    .addColumn("lastP", "text", (col) => col.defaultTo(null))
+    .addColumn("publisher", "text", (col) => col.defaultTo(''))
+    .addColumn("notes", "text", (col) => col.defaultTo(null))
+    .addColumn("language", "text", (col) => col.defaultTo(null))
+    .addColumn("editors", "text", (col) => col.defaultTo(null))
+    .addColumn("vol_title", "text", (col) => col.defaultTo(null))
+    .addColumn("ref_type", "text", (col) => col.defaultTo(null))
+    .addColumn("DOI", "text", (col) => col.defaultTo(null))
+    .addColumn("pdf_name", "text", (col) => col.defaultTo(null))
+    .addColumn("pdf_path", "text", (col) => col.defaultTo(null))
+    .addColumn("pdf_size", "integer", (col) => col.defaultTo(null))
+    .addColumn("pdf_shareable", "text", (col) => col.defaultTo(null))
+    .addColumn("pdf_quality", "text", (col) => col.defaultTo(null))
+    .addColumn("pdf_upload_date", "text", (col) => col.defaultTo(null))
+    .addColumn("full_ref", "text", (col) => col.defaultTo(null))
+    .execute();
+
+    await new Promise<void>((resolve, reject) => {
+        exec("node dist/london-db/dump-to-csv.js", (err, stdout, stderr) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve();
+            }
+        })
+    });
+    await new Promise<void>((resolve, reject) => {
+        exec("node dist/london-db/csv-to-sqlite.js", (err, stdout, stderr) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve();
+            }
+        })
+    });
+}
+
+await initializeLondonDatabase();

--- a/server/src/london-db/london-database.ts
+++ b/server/src/london-db/london-database.ts
@@ -169,7 +169,7 @@ export async function initializeLondonDatabase() {
   await convertSQLDumpToCSV(sqlDump);
   console.log(chalk.green("London database CSVs exported successfully!"));
   await importAllTables();
-  console.log(chalk.green("London database imported successfully!"));
+  console.log(chalk.green("✅London database imported successfully!"));
 }
 
 await rm(londonDBFilePath).catch(() => {});

--- a/server/src/london-db/london-database.ts
+++ b/server/src/london-db/london-database.ts
@@ -1,38 +1,11 @@
 import { access, mkdir, rm } from "fs/promises";
 import { Kysely, SqliteDialect } from "kysely";
-import { CPdinos, CPdinos_icons, CPdinos_images, CPdinos_reflinks, CPdinos_refs } from "./types";
 import BetterSqlite3 from "better-sqlite3";
 import { join } from "path";
 import chalk from "chalk";
 import { convertSQLDumpToCSV } from "./dump-to-csv.js";
 import { importAllTables } from "./csv-to-sqlite.js";
-
-export interface LondonDatabase {
-  cpdinos: CPdinos;
-  cpdinosIcons: CPdinos_icons;
-  cpdinosImages: CPdinos_images;
-  cpdinosReflinks: CPdinos_reflinks;
-  cpdinosRefs: CPdinos_refs;
-}
-
-export function isLondonDatabaseType(key: string): boolean {
-  return ["CPdinos", "CPdinos_icons", "CPdinos_images", "CPdinos_reflinks", "CPdinos_refs"].includes(key);
-}
-export function isLondonDatabaseKey(key: string): key is LondonDatabaseKey {
-  return ["cpdinos", "cpdinosIcons", "cpdinosImages", "cpdinosReflinks", "cpdinosRefs"].includes(key);
-}
-export function assertLondonDatabaseKey(key: string): asserts key is LondonDatabaseKey {
-  if (!isLondonDatabaseKey(key)) {
-    throw new Error(`Invalid London database key: ${key}`);
-  }
-}
-export function toCamelCase(str: string): string {
-  return str
-    .toLowerCase() // Convert everything to lowercase
-    .replace(/[^a-zA-Z0-9]+(.)/g, (match, char) => char.toUpperCase()); // Remove non-alphanumeric & capitalize next letter
-}
-// get the table names
-export type LondonDatabaseKey = keyof LondonDatabase;
+import { LondonDatabase } from "../types";
 
 const londonDBFilePath = join("db", "london", "london.db");
 const londonDBDir = join("db", "london");
@@ -45,7 +18,7 @@ export async function initializeLondonDatabase() {
   try {
     await access(outputCSVDir);
   } catch (e) {
-    if ((e as any).code === "ENOENT") {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
       mkdir(outputCSVDir, { recursive: true });
     } else {
       throw e;
@@ -54,7 +27,7 @@ export async function initializeLondonDatabase() {
   try {
     await access(londonDBDir);
   } catch (e) {
-    if ((e as any).code === "ENOENT") {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
       console.log("London database directory does not exist. Creating it now...");
       await mkdir(londonDBDir, { recursive: true });
     }

--- a/server/src/london-db/types.ts
+++ b/server/src/london-db/types.ts
@@ -1,0 +1,115 @@
+//   UNIQUE: ["Taxon"],
+//   PRIMARY KEY: ["id"],
+export interface CPdinos {
+  id: number; // int unsigned NOT NULL
+  Taxon: string; // varchar(255) NOT NULL DEFAULT ''
+  citation: string | null; // varchar(255) DEFAULT NULL
+  basionym: string | null; // varchar(255) DEFAULT ''
+  synonyms: string | null; // varchar(255) DEFAULT NULL
+  type_species: string | null; // varchar(255) DEFAULT NULL
+  tax_rank: string | null; // varchar(255) DEFAULT NULL
+  tax_rank_sorter: number | null; // int DEFAULT NULL
+  weight: number | null; // int DEFAULT '0'
+  EURA_number: string | null; // varchar(255) DEFAULT NULL
+  diagnosis: string | null; // varchar(255) DEFAULT NULL
+  FCPD_weblink: string | null; // varchar(255) DEFAULT NULL
+  "3D_scanning": string | null; // varchar(255) DEFAULT NULL
+  strat_notes: string | null; // mediumtext
+  lad_text: string | null; // varchar(255) DEFAULT NULL
+  fad_text: string | null; // varchar(255) DEFAULT NULL
+  Age_Ma: number | null; // int DEFAULT NULL
+  Subject: string | null; // mediumtext
+  Construction: string | null; // mediumtext
+  Conservation: string | null; // mediumtext
+  Cons_summary: string | null; // mediumtext
+  review2022: string | null; // mediumtext
+  review2023: string | null; // mediumtext
+  refs: string | null; // varchar(255) DEFAULT NULL
+  refs_linked: string | null; // mediumtext
+  Parent: string | null; // varchar(255) DEFAULT NULL
+  detached_from: string | null; // varchar(255) DEFAULT NULL
+  detached_from_id: number | null; // int DEFAULT NULL
+  table_header: string | null; // varchar(255) DEFAULT NULL
+  table_caption: string | null; // varchar(255) DEFAULT NULL
+  path: string | null; // varchar(255) DEFAULT NULL
+  path_flag: string | null; // varchar(10) DEFAULT NULL
+  last_edit: string | null; // mediumtext
+}
+
+//   PRIMARY KEY: ["file_name", "taxon", "module"],
+export interface CPdinos_icons {
+  file_name: string; // varchar(255) NOT NULL DEFAULT ''
+  file_module: string | null; // varchar(25) DEFAULT NULL
+  taxon: string; // varchar(255) NOT NULL DEFAULT ''
+  module: string; // varchar(255) NOT NULL DEFAULT ''
+  rating: number | null; // int DEFAULT NULL
+}
+
+//   PRIMARY KEY: ["file_name"],
+export interface CPdinos_images {
+  file_name: string; // varchar(255) NOT NULL DEFAULT ''
+  image_type: string | null; // varchar(255) DEFAULT NULL
+  species_f: string | null; // varchar(255) DEFAULT NULL
+  taxon_id: number | null; // int DEFAULT NULL
+  caption: string | null; // mediumtext
+  type_status: string | null; // varchar(255) DEFAULT NULL
+  location: string | null; // varchar(255) DEFAULT NULL
+  sample: string | null; // varchar(255) DEFAULT NULL
+  geol_age: string | null; // varchar(255) DEFAULT NULL
+  search_age: string | null; // varchar(100) DEFAULT NULL
+  rating: number | null; // decimal(11,2) DEFAULT NULL
+  source: string | null; // varchar(125) DEFAULT NULL
+  source_refno: number | null; // int DEFAULT NULL
+  notes: string | null; // mediumtext
+  lat_long: string | null; // varchar(255) DEFAULT NULL
+  latitude: number | null; // float(10,6) DEFAULT NULL
+  longitude: number | null; // float(10,6) DEFAULT NULL
+  water_depth: string | null; // varchar(255) DEFAULT NULL
+  collection_details: string | null; // varchar(255) DEFAULT NULL
+  path: string | null; // varchar(255) DEFAULT NULL
+  path_flag: string | null; // varchar(255) DEFAULT NULL
+  width: number | null; // int DEFAULT NULL
+  height: string | null; // varchar(11) DEFAULT NULL
+  capture_date: string | null; // varchar(255) DEFAULT NULL
+  display_field: string | null; // varchar(50) DEFAULT NULL
+  uploaded: string | null; // varchar(255) DEFAULT NULL
+}
+
+//   PRIMARY KEY: ["id"],
+export interface CPdinos_reflinks {
+  id: number; // int unsigned NOT NULL
+  refno: number | null; // int DEFAULT NULL
+  taxon_id: number | null; // int DEFAULT NULL
+  category: string | null; // varchar(255) DEFAULT ''
+}
+
+//   PRIMARY KEY: ["refno"],
+export interface CPdinos_refs {
+  refno: number; // int NOT NULL
+  abv_ref: string | null; // varchar(255) DEFAULT NULL
+  authors: string | null; // mediumtext
+  year: number | null; // int DEFAULT NULL
+  disambig: string | null; // varchar(255) DEFAULT NULL
+  title: string | null; // mediumtext
+  journal: string | null; // varchar(255) DEFAULT NULL
+  journalid: number | null; // int DEFAULT NULL
+  series: string | null; // varchar(255) DEFAULT NULL
+  vol: string | null; // varchar(50) DEFAULT NULL
+  part: string | null; // varchar(50) DEFAULT NULL
+  firstP: string | null; // varchar(50) DEFAULT NULL
+  lastP: string | null; // varchar(50) DEFAULT NULL
+  publisher: string | null; // varchar(255) DEFAULT ''
+  notes: string | null; // mediumtext
+  language: string | null; // varchar(50) DEFAULT NULL
+  editors: string | null; // mediumtext
+  vol_title: string | null; // mediumtext
+  ref_type: string | null; // varchar(50) DEFAULT NULL
+  DOI: string | null; // varchar(255) DEFAULT NULL
+  pdf_name: string | null; // varchar(500) DEFAULT NULL
+  pdf_path: string | null; // varchar(500) DEFAULT NULL
+  pdf_size: number | null; // int DEFAULT NULL
+  pdf_shareable: string | null; // varchar(255) DEFAULT NULL
+  pdf_quality: string | null; // varchar(100) DEFAULT NULL
+  pdf_upload_date: string | null; // varchar(50) DEFAULT NULL
+  full_ref: string | null; // mediumtext
+}

--- a/server/src/london-db/types.ts
+++ b/server/src/london-db/types.ts
@@ -28,7 +28,7 @@ export interface CPdinos {
   refs_linked: string | null; // mediumtext
   Parent: string | null; // varchar(255) DEFAULT NULL
   detached_from: string | null; // varchar(255) DEFAULT NULL
-  detached_from_id: number | null; // int DEFAULT NULL
+  detached_from_id: string | null; // varchar(255) DEFAULT NULL
   table_header: string | null; // varchar(255) DEFAULT NULL
   table_caption: string | null; // varchar(255) DEFAULT NULL
   path: string | null; // varchar(255) DEFAULT NULL

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -136,12 +136,6 @@ export function assertLondonDatabaseKey(key: string): asserts key is LondonDatab
     throw new Error(`Invalid London database key: ${key}`);
   }
 }
-export function toCamelCase(str: string): string {
-  return str
-    .toLowerCase() // Convert everything to lowercase
-    .replace(/[^a-zA-Z0-9]+(.)/g, (match, char) => char.toUpperCase()); // Remove non-alphanumeric & capitalize next letter
-}
-// get the table names
 export type LondonDatabaseKey = keyof LondonDatabase;
 
 export function assertEmail(o: any): asserts o is Email {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,5 +1,6 @@
 import { throwError } from "@tsconline/shared";
 import { Generated, Insertable, Selectable, Updateable } from "kysely";
+import { CPdinos, CPdinos_icons, CPdinos_images, CPdinos_reflinks, CPdinos_refs } from "./london-db/types";
 
 export interface Database {
   users: UserTable;
@@ -115,6 +116,33 @@ export type FileMetadata = {
   lastUpdated: string;
   uuid: string;
 };
+
+export interface LondonDatabase {
+  cpdinos: CPdinos;
+  cpdinosIcons: CPdinos_icons;
+  cpdinosImages: CPdinos_images;
+  cpdinosReflinks: CPdinos_reflinks;
+  cpdinosRefs: CPdinos_refs;
+}
+
+export function isLondonDatabaseType(key: string): boolean {
+  return ["CPdinos", "CPdinos_icons", "CPdinos_images", "CPdinos_reflinks", "CPdinos_refs"].includes(key);
+}
+export function isLondonDatabaseKey(key: string): key is LondonDatabaseKey {
+  return ["cpdinos", "cpdinosIcons", "cpdinosImages", "cpdinosReflinks", "cpdinosRefs"].includes(key);
+}
+export function assertLondonDatabaseKey(key: string): asserts key is LondonDatabaseKey {
+  if (!isLondonDatabaseKey(key)) {
+    throw new Error(`Invalid London database key: ${key}`);
+  }
+}
+export function toCamelCase(str: string): string {
+  return str
+    .toLowerCase() // Convert everything to lowercase
+    .replace(/[^a-zA-Z0-9]+(.)/g, (match, char) => char.toUpperCase()); // Remove non-alphanumeric & capitalize next letter
+}
+// get the table names
+export type LondonDatabaseKey = keyof LondonDatabase;
 
 export function assertEmail(o: any): asserts o is Email {
   if (typeof o !== "object" || !o) throw "Email must be an object";

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -310,3 +310,8 @@ export function extractMetadataFromDatapack(datapack: Datapack) {
   assertDatapackMetadata(metadata);
   return metadata;
 }
+export const toCamelCase = (str: string): string => {
+  return str
+    .toLowerCase() // Convert everything to lowercase
+    .replace(/[^a-zA-Z0-9]+(.)/g, (match, char) => char.toUpperCase()); // Remove non-alphanumeric & capitalize next letter
+};

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -311,7 +311,5 @@ export function extractMetadataFromDatapack(datapack: Datapack) {
   return metadata;
 }
 export const toCamelCase = (str: string): string => {
-  return str
-    .toLowerCase() // Convert everything to lowercase
-    .replace(/[^a-zA-Z0-9]+(.)/g, (match, char) => char.toUpperCase()); // Remove non-alphanumeric & capitalize next letter
+  return str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (_, char) => char.toUpperCase());
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,6 +2621,7 @@ __metadata:
     better-sqlite3: "npm:^9.4.4"
     chalk: "npm:^5.3.0"
     cors: "npm:^2.8.5"
+    csv-writer: "npm:^1.6.0"
     dompurify: "npm:^3.1.3"
     dotenv: "npm:^16.4.5"
     fastify: "npm:^4.27.0"
@@ -5127,6 +5128,13 @@ __metadata:
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: f593cce41ff5ade23f44e77521e3a1bcc2c64107041e1bf6c3c32adc5187d0d60983292fda326154d20b01079e24931aa5b08e4467cc488b60bb1e7f6d478ade
+  languageName: node
+  linkType: hard
+
+"csv-writer@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "csv-writer@npm:1.6.0"
+  checksum: 01ae6eb0653ef823278ba89192146631c577a8d4f69eba82cb71b315b87852952d7e1fa1d693561f00f89fd4e99433e2a8e570394d0273b0214999a0607326da
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,6 +2621,7 @@ __metadata:
     better-sqlite3: "npm:^9.4.4"
     chalk: "npm:^5.3.0"
     cors: "npm:^2.8.5"
+    csv-parser: "npm:^3.2.0"
     csv-writer: "npm:^1.6.0"
     dompurify: "npm:^3.1.3"
     dotenv: "npm:^16.4.5"
@@ -5128,6 +5129,15 @@ __metadata:
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: f593cce41ff5ade23f44e77521e3a1bcc2c64107041e1bf6c3c32adc5187d0d60983292fda326154d20b01079e24931aa5b08e4467cc488b60bb1e7f6d478ade
+  languageName: node
+  linkType: hard
+
+"csv-parser@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "csv-parser@npm:3.2.0"
+  bin:
+    csv-parser: bin/csv-parser
+  checksum: 09a63fa8b6e9c0b75cf5a12cc53abecbe696b8b6ebfdf7ddb0a1e3a97e8f3f19a77d2ffa434810958fd4841682ea8d1a9c08f6fb84f1c0ec393cecdb72131735
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* mySql -> csv -> sql lite
* hard coding the kysley table
* i create a dummy `kysley-schema.ts` file that gets created on mySql->csv to help us with that conversion. i don't think we want to necessarily have the auto generated schema from my code pushed to the main so i just copied it so it's more or less manual but exists in two places (only one is imported and in `src`). if it ever changes or gets migrated we would just copy it again. i can see both ways but it feels like the compiled js files if we keep a generated file on the repo and people accidentally change it in their repos if they didn't update their sql dump or something
* not really sure when to do the conversion, if you have ideas let me know ie i'm thinking the same as our database, but would we just not update it if it exists -> haven't thought about yet
* `yarn london` lol for now it's just a command and is not imported in the normal flow of the website since it doesn't affect it
* tbh the fields are not like he described it in the powerpoint so i'm not really sure what to do with this, i've emailed him to clarify
* wish i could use a library, but none specialize in going dump -> sqllite so i coded them myself. csv -> sqllite is straightforward, i can handle errors and there shouldn't be much variation. filp side, dump -> csv is probably better done by a library because there are edge cases i probably haven't caught. probably really minor but i couldn't find a library so i settled on this. lmk anything u find


<img width="672" alt="Screenshot 2025-02-09 at 11 34 53 PM" src="https://github.com/user-attachments/assets/558a3868-6430-4562-b79f-4e7109a315be" />
