### PR TITLE
added refreshing to datapack profile

### DIFF
--- a/app/src/DatapackProfile.tsx
+++ b/app/src/DatapackProfile.tsx
@@ -114,19 +114,6 @@ export const DatapackProfile = observer(() => {
   };
   useEffect(() => {
     const controller = new AbortController();
-    if (state.user.isAdmin) {
-      loadRecaptcha().then(async () => {
-        if (state.user.isAdmin) {
-          await actions.adminFetchPrivateOfficialDatapacks({ signal: controller.signal });
-        }
-      });
-    }
-    return () => {
-      controller.abort();
-    };
-  }, [state.user.isAdmin]);
-  useEffect(() => {
-    const controller = new AbortController();
     initializePage(controller).catch((e) => {
       console.error("Error fetching datapack", e);
       displayServerError(e, ErrorCodes.UNABLE_TO_FETCH_DATAPACKS, ErrorMessages[ErrorCodes.UNABLE_TO_FETCH_DATAPACKS]);

--- a/app/src/DatapackProfile.tsx
+++ b/app/src/DatapackProfile.tsx
@@ -101,8 +101,9 @@ export const DatapackProfile = observer(() => {
       setIsMetadataInitialized(true);
     }
   };
+  const metadataLoading = isMetadataLoading(state.skeletonStates);
   const initializePage = async (controller: AbortController) => {
-    if (!datapack && isMetadataLoading(state.skeletonStates)) {
+    if (!datapack && metadataLoading) {
       setLoading(true);
       return;
     }
@@ -132,7 +133,7 @@ export const DatapackProfile = observer(() => {
         controller.abort();
       }
     };
-  }, [queryType, id, isMetadataInitialized, isMetadataLoading(state.skeletonStates)]);
+  }, [queryType, id, isMetadataInitialized, metadataLoading]);
   useEffect(() => {
     return () => {
       actions.setDatapackProfilePageEditMode(false);

--- a/app/src/DatapackProfile.tsx
+++ b/app/src/DatapackProfile.tsx
@@ -122,9 +122,6 @@ export const DatapackProfile = observer(() => {
       });
     }
     return () => {
-      if (state.user.isAdmin) {
-        removeRecaptcha();
-      }
       controller.abort();
     };
   }, [state.user.isAdmin]);

--- a/app/src/DatapackProfile.tsx
+++ b/app/src/DatapackProfile.tsx
@@ -102,7 +102,7 @@ export const DatapackProfile = observer(() => {
     }
   };
   const initializePage = async (controller: AbortController) => {
-    if (!datapack && isMetadataLoading()) {
+    if (!datapack && isMetadataLoading(state.skeletonStates)) {
       setLoading(true);
       return;
     }
@@ -132,7 +132,7 @@ export const DatapackProfile = observer(() => {
         controller.abort();
       }
     };
-  }, [queryType, id, isMetadataInitialized, isMetadataLoading()]);
+  }, [queryType, id, isMetadataInitialized, isMetadataLoading(state.skeletonStates)]);
   useEffect(() => {
     return () => {
       actions.setDatapackProfilePageEditMode(false);

--- a/app/src/DatapackProfile.tsx
+++ b/app/src/DatapackProfile.tsx
@@ -107,11 +107,14 @@ export const DatapackProfile = observer(() => {
       setLoading(true);
       return;
     }
-    if (shouldLoadRecaptcha) {
-      await loadRecaptcha();
+    try {
+      if (shouldLoadRecaptcha) {
+        await loadRecaptcha();
+      }
+      await initializeDatapack(controller);
+    } finally {
+      setLoading(false);
     }
-    await initializeDatapack(controller);
-    setLoading(false);
   };
   useEffect(() => {
     const controller = new AbortController();

--- a/app/src/Presets.tsx
+++ b/app/src/Presets.tsx
@@ -84,7 +84,7 @@ const TSCPresetHighlights = observer(function TSCPresetHighlights({
                             continue;
                           }
                           actions.setLoadingDatapacks(true);
-                          const fetchedDatapack = await actions.fetchOfficialDatapack(dp.name);
+                          const fetchedDatapack = await actions.fetchPublicOfficialDatapack(dp.name);
                           if (!fetchedDatapack) {
                             return;
                           }

--- a/app/src/settings_tabs/Datapack.tsx
+++ b/app/src/settings_tabs/Datapack.tsx
@@ -41,7 +41,8 @@ export const Datapacks = observer(function Datapacks() {
   const navigate = useNavigate();
   const shouldLoadRecaptcha =
     state.isLoggedIn &&
-    (state.user.isAdmin ||
+    (formOpen ||
+      state.user.isAdmin ||
       state.datapackMetadata.some((dp) => isWorkshopDatapack(dp) || (isUserDatapack(dp) && !dp.isPublic)));
   useEffect(() => {
     const controller = new AbortController();

--- a/app/src/settings_tabs/Datapack.tsx
+++ b/app/src/settings_tabs/Datapack.tsx
@@ -45,19 +45,9 @@ export const Datapacks = observer(function Datapacks() {
       state.user.isAdmin ||
       state.datapackMetadata.some((dp) => isWorkshopDatapack(dp) || (isUserDatapack(dp) && !dp.isPublic)));
   useEffect(() => {
-    const controller = new AbortController();
-    if (shouldLoadRecaptcha) {
-      loadRecaptcha().then(async () => {
-        if (state.user.isAdmin) {
-          await actions.adminFetchPrivateOfficialDatapacks({ signal: controller.signal });
-        }
-      });
-    }
+    if (shouldLoadRecaptcha) loadRecaptcha();
     return () => {
-      if (shouldLoadRecaptcha) {
-        removeRecaptcha();
-      }
-      controller.abort();
+      if (shouldLoadRecaptcha) removeRecaptcha();
     };
   }, [shouldLoadRecaptcha]);
 

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -112,7 +112,7 @@ export const fetchPublicOfficialDatapack = action(
   "fetchOfficialDatapack",
   async (datapack: string, options?: { signal?: AbortSignal }) => {
     try {
-      const response = await fetcher(`/server/datapack/${encodeURIComponent(datapack)}`, options);
+      const response = await fetcher(`/official/datapack/${encodeURIComponent(datapack)}`, options);
       const data = await response.json();
       if (response.ok) {
         assertOfficialDatapack(data);
@@ -955,6 +955,7 @@ export const logout = action("logout", async () => {
 export const sessionCheck = action("sessionCheck", async () => {
   const cookieConsentValue = localStorage.getItem("cookieConsent");
   state.cookieConsent = cookieConsentValue !== null ? cookieConsentValue === "true" : null;
+  let fetchStarted = false;
   try {
     const response = await fetcher("/auth/session-check", {
       method: "POST",
@@ -965,6 +966,7 @@ export const sessionCheck = action("sessionCheck", async () => {
       setIsLoggedIn(true);
       assertSharedUser(data.user);
       setUser(data.user);
+      fetchStarted = true;
       if (data.user.isAdmin) {
         adminFetchPrivateOfficialDatapacksMetadata();
       } else {
@@ -973,11 +975,14 @@ export const sessionCheck = action("sessionCheck", async () => {
       fetchUserDatapacksMetadata();
     } else {
       setIsLoggedIn(false);
-      setPrivateOfficialDatapacksLoading(false);
-      setPrivateUserDatapacksLoading(false);
     }
   } catch (error) {
     console.error("Failed to check session:", error);
+  } finally {
+    if (!fetchStarted) {
+      setPrivateOfficialDatapacksLoading(false);
+      setPrivateUserDatapacksLoading(false);
+    }
   }
 });
 

--- a/app/src/state/actions/general-actions.ts
+++ b/app/src/state/actions/general-actions.ts
@@ -198,7 +198,7 @@ export const fetchAllPublicDatapacksMetadata = action("fetchAllPublicDatapacksMe
     console.error(e);
   } finally {
     setPublicOfficialDatapacksLoading(false);
-    setPublicDatapacksLoading(false);
+    setPublicUserDatapacksLoading(false);
   }
 });
 
@@ -957,9 +957,12 @@ export const sessionCheck = action("sessionCheck", async () => {
       setIsLoggedIn(true);
       assertSharedUser(data.user);
       setUser(data.user);
+      if (!data.user.isAdmin) setPrivateOfficialDatapacksLoading(false);
       fetchUserDatapacksMetadata();
     } else {
       setIsLoggedIn(false);
+      setPrivateOfficialDatapacksLoading(false);
+      setPrivateUserDatapacksLoading(false);
     }
   } catch (error) {
     console.error("Failed to check session:", error);
@@ -1264,7 +1267,7 @@ export const setPublicOfficialDatapacksLoading = action((fetching: boolean) => {
 export const setPrivateOfficialDatapacksLoading = action((fetching: boolean) => {
   state.skeletonStates.privateOfficialDatapacksLoading = fetching;
 });
-export const setPublicDatapacksLoading = action((fetching: boolean) => {
+export const setPublicUserDatapacksLoading = action((fetching: boolean) => {
   state.skeletonStates.publicUserDatapacksLoading = fetching;
 });
 export const setPrivateUserDatapacksLoading = action((fetching: boolean) => {

--- a/app/src/state/non-action-util.ts
+++ b/app/src/state/non-action-util.ts
@@ -10,7 +10,24 @@ import {
 import { devSafeUrl } from "../util";
 import dayjs from "dayjs";
 import { Workshop } from "../Workshops";
+import { state } from "./state";
 
+export function isMetadataLoading() {
+  const {
+    skeletonStates: {
+      publicOfficialDatapacksLoading,
+      privateOfficialDatapacksLoading,
+      publicUserDatapacksLoading,
+      privateUserDatapacksLoading
+    }
+  } = state;
+  return (
+    publicOfficialDatapacksLoading ||
+    privateOfficialDatapacksLoading ||
+    publicUserDatapacksLoading ||
+    privateUserDatapacksLoading
+  );
+}
 export function canEditDatapack(datapack: DatapackUniqueIdentifier, user: SharedUser) {
   return (
     isOwnedByUser(datapack, user.uuid) ||

--- a/app/src/state/non-action-util.ts
+++ b/app/src/state/non-action-util.ts
@@ -10,17 +10,15 @@ import {
 import { devSafeUrl } from "../util";
 import dayjs from "dayjs";
 import { Workshop } from "../Workshops";
-import { state } from "./state";
+import { State } from "./state";
 
-export function isMetadataLoading() {
+export function isMetadataLoading(skeletonStates: State["skeletonStates"]) {
   const {
-    skeletonStates: {
-      publicOfficialDatapacksLoading,
-      privateOfficialDatapacksLoading,
-      publicUserDatapacksLoading,
-      privateUserDatapacksLoading
-    }
-  } = state;
+    publicOfficialDatapacksLoading,
+    privateOfficialDatapacksLoading,
+    publicUserDatapacksLoading,
+    privateUserDatapacksLoading
+  } = skeletonStates;
   return (
     publicOfficialDatapacksLoading ||
     privateOfficialDatapacksLoading ||

--- a/server/__tests__/user-routes.test.ts
+++ b/server/__tests__/user-routes.test.ts
@@ -265,26 +265,26 @@ describe("get a single user datapack", () => {
     expect(fetchUserDatapack).not.toHaveBeenCalled();
     expect(await response.json()).toEqual({ error: "Database error" });
   });
-  it("should reply 500 if an error occurred in fetchUserDatapack", async () => {
+  it("should reply 404 if an error occurred in fetchUserDatapack", async () => {
     fetchUserDatapack.mockRejectedValueOnce(new Error("Unknown error"));
     const response = await app.inject({
       method: "GET",
       url: `/user/datapack/${filename}`,
       headers
     });
-    expect(response.statusCode).toBe(500);
+    expect(response.statusCode).toBe(404);
     expect(findUser).toHaveBeenCalledTimes(2);
     expect(fetchUserDatapack).toHaveBeenCalledOnce();
     expect(await response.json()).toEqual({ error: "Datapack does not exist or cannot be found" });
   });
-  it("should reply 500 if no metadata is found", async () => {
+  it("should reply 404 if no metadata is found", async () => {
     fetchUserDatapack.mockResolvedValueOnce("" as unknown as shared.Datapack);
     const response = await app.inject({
       method: "GET",
       url: `/user/datapack/${filename}`,
       headers
     });
-    expect(response.statusCode).toBe(500);
+    expect(response.statusCode).toBe(404);
     expect(findUser).toHaveBeenCalledTimes(2);
     expect(fetchUserDatapack).toHaveBeenCalledOnce();
     expect(await response.json()).toEqual({ error: "Datapack does not exist or cannot be found" });

--- a/server/src/admin/admin-auth.ts
+++ b/server/src/admin/admin-auth.ts
@@ -16,7 +16,8 @@ import {
   adminEditDatapackPriorities,
   adminAddOfficialDatapackToWorkshop,
   adminEditDatapackMetadata,
-  adminUploadDatapack
+  adminUploadDatapack,
+  adminFetchSingleOfficialDatapack
 } from "./admin-routes.js";
 import { checkRecaptchaToken } from "../verify.js";
 import { googleRecaptchaBotThreshold } from "../routes/login-routes.js";
@@ -72,6 +73,13 @@ export const adminRoutes = async (fastify: FastifyInstance, _options: RegisterOp
   const moderateRateLimit = {
     max: 30,
     timeWindow: "1 minute"
+  };
+  const adminFetchSingleOfficialDatapackParams = {
+    type: "object",
+    properties: {
+      datapackTitle: { type: "string" }
+    },
+    required: ["datapackTitle"]
   };
   const adminCreateUserBody = {
     type: "object",
@@ -165,6 +173,11 @@ export const adminRoutes = async (fastify: FastifyInstance, _options: RegisterOp
     "/official/datapacks/private",
     { config: { rateLimit: looseRateLimit } },
     fetchAllPrivateOfficialDatapacks
+  );
+  fastify.get(
+    "/official/datapack/:datapackTitle",
+    { schema: { params: adminFetchSingleOfficialDatapackParams }, config: { rateLimit: looseRateLimit } },
+    adminFetchSingleOfficialDatapack
   );
   fastify.post(
     "/user",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -178,7 +178,7 @@ server.get("/presets", async (_request, reply) => {
   reply.send(presets);
 });
 
-server.get("/server/datapack/:name", routes.fetchOfficialDatapack);
+server.get("/server/datapack/:name", routes.fetchPublicOfficialDatapack);
 server.get("/public/metadata", routes.fetchPublicDatapacksMetadata);
 
 server.get("/facies-patterns", (_request, reply) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,7 @@ import { userRoutes } from "./routes/user-auth.js";
 import { fetchPublicUserDatapack, fetchUserDatapacksMetadata } from "./routes/user-routes.js";
 import logger from "./error-logger.js";
 import { workshopRoutes } from "./workshop/workshop-auth.js";
+import { adminFetchPrivateOfficialDatapacksMetadata } from "./admin/admin-routes.js";
 
 const maxConcurrencySize = 2;
 export const maxQueueSize = 30;
@@ -233,10 +234,13 @@ server.get<{ Params: { title: string; uuid: string } }>(
 );
 
 server.register(adminRoutes, { prefix: "/admin" });
+// these are seperate from the admin routes because they don't require recaptcha
+server.get("/admin/official/private/metadata", looseRateLimit, adminFetchPrivateOfficialDatapacksMetadata);
+
 server.register(workshopRoutes, { prefix: "/workshop" });
 
 server.register(userRoutes, { prefix: "/user" });
-// these are seperate from the user routes because they doesn't require recaptcha
+// these are seperate from the user routes because they don't require recaptcha
 server.get("/user/metadata", looseRateLimit, fetchUserDatapacksMetadata);
 server.get("/user/uuid/:uuid/datapack/:datapackTitle", looseRateLimit, fetchPublicUserDatapack);
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -178,7 +178,7 @@ server.get("/presets", async (_request, reply) => {
   reply.send(presets);
 });
 
-server.get("/server/datapack/:name", routes.fetchPublicOfficialDatapack);
+server.get("/official/datapack/:name", routes.fetchPublicOfficialDatapack);
 server.get("/public/metadata", routes.fetchPublicDatapacksMetadata);
 
 server.get("/facies-patterns", (_request, reply) => {

--- a/server/src/routes/routes.ts
+++ b/server/src/routes/routes.ts
@@ -36,7 +36,7 @@ import { fetchDatapackProfilePictureFilepath } from "../upload-handlers.js";
  * @param reply
  * @returns
  */
-export const fetchOfficialDatapack = async function fetchOfficialDatapack(
+export const fetchPublicOfficialDatapack = async function fetchPublicOfficialDatapack(
   request: FastifyRequest<{ Params: { name: string } }>,
   reply: FastifyReply
 ) {

--- a/server/src/routes/routes.ts
+++ b/server/src/routes/routes.ts
@@ -30,6 +30,12 @@ import { fetchUserDatapack } from "../user/user-handler.js";
 import { loadPublicUserDatapacks } from "../public-datapack-handler.js";
 import { fetchDatapackProfilePictureFilepath } from "../upload-handlers.js";
 
+/**
+ * Fetches the official datapack with the given name if it is public
+ * @param request
+ * @param reply
+ * @returns
+ */
 export const fetchOfficialDatapack = async function fetchOfficialDatapack(
   request: FastifyRequest<{ Params: { name: string } }>,
   reply: FastifyReply
@@ -42,6 +48,10 @@ export const fetchOfficialDatapack = async function fetchOfficialDatapack(
   const officialDatapack = await fetchUserDatapack("official", name);
   if (!officialDatapack) {
     reply.status(404).send({ error: "Datapack not found" });
+    return;
+  }
+  if (!officialDatapack.isPublic) {
+    reply.status(403).send({ error: "Datapack is not public" });
     return;
   }
   reply.send(officialDatapack);

--- a/server/src/routes/user-routes.ts
+++ b/server/src/routes/user-routes.ts
@@ -56,7 +56,7 @@ export const fetchSingleUserDatapack = async function fetchSingleUserDatapack(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     });
     if (!metadata) {
-      reply.status(500).send({ error: "Datapack does not exist or cannot be found" });
+      reply.status(404).send({ error: "Datapack does not exist or cannot be found" });
       return;
     }
     reply.send(metadata);


### PR DESCRIPTION
- can refresh on datapack pages now
- changed private official datapacks to now only send metadata on page load for admins and when clicked on do the actual fetch (was causing lots of problems with timing issues and recaptcha on datapackProfile). admin page still uses the fetch all route