### PR TITLE
bug fixes

### DIFF
--- a/server/__tests__/upload-datapack.test.ts
+++ b/server/__tests__/upload-datapack.test.ts
@@ -167,6 +167,22 @@ describe("getDatapackMetadataFromIterableAndTemporarilyDownloadDatapack", () => 
       datapackMetadata: {}
     });
   });
+  it("should return file, filepath, tempProfilePictureFilepath, datapackMetadata, and PDFFILES if successful", async () => {
+    processMultipartPartsForDatapackUpload.mockResolvedValueOnce({
+      file: { file: { bytesRead: 1 } } as MultipartFile,
+      fields: { filepath: "test", originalFileName: "test", storedFileName: "test" },
+      pdfFields: { "test.pdf": "test" }
+    });
+    uploadUserDatapackHandler.mockResolvedValueOnce({} as DatapackMetadata);
+    const val = await getDatapackMetadataFromIterableAndTemporarilyDownloadDatapack("uuid", formData);
+    expect(val).toEqual({
+      file: { file: { bytesRead: 1 } } as MultipartFile,
+      filepath: "test",
+      tempProfilePictureFilepath: undefined,
+      datapackMetadata: {},
+      pdfFields: { "test.pdf": "test" }
+    });
+  });
 });
 describe("processAndUploadDatapack", () => {
   const isOfficialDatapack = vi.spyOn(shared, "isOfficialDatapack");

--- a/server/__tests__/upload-handlers.test.ts
+++ b/server/__tests__/upload-handlers.test.ts
@@ -122,8 +122,8 @@ vi.mock("fs", async () => {
     createWriteStream: vi.fn().mockReturnValue({})
   };
 });
-// vi.spyOn(console, "error").mockImplementation(() => undefined);
-// vi.spyOn(console, "log").mockImplementation(() => undefined);
+vi.spyOn(console, "error").mockImplementation(() => undefined);
+vi.spyOn(console, "log").mockImplementation(() => undefined);
 
 describe("uploadUserDatapackHandler", () => {
   const rm = vi.spyOn(fsPromises, "rm");

--- a/server/src/upload-datapack.ts
+++ b/server/src/upload-datapack.ts
@@ -21,7 +21,7 @@ export const getDatapackMetadataFromIterableAndTemporarilyDownloadDatapack = asy
       filepath: string;
       datapackMetadata: DatapackMetadata;
       tempProfilePictureFilepath?: string;
-      pdfFields: { [fileName: string]: string };
+      pdfFields?: { [fileName: string]: string };
     }
 > => {
   let fields: Record<string, string> = {};
@@ -34,7 +34,9 @@ export const getDatapackMetadataFromIterableAndTemporarilyDownloadDatapack = asy
     }
     file = result.file;
     fields = result.fields;
-    pdfFields = result.pdfFields;
+    if (result.pdfFields) {
+      pdfFields = result.pdfFields;
+    }
   } catch (error) {
     return { code: 500, message: "Failed to process multipart parts" };
   }
@@ -53,7 +55,7 @@ export const getDatapackMetadataFromIterableAndTemporarilyDownloadDatapack = asy
     filepath: fields.filepath,
     tempProfilePictureFilepath: fields.tempProfilePictureFilepath,
     datapackMetadata,
-    pdfFields
+    ...(Object.keys(pdfFields).length > 0 && { pdfFields })
   };
 };
 export const processAndUploadDatapack = async (uuid: string, parts: AsyncIterableIterator<Multipart>) => {

--- a/server/src/upload-handlers.ts
+++ b/server/src/upload-handlers.ts
@@ -393,7 +393,7 @@ export async function processMultipartPartsForDatapackUpload(
   uuid: string | undefined,
   parts: AsyncIterableIterator<Multipart>
 ): Promise<
-  | { fields: { [key: string]: string }; file: MultipartFile; pdfFields: { [fileName: string]: string } }
+  | { fields: { [key: string]: string }; file: MultipartFile; pdfFields?: { [fileName: string]: string } }
   | OperationResult
 > {
   let file: MultipartFile | undefined;
@@ -487,7 +487,7 @@ export async function processMultipartPartsForDatapackUpload(
       ...(datapackImage && { datapackImage }),
       ...(tempProfilePictureFilepath && { tempProfilePictureFilepath })
     },
-    pdfFields
+    ...(Object.keys(pdfFields).length > 0 && { pdfFields })
   };
 }
 


### PR DESCRIPTION
pdf field bug fixes for tests

tests for uploading had compiler errors so i fixed those (stemming from pdf stuff)

made pdfFields optional as well instead of passing in empty {}

NOTE: sometimes tests with compiler issues can get past actions so we might have to think about that