### PR TITLE
fix time setting centering issue on firefox

### DIFF
--- a/app/src/settings_tabs/Time.css
+++ b/app/src/settings_tabs/Time.css
@@ -6,9 +6,9 @@
   border: 1px solid gray;
   border-radius: 4px;
   padding: 10px;
-  margin: 10px;
+  /* top | left and right | bottom */
+  margin: 10px auto 10px;
   width: 50%;
-  justify-self: center;
 }
 .time-settings-container > * {
   width: 100%;


### PR DESCRIPTION
css was using justify-self, which works in some browsers but not others (e.g. firefox).
https://stackoverflow.com/questions/49658425/flexbox-justify-self-flex-end-not-working
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_alignment/Box_alignment_in_flexbox#there_is_no_justify-self_in_flexbox

<img width="1762" alt="image" src="https://github.com/user-attachments/assets/7c2c0fd0-5657-44cd-a808-c03a61b9d110" />
