### PR TITLE
revert changes properly

### DIFF
--- a/app/src/crossplot/CrossPlotChart.tsx
+++ b/app/src/crossplot/CrossPlotChart.tsx
@@ -189,7 +189,13 @@ const MismatchModal: React.FC = observer(() => {
           {t("crossPlot.out-of-date.description")}
         </Typography>
         <Box className={styles.changeButtons}>
-          <Button variant="outlined">{t("crossPlot.out-of-date.revert")}</Button>
+          <Button
+            variant="outlined"
+            onClick={() => {
+              actions.revertCrossPlot();
+            }}>
+            {t("crossPlot.out-of-date.revert")}
+          </Button>
           <TSCButton buttonType="gradient" onClick={() => actions.compileAndSendCrossPlotChartRequest(navigate)}>
             {t("crossPlot.out-of-date.apply")}
           </TSCButton>

--- a/app/src/crossplot/CrossPlotSideBar.tsx
+++ b/app/src/crossplot/CrossPlotSideBar.tsx
@@ -592,6 +592,7 @@ const CrossPlotColumns: React.FC = observer(() => {
             actions.setCrossPlotColumnSelected(col);
           },
           toggleSettingsTabColumn: (col) => {
+            actions.setCrossPlotChartMatchesSettings(false);
             actions.toggleSettingsTabColumn(col, {
               hashMap: state.crossPlot.columnHashMap
             });

--- a/app/src/state/actions/crossplot-actions.ts
+++ b/app/src/state/actions/crossplot-actions.ts
@@ -835,9 +835,6 @@ export const setCrossPlotDatapackConfig = action(
     if (!state.crossPlot.chartX) state.crossPlot.chartX = state.crossPlot.columns!.children[0];
     state.crossPlot.chartY = state.crossPlot.columns!.children[0];
     state.crossPlot.state.matchesSettings = true;
-    runInAction(() => {
-      state.crossPlot.state.matchesSettings = true;
-    });
   }
 );
 const initializeColumnHashMap = action("initializeColumnHashmap", async (columnInfo: ColumnInfo) => {

--- a/app/src/state/actions/crossplot-actions.ts
+++ b/app/src/state/actions/crossplot-actions.ts
@@ -439,18 +439,45 @@ export const removeCrossPlotMarker = action((marker: Marker) => {
 });
 
 export const setCrossPlotChartX = action((chart?: ColumnInfo) => {
+  setCrossPlotChartMatchesSettings(false);
   state.crossPlot.chartX = chart;
 });
 export const setCrossPlotChartY = action((chart?: ColumnInfo) => {
+  setCrossPlotChartMatchesSettings(false);
   state.crossPlot.chartY = chart;
 });
+// set this before you set the actual changes so it remembers the previous settings
+export const setCrossPlotChartMatchesSettings = action((matchesSettings: boolean) => {
+  if (state.crossPlot.state.matchesSettings) {
+    state.crossPlot.previousSettings = cloneDeep({
+      chartX: state.crossPlot.chartX,
+      chartY: state.crossPlot.chartY,
+      chartXTimeSettings: state.crossPlot.chartXTimeSettings,
+      chartYTimeSettings: state.crossPlot.chartYTimeSettings,
+      columnHashMap: state.crossPlot.columnHashMap,
+      columns: state.crossPlot.columns
+    });
+  }
+  state.crossPlot.state.matchesSettings = matchesSettings;
+});
 export const setCrossPlotChartXTimeSettings = action((timeSettings: Partial<CrossPlotTimeSettings>) => {
+  setCrossPlotChartMatchesSettings(false);
   state.crossPlot.chartXTimeSettings = {
     ...state.crossPlot.chartXTimeSettings,
     ...timeSettings
   };
 });
+export const revertCrossPlot = action(() => {
+  state.crossPlot.chartX = cloneDeep(state.crossPlot.previousSettings.chartX);
+  state.crossPlot.chartY = state.crossPlot.previousSettings.chartY;
+  state.crossPlot.chartXTimeSettings = state.crossPlot.previousSettings.chartXTimeSettings;
+  state.crossPlot.chartYTimeSettings = state.crossPlot.previousSettings.chartYTimeSettings;
+  state.crossPlot.columnHashMap = state.crossPlot.previousSettings.columnHashMap;
+  state.crossPlot.columns = state.crossPlot.previousSettings.columns;
+  state.crossPlot.state.matchesSettings = true;
+});
 export const setCrossPlotChartYTimeSettings = action((timeSettings: Partial<CrossPlotTimeSettings>) => {
+  setCrossPlotChartMatchesSettings(false);
   state.crossPlot.chartYTimeSettings = {
     ...state.crossPlot.chartYTimeSettings,
     ...timeSettings
@@ -801,22 +828,26 @@ export const setCrossPlotDatapackConfig = action(
     });
     for (const child of state.crossPlot.columns!.children) {
       if (child.units.toLowerCase() === "ma") {
-        setCrossPlotChartX(child);
+        state.crossPlot.chartX = child;
         break;
       }
     }
-    if (!state.crossPlot.chartX) setCrossPlotChartX(state.crossPlot.columns!.children[0]);
-    setCrossPlotChartY(state.crossPlot.columns!.children[0]);
+    if (!state.crossPlot.chartX) state.crossPlot.chartX = state.crossPlot.columns!.children[0];
+    state.crossPlot.chartY = state.crossPlot.columns!.children[0];
+    state.crossPlot.state.matchesSettings = true;
+    runInAction(() => {
+      state.crossPlot.state.matchesSettings = true;
+    });
   }
 );
-const initializeColumnHashMap = async (columnInfo: ColumnInfo) => {
+const initializeColumnHashMap = action("initializeColumnHashmap", async (columnInfo: ColumnInfo) => {
   state.crossPlot.columnHashMap.set(columnInfo.name, columnInfo);
   if (columnInfo.children) {
     for (const child of columnInfo.children) {
       await initializeColumnHashMap(child);
     }
   }
-};
+});
 
 export const setCrossPlotColumnSelected = action((column: string | null) => {
   state.crossPlot.columnSelected = column;

--- a/app/src/state/state.ts
+++ b/app/src/state/state.ts
@@ -64,6 +64,14 @@ export type State = {
     datapacks: DatapackConfigForChartRequest[];
     columnHashMap: Map<string, ColumnInfo>;
     columnSelected: string | null;
+    previousSettings: {
+      chartXTimeSettings: CrossPlotTimeSettings;
+      chartYTimeSettings: CrossPlotTimeSettings;
+      chartX: ColumnInfo | undefined;
+      chartY: ColumnInfo | undefined;
+      columnHashMap: Map<string, ColumnInfo>;
+      columns: ColumnInfo | undefined;
+    };
   };
   loadSaveFilename: string;
   cookieConsent: boolean | null;
@@ -181,7 +189,15 @@ export const state = observable<State>({
     loading: false,
     datapacks: [],
     columnHashMap: new Map<string, ColumnInfo>(),
-    columnSelected: null
+    columnSelected: null,
+    previousSettings: {
+      chartXTimeSettings: cloneDeep(defaultCrossPlotSettings),
+      chartYTimeSettings: cloneDeep(defaultCrossPlotSettings),
+      chartX: undefined,
+      chartY: undefined,
+      columnHashMap: new Map<string, ColumnInfo>(),
+      columns: undefined
+    }
   },
   loadSaveFilename: "settings", //name without extension (.tsc)
   cookieConsent: null,
@@ -316,17 +332,5 @@ reaction(
   () => {
     if (state.chartTab.state.madeChart === false) return;
     state.chartTab.state.matchesSettings = false;
-  }
-);
-reaction(
-  () => [
-    state.crossPlot.chartX,
-    state.crossPlot.chartY,
-    state.crossPlot.chartXTimeSettings,
-    state.crossPlot.chartYTimeSettings
-  ],
-  () => {
-    if (state.crossPlot.state.madeChart === false) return;
-    state.crossPlot.state.matchesSettings = false;
   }
 );


### PR DESCRIPTION
this properly makes the revert button work

known issue: expanding the column and pressing revert will revert the expansion in some cases. no real way around this tbh

i track the dirty state manually in each action. I tried using reactions but it seems against the philosophy of reactions to make changes to the observable AND it doesn't work after a while debugging


https://github.com/user-attachments/assets/8f58d981-783c-4804-a15b-a08c57c12649



Closes 410