### PR TITLE
Tsc 633 datapacks in UUID dir

### DIFF
--- a/server/__tests__/upload-handlers.test.ts
+++ b/server/__tests__/upload-handlers.test.ts
@@ -29,7 +29,7 @@ vi.mock("../src/database", () => ({
 vi.mock("../src/user/fetch-user-files", () => ({
   fetchUserDatapackDirectory: vi.fn().mockResolvedValue("directory"),
   getUserUUIDDirectory: vi.fn().mockResolvedValue("uuid-directory"),
-  getDatapacksDirectoryFromUUIDDirectory: vi.fn().mockReturnValue("datapacks-directory"),
+  getUsersDatapacksDirectoryFromUUIDDirectory: vi.fn().mockReturnValue("datapacks-directory"),
   getUnsafeCachedDatapackFilePath: vi.fn().mockReturnValue("cached-datapack-filepath")
 }));
 vi.mock("stream/promises", () => ({

--- a/server/__tests__/upload-handlers.test.ts
+++ b/server/__tests__/upload-handlers.test.ts
@@ -28,7 +28,9 @@ vi.mock("../src/database", () => ({
 }));
 vi.mock("../src/user/fetch-user-files", () => ({
   fetchUserDatapackDirectory: vi.fn().mockResolvedValue("directory"),
-  getUserUUIDDirectory: vi.fn().mockResolvedValue("uuid-directory")
+  getUserUUIDDirectory: vi.fn().mockResolvedValue("uuid-directory"),
+  getDatapacksDirectoryFromUUIDDirectory: vi.fn().mockReturnValue("datapacks-directory"),
+  getUnsafeCachedDatapackFilePath: vi.fn().mockReturnValue("cached-datapack-filepath")
 }));
 vi.mock("stream/promises", () => ({
   pipeline: vi.fn().mockResolvedValue(undefined)

--- a/server/src/migrate-cached-datapacks.ts
+++ b/server/src/migrate-cached-datapacks.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import {
   getCachedDatapackFilePath,
-  getDatapacksDirectoryFromUUIDDirectory,
+  getUsersDatapacksDirectoryFromUUIDDirectory,
   getDirectories
 } from "./user/fetch-user-files.js";
 import { assetconfigs, loadAssetConfigs } from "./util.js";
@@ -26,7 +26,7 @@ try {
           `\n======================================================\nLoading datapacks for ${user}\n======================================================\n`
         )
       );
-      const datapacksDir = await getDatapacksDirectoryFromUUIDDirectory(directory);
+      const datapacksDir = await getUsersDatapacksDirectoryFromUUIDDirectory(directory);
       // TEMPORARY, THIS IS FOR CLEANUP WILL REMOVE IN 2 WEEKS OR SO. IN THAT TIME, NO OTHER FILES ARE OF USE IN USER DIRECTORIES
       await removeOldDatapackFolders(path.join(directory, user));
       const datapacks = await getDirectories(datapacksDir);

--- a/server/src/migrate-cached-datapacks.ts
+++ b/server/src/migrate-cached-datapacks.ts
@@ -5,7 +5,7 @@ import {
   getDirectories
 } from "./user/fetch-user-files.js";
 import { assetconfigs, loadAssetConfigs } from "./util.js";
-import { mkdir, readdir, readFile, writeFile } from "fs/promises";
+import { mkdir, readdir, readFile, writeFile, rm } from "fs/promises";
 import { DatapackIndex, DatapackMetadata, assertDatapackMetadata } from "@tsconline/shared";
 import { loadDatapackIntoIndex } from "./load-packs.js";
 import chalk from "chalk";
@@ -27,6 +27,8 @@ try {
         )
       );
       const datapacksDir = await getDatapacksDirectoryFromUUIDDirectory(directory);
+      // TEMPORARY, THIS IS FOR CLEANUP WILL REMOVE IN 2 WEEKS OR SO. IN THAT TIME, NO OTHER FILES ARE OF USE IN USER DIRECTORIES
+      await removeOldDatapackFolders(path.join(directory, user));
       const datapacks = await getDirectories(datapacksDir);
       for (const datapack of datapacks) {
         const datapackDir = path.join(datapacksDir, datapack);
@@ -98,4 +100,14 @@ function migrateImageToDatapackImage(datapack: any) {
     delete datapack.image;
   }
   return datapack;
+}
+
+async function removeOldDatapackFolders(directory: string) {
+  await readdir(directory, { withFileTypes: true }).then(async (entries) => {
+    for (const entry of entries) {
+      if (entry.isDirectory() && entry.name !== "datapacks") {
+        await rm(path.join(directory, entry.name), { recursive: true });
+      }
+    }
+  });
 }

--- a/server/src/migrate-cached-datapacks.ts
+++ b/server/src/migrate-cached-datapacks.ts
@@ -1,8 +1,11 @@
 import path from "path";
-import { getDirectories } from "./user/fetch-user-files.js";
+import {
+  getCachedDatapackFilePath,
+  getDatapacksDirectoryFromUUIDDirectory,
+  getDirectories
+} from "./user/fetch-user-files.js";
 import { assetconfigs, loadAssetConfigs } from "./util.js";
 import { mkdir, readdir, readFile, writeFile } from "fs/promises";
-import { CACHED_USER_DATAPACK_FILENAME } from "./constants.js";
 import { DatapackIndex, DatapackMetadata, assertDatapackMetadata } from "@tsconline/shared";
 import { loadDatapackIntoIndex } from "./load-packs.js";
 import chalk from "chalk";
@@ -23,12 +26,13 @@ try {
           `\n======================================================\nLoading datapacks for ${user}\n======================================================\n`
         )
       );
-      const datapacks = await getDirectories(path.join(directory, user));
+      const datapacksDir = await getDatapacksDirectoryFromUUIDDirectory(directory);
+      const datapacks = await getDirectories(datapacksDir);
       for (const datapack of datapacks) {
-        const datapackDir = path.join(directory, user, datapack);
+        const datapackDir = path.join(datapacksDir, datapack);
         const files = (await readdir(datapackDir)).filter((f) => allowedExtensions.includes(path.extname(f)));
         for (const file of files) {
-          const cachedFilepath = path.join(datapackDir, CACHED_USER_DATAPACK_FILENAME);
+          const cachedFilepath = await getCachedDatapackFilePath(datapackDir);
           const cache = await readFile(cachedFilepath, "utf-8");
           const cachedDatapack = JSON.parse(cache);
           try {

--- a/server/src/public-datapack-handler.ts
+++ b/server/src/public-datapack-handler.ts
@@ -3,7 +3,9 @@ import { Mutex } from "async-mutex";
 import {
   fetchUserDatapackDirectory,
   getDirectories,
+  getPrivateDatapacksDirectoryFromUUID,
   getPrivateUserUUIDDirectory,
+  getPublicDatapacksDirectoryFromUUID,
   getPublicUserUUIDDirectory
 } from "./user/fetch-user-files.js";
 import { fetchUserDatapack } from "./user/user-handler.js";
@@ -24,7 +26,7 @@ export async function loadPublicUserDatapacks() {
     for (const uuid of uuids) {
       if (isUUIDFolderAWorkshopFolder(uuid)) continue;
       try {
-        const datapackDirs = await getDirectories(await getPublicUserUUIDDirectory(uuid));
+        const datapackDirs = await getDirectories(await getPrivateDatapacksDirectoryFromUUID(uuid));
         for (const datapack of datapackDirs) {
           try {
             const dp = await fetchUserDatapack(uuid, datapack);
@@ -57,7 +59,7 @@ export async function switchPrivacySettingsOfDatapack(
   try {
     const oldDatapackPath = await fetchUserDatapackDirectory(uuid, datapack);
     const newDatapackPath = join(
-      newIsPublic ? await getPublicUserUUIDDirectory(uuid) : await getPrivateUserUUIDDirectory(uuid),
+      newIsPublic ? await getPublicDatapacksDirectoryFromUUID(uuid) : await getPrivateDatapacksDirectoryFromUUID(uuid),
       datapack
     );
     if (!(await verifyNonExistentFilepath(newDatapackPath))) {

--- a/server/src/public-datapack-handler.ts
+++ b/server/src/public-datapack-handler.ts
@@ -4,9 +4,7 @@ import {
   fetchUserDatapackDirectory,
   getDirectories,
   getPrivateDatapacksDirectoryFromUUID,
-  getPrivateUserUUIDDirectory,
-  getPublicDatapacksDirectoryFromUUID,
-  getPublicUserUUIDDirectory
+  getPublicDatapacksDirectoryFromUUID
 } from "./user/fetch-user-files.js";
 import { fetchUserDatapack } from "./user/user-handler.js";
 import logger from "./error-logger.js";
@@ -26,7 +24,7 @@ export async function loadPublicUserDatapacks() {
     for (const uuid of uuids) {
       if (isUUIDFolderAWorkshopFolder(uuid)) continue;
       try {
-        const datapackDirs = await getDirectories(await getPrivateDatapacksDirectoryFromUUID(uuid));
+        const datapackDirs = await getDirectories(await getPublicDatapacksDirectoryFromUUID(uuid));
         for (const datapack of datapackDirs) {
           try {
             const dp = await fetchUserDatapack(uuid, datapack);

--- a/server/src/public-datapack-handler.ts
+++ b/server/src/public-datapack-handler.ts
@@ -3,8 +3,8 @@ import { Mutex } from "async-mutex";
 import {
   fetchUserDatapackDirectory,
   getDirectories,
-  getPrivateDatapacksDirectoryFromUUID,
-  getPublicDatapacksDirectoryFromUUID
+  getUsersPrivateDatapacksDirectoryFromUUID,
+  getUsersPublicDatapacksDirectoryFromUUID
 } from "./user/fetch-user-files.js";
 import { fetchUserDatapack } from "./user/user-handler.js";
 import logger from "./error-logger.js";
@@ -24,7 +24,7 @@ export async function loadPublicUserDatapacks() {
     for (const uuid of uuids) {
       if (isUUIDFolderAWorkshopFolder(uuid)) continue;
       try {
-        const datapackDirs = await getDirectories(await getPublicDatapacksDirectoryFromUUID(uuid));
+        const datapackDirs = await getDirectories(await getUsersPublicDatapacksDirectoryFromUUID(uuid));
         for (const datapack of datapackDirs) {
           try {
             const dp = await fetchUserDatapack(uuid, datapack);
@@ -57,7 +57,9 @@ export async function switchPrivacySettingsOfDatapack(
   try {
     const oldDatapackPath = await fetchUserDatapackDirectory(uuid, datapack);
     const newDatapackPath = join(
-      newIsPublic ? await getPublicDatapacksDirectoryFromUUID(uuid) : await getPrivateDatapacksDirectoryFromUUID(uuid),
+      newIsPublic
+        ? await getUsersPublicDatapacksDirectoryFromUUID(uuid)
+        : await getUsersPrivateDatapacksDirectoryFromUUID(uuid),
       datapack
     );
     if (!(await verifyNonExistentFilepath(newDatapackPath))) {

--- a/server/src/upload-handlers.ts
+++ b/server/src/upload-handlers.ts
@@ -27,7 +27,12 @@ import {
   deleteDatapackFileAndDecryptedCounterpart,
   doesDatapackFolderExistInAllUUIDDirectories
 } from "./user/user-handler.js";
-import { fetchUserDatapackDirectory, getUserUUIDDirectory } from "./user/fetch-user-files.js";
+import {
+  fetchUserDatapackDirectory,
+  getDatapacksDirectoryFromUUIDDirectory,
+  getUnsafeCachedDatapackFilePath,
+  getUserUUIDDirectory
+} from "./user/fetch-user-files.js";
 import { loadDatapackIntoIndex } from "./load-packs.js";
 import {
   CACHED_USER_DATAPACK_FILENAME,
@@ -248,7 +253,7 @@ export async function setupNewDatapackDirectoryInUUIDDirectory(
   }
   const datapackIndex: DatapackIndex = {};
   const directory = await getUserUUIDDirectory(uuid, metadata.isPublic);
-  const datapackFolder = path.join(directory, metadata.title);
+  const datapackFolder = await getDatapacksDirectoryFromUUIDDirectory(directory);
   await mkdir(datapackFolder, { recursive: true });
   const sourceFileDestination = path.join(datapackFolder, metadata.storedFileName);
   const decryptDestination = path.join(datapackFolder, "decrypted");
@@ -275,7 +280,7 @@ export async function setupNewDatapackDirectoryInUUIDDirectory(
     }
   }
   await writeFile(
-    path.join(datapackFolder, CACHED_USER_DATAPACK_FILENAME),
+    getUnsafeCachedDatapackFilePath(datapackFolder),
     JSON.stringify(datapackIndex[metadata.title]!, null, 2)
   );
   // could change when we want to allow users make workshops

--- a/server/src/upload-handlers.ts
+++ b/server/src/upload-handlers.ts
@@ -34,11 +34,7 @@ import {
   getUserUUIDDirectory
 } from "./user/fetch-user-files.js";
 import { loadDatapackIntoIndex } from "./load-packs.js";
-import {
-  CACHED_USER_DATAPACK_FILENAME,
-  DATAPACK_PROFILE_PICTURE_FILENAME,
-  DECRYPTED_DIRECTORY_NAME
-} from "./constants.js";
+import { DATAPACK_PROFILE_PICTURE_FILENAME, DECRYPTED_DIRECTORY_NAME } from "./constants.js";
 import { writeFileMetadata } from "./file-metadata-handler.js";
 import { Multipart, MultipartFile } from "@fastify/multipart";
 import { createWriteStream } from "fs";

--- a/server/src/upload-handlers.ts
+++ b/server/src/upload-handlers.ts
@@ -249,7 +249,8 @@ export async function setupNewDatapackDirectoryInUUIDDirectory(
   }
   const datapackIndex: DatapackIndex = {};
   const directory = await getUserUUIDDirectory(uuid, metadata.isPublic);
-  const datapackFolder = await getDatapacksDirectoryFromUUIDDirectory(directory);
+  const datapacksFolder = await getDatapacksDirectoryFromUUIDDirectory(directory);
+  const datapackFolder = path.join(datapacksFolder, metadata.title);
   await mkdir(datapackFolder, { recursive: true });
   const sourceFileDestination = path.join(datapackFolder, metadata.storedFileName);
   const decryptDestination = path.join(datapackFolder, "decrypted");

--- a/server/src/upload-handlers.ts
+++ b/server/src/upload-handlers.ts
@@ -29,7 +29,7 @@ import {
 } from "./user/user-handler.js";
 import {
   fetchUserDatapackDirectory,
-  getDatapacksDirectoryFromUUIDDirectory,
+  getUsersDatapacksDirectoryFromUUIDDirectory,
   getUnsafeCachedDatapackFilePath,
   getUserUUIDDirectory
 } from "./user/fetch-user-files.js";
@@ -249,7 +249,7 @@ export async function setupNewDatapackDirectoryInUUIDDirectory(
   }
   const datapackIndex: DatapackIndex = {};
   const directory = await getUserUUIDDirectory(uuid, metadata.isPublic);
-  const datapacksFolder = await getDatapacksDirectoryFromUUIDDirectory(directory);
+  const datapacksFolder = await getUsersDatapacksDirectoryFromUUIDDirectory(directory);
   const datapackFolder = path.join(datapacksFolder, metadata.title);
   await mkdir(datapackFolder, { recursive: true });
   const sourceFileDestination = path.join(datapackFolder, metadata.storedFileName);

--- a/server/src/user/fetch-user-files.ts
+++ b/server/src/user/fetch-user-files.ts
@@ -37,7 +37,7 @@ export async function getPublicUserUUIDDirectory(uuid: string): Promise<string> 
   return userDirectory;
 }
 
-export async function getPublicDatapacksDirectoryFromUUID(uuid: string) {
+export async function getUsersPublicDatapacksDirectoryFromUUID(uuid: string) {
   const dir = await getPublicUserUUIDDirectory(uuid);
   const datpackDir = path.join(dir, "datapacks");
   if (!(await verifyFilepath(datpackDir))) {
@@ -50,7 +50,7 @@ export async function getPublicDatapacksDirectoryFromUUID(uuid: string) {
   return datpackDir;
 }
 
-export async function getPrivateDatapacksDirectoryFromUUID(uuid: string) {
+export async function getUsersPrivateDatapacksDirectoryFromUUID(uuid: string) {
   const dir = await getPrivateUserUUIDDirectory(uuid);
   const datpackDir = path.join(dir, "datapacks");
   if (!(await verifyFilepath(datpackDir))) {
@@ -63,7 +63,7 @@ export async function getPrivateDatapacksDirectoryFromUUID(uuid: string) {
   return datpackDir;
 }
 
-export async function getDatapacksDirectoryFromUUIDDirectory(directory: string) {
+export async function getUsersDatapacksDirectoryFromUUIDDirectory(directory: string) {
   const datpackDir = path.join(directory, "datapacks");
   if (!(await verifyFilepath(datpackDir))) {
     if (await verifyNonExistentFilepath(datpackDir)) {
@@ -120,8 +120,8 @@ export async function getDirectories(source: string): Promise<string[]> {
  */
 export async function getAllUserDatapackDirectories(uuid: string): Promise<string[]> {
   return [
-    await getPrivateDatapacksDirectoryFromUUID(uuid).catch(() => ""),
-    await getPublicDatapacksDirectoryFromUUID(uuid).catch(() => "")
+    await getUsersPrivateDatapacksDirectoryFromUUID(uuid).catch(() => ""),
+    await getUsersPublicDatapacksDirectoryFromUUID(uuid).catch(() => "")
   ].filter(Boolean);
 }
 /**

--- a/server/src/user/fetch-user-files.ts
+++ b/server/src/user/fetch-user-files.ts
@@ -1,6 +1,7 @@
 import { mkdir, readdir } from "fs/promises";
 import path from "path";
 import { assetconfigs, verifyNonExistentFilepath, verifyFilepath } from "../util.js";
+import { CACHED_USER_DATAPACK_FILENAME } from "../constants.js";
 
 // TODO WRITE TESTS FOR WHOLE FILE
 /**
@@ -36,6 +37,56 @@ export async function getPublicUserUUIDDirectory(uuid: string): Promise<string> 
   return userDirectory;
 }
 
+export async function getPublicDatapacksDirectoryFromUUID(uuid: string) {
+  const dir = await getPublicUserUUIDDirectory(uuid);
+  const datpackDir = path.join(dir, "datapacks");
+  if (!(await verifyFilepath(datpackDir))) {
+    if (await verifyNonExistentFilepath(datpackDir)) {
+      await mkdir(datpackDir, { recursive: true });
+    } else {
+      throw new Error("Invalid filepath");
+    }
+  }
+  return datpackDir;
+}
+
+export async function getPrivateDatapacksDirectoryFromUUID(uuid: string) {
+  const dir = await getPrivateUserUUIDDirectory(uuid);
+  const datpackDir = path.join(dir, "datapacks");
+  if (!(await verifyFilepath(datpackDir))) {
+    if (await verifyNonExistentFilepath(datpackDir)) {
+      await mkdir(datpackDir, { recursive: true });
+    } else {
+      throw new Error("Invalid filepath");
+    }
+  }
+  return datpackDir;
+}
+
+export async function getDatapacksDirectoryFromUUIDDirectory(directory: string) {
+  const datpackDir = path.join(directory, "datapacks");
+  if (!(await verifyFilepath(datpackDir))) {
+    if (await verifyNonExistentFilepath(datpackDir)) {
+      await mkdir(datpackDir, { recursive: true });
+    } else {
+      throw new Error("Invalid filepath");
+    }
+  }
+  return datpackDir;
+}
+
+export function getUnsafeCachedDatapackFilePath(directory: string) {
+  return path.join(directory, CACHED_USER_DATAPACK_FILENAME);
+}
+
+export async function getCachedDatapackFilePath(directory: string) {
+  const cachedDatapackFilePath = path.join(directory, CACHED_USER_DATAPACK_FILENAME);
+  if (!(await verifyFilepath(cachedDatapackFilePath))) {
+    throw new Error("Invalid filepath");
+  }
+  return cachedDatapackFilePath;
+}
+
 export async function fetchUserDatapackDirectory(uuid: string, datapack: string): Promise<string> {
   // check both public and private directories
   const directoriesToCheck: string[] = await getAllUserDatapackDirectories(uuid);
@@ -69,8 +120,8 @@ export async function getDirectories(source: string): Promise<string[]> {
  */
 export async function getAllUserDatapackDirectories(uuid: string): Promise<string[]> {
   return [
-    await getPrivateUserUUIDDirectory(uuid).catch(() => ""),
-    await getPublicUserUUIDDirectory(uuid).catch(() => "")
+    await getPrivateDatapacksDirectoryFromUUID(uuid).catch(() => ""),
+    await getPublicDatapacksDirectoryFromUUID(uuid).catch(() => "")
   ].filter(Boolean);
 }
 /**

--- a/server/src/user/user-handler.ts
+++ b/server/src/user/user-handler.ts
@@ -21,7 +21,6 @@ import {
   getAllUserDatapackDirectories,
   fetchUserDatapackDirectory,
   getDirectories,
-  getPrivateUserUUIDDirectory,
   getPrivateDatapacksDirectoryFromUUID,
   getCachedDatapackFilePath
 } from "./fetch-user-files.js";

--- a/server/src/user/user-handler.ts
+++ b/server/src/user/user-handler.ts
@@ -21,7 +21,9 @@ import {
   getAllUserDatapackDirectories,
   fetchUserDatapackDirectory,
   getDirectories,
-  getPrivateUserUUIDDirectory
+  getPrivateUserUUIDDirectory,
+  getPrivateDatapacksDirectoryFromUUID,
+  getCachedDatapackFilePath
 } from "./fetch-user-files.js";
 import { Multipart, MultipartFile } from "@fastify/multipart";
 import { findUser } from "../database.js";
@@ -81,10 +83,11 @@ export async function fetchAllUsersDatapacks(uuid: string): Promise<Datapack[]> 
 export async function fetchAllPrivateOfficialDatapacks(): Promise<Datapack[]> {
   const directory = await getPrivateUserUUIDDirectory("official");
   const datapacksArray: Datapack[] = [];
-  const datapacks = await getDirectories(directory);
+  const datapacksDir = await getPrivateDatapacksDirectoryFromUUID("official");
+  const datapacks = await getDirectories(datapacksDir);
   for (const datapack of datapacks) {
     try {
-      const cachedDatapack = path.join(directory, datapack, CACHED_USER_DATAPACK_FILENAME);
+      const cachedDatapack = await getCachedDatapackFilePath(path.join(datapacksDir, datapack));
       const parsedCachedDatapack = JSON.parse(await readFile(cachedDatapack, "utf-8"));
       if (await verifyFilepath(cachedDatapack)) {
         if (datapacksArray.find((datapack) => datapack.title === parsedCachedDatapack.title)) {

--- a/server/src/user/user-handler.ts
+++ b/server/src/user/user-handler.ts
@@ -21,7 +21,7 @@ import {
   getAllUserDatapackDirectories,
   fetchUserDatapackDirectory,
   getDirectories,
-  getPrivateDatapacksDirectoryFromUUID,
+  getUsersPrivateDatapacksDirectoryFromUUID,
   getCachedDatapackFilePath
 } from "./fetch-user-files.js";
 import { Multipart, MultipartFile } from "@fastify/multipart";
@@ -81,7 +81,7 @@ export async function fetchAllUsersDatapacks(uuid: string): Promise<Datapack[]> 
 
 export async function fetchAllPrivateOfficialDatapacks(): Promise<Datapack[]> {
   const datapacksArray: Datapack[] = [];
-  const datapacksDir = await getPrivateDatapacksDirectoryFromUUID("official");
+  const datapacksDir = await getUsersPrivateDatapacksDirectoryFromUUID("official");
   const datapacks = await getDirectories(datapacksDir);
   for (const datapack of datapacks) {
     try {

--- a/server/src/user/user-handler.ts
+++ b/server/src/user/user-handler.ts
@@ -130,10 +130,7 @@ export async function getUploadedDatapackFilepath(uuid: string, datapack: string
  */
 export async function fetchUserDatapack(uuid: string, datapack: string): Promise<Datapack> {
   const datapackPath = await fetchUserDatapackDirectory(uuid, datapack);
-  const cachedDatapack = path.join(datapackPath, CACHED_USER_DATAPACK_FILENAME);
-  if (!cachedDatapack || !(await verifyFilepath(cachedDatapack))) {
-    throw new Error(`File ${datapack} doesn't exist`);
-  }
+  const cachedDatapack = await getCachedDatapackFilePath(datapackPath);
   const parsedCachedDatapack = JSON.parse(await readFile(cachedDatapack, "utf-8"));
   assertDatapack(parsedCachedDatapack);
   return parsedCachedDatapack;

--- a/server/src/user/user-handler.ts
+++ b/server/src/user/user-handler.ts
@@ -61,7 +61,7 @@ export async function fetchAllUsersDatapacks(uuid: string): Promise<Datapack[]> 
     const datapacks = await getDirectories(directory);
     for (const datapack of datapacks) {
       try {
-        const cachedDatapack = path.join(directory, datapack, CACHED_USER_DATAPACK_FILENAME);
+        const cachedDatapack = await getCachedDatapackFilePath(path.join(directory, datapack));
         const parsedCachedDatapack = JSON.parse(await readFile(cachedDatapack, "utf-8"));
         if (await verifyFilepath(cachedDatapack)) {
           if (datapacksArray.find((datapack) => datapack.title === parsedCachedDatapack.title)) {

--- a/server/src/user/user-handler.ts
+++ b/server/src/user/user-handler.ts
@@ -81,7 +81,6 @@ export async function fetchAllUsersDatapacks(uuid: string): Promise<Datapack[]> 
 }
 
 export async function fetchAllPrivateOfficialDatapacks(): Promise<Datapack[]> {
-  const directory = await getPrivateUserUUIDDirectory("official");
   const datapacksArray: Datapack[] = [];
   const datapacksDir = await getPrivateDatapacksDirectoryFromUUID("official");
   const datapacks = await getDirectories(datapacksDir);


### PR DESCRIPTION
* for @JacquiFreeElectron and @lbostre 
* datapacks in `/[uuid]/datapacks/[title]`
* small change that will be changed in two weeks, i'll comment on it below -> removes all files besides datapacks in someone's `uuid` directory to get rid of the previous datapacks in previous structure `[uuid]/[title]`